### PR TITLE
docs: rewrite README for the iris-interop-dev fork

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,59 +1,55 @@
-# iris-agentic-dev
+# iris-interop-dev
 
-Connect GitHub Copilot, Claude Code, and other AI coding assistants directly to a live InterSystems IRIS instance. The AI can compile classes, run ObjectScript, execute SQL, search the namespace, run unit tests, and inspect class definitions — without leaving the chat.
+Connect Claude Code and other AI coding assistants directly to a live InterSystems IRIS
+instance. The AI can compile classes, run ObjectScript, execute SQL, run `%UnitTest` tests,
+drive Interoperability productions, and inspect class definitions — without leaving the chat.
 
 Works with IRIS installed natively on Windows or Linux, and with Docker. Requires IRIS 2023.1 or later.
 
----
-
-## Quick start: VS Code + GitHub Copilot
-
-This is the fastest path if you already use VS Code with the InterSystems ObjectScript extension.
-
-**Prerequisites**: VS Code, GitHub Copilot, [InterSystems ObjectScript extension](https://marketplace.visualstudio.com/items?itemName=intersystems-community.vscode-objectscript)
-
-1. Download `vscode-iris-agentic-dev-*.vsix` from the [releases page](https://github.com/intersystems-community/iris-agentic-dev/releases/latest)
-2. In VS Code: Extensions (`Ctrl+Shift+X`) → `...` → **Install from VSIX**
-3. Reload VS Code
-
-**iris-agentic-dev (IRIS)** now appears in **Copilot Chat → Agent mode → tools**. It reads your existing `objectscript.conn` or `intersystems.servers` configuration — no additional setup needed.
-
-To verify the connection, ask Copilot: *"Call check_config and show me the result."*
-
-If the [InterSystems Server Manager](https://marketplace.visualstudio.com/items?itemName=intersystems-community.servermanager) extension is installed, credentials are retrieved from the OS keychain automatically.
-
-> **Windows users**: iris-agentic-dev works with native IRIS on Windows — Docker is not required. If you hit a 404 on `/api/atelier`, see [Windows IIS setup](#windows-iis-api-web-application-required) below.
+> **What this is.** `iris-interop-dev` is the **streamlined, interoperability-focused fork** of the
+> community [`intersystems-community/iris-agentic-dev`](https://github.com/intersystems-community/iris-agentic-dev)
+> MCP server. It exposes a locked **20-tool interop profile**, ships as a **single binary (no Python)**,
+> and uses a **distinct MCP server name (`iris-interop-dev`)** so it can be installed alongside the
+> original. **Tool names are identical**, so the [`intersystems-ib/iris-interop-skills`](https://github.com/intersystems-ib/iris-interop-skills)
+> plugin works with either server. It is the binary baked into the *"De Prompt a Producción"* workshop VM.
 
 ---
 
-## Quick start: Claude Code / OpenCode
+## Quick start: Claude Code
 
-**Install the binary:**
+**1. Install the binary** from the [latest release](https://github.com/intersystems-ib/iris-interop-dev/releases/latest):
 
 ```bash
-# Mac (Homebrew)
-brew tap intersystems-community/iris-agentic-dev
-brew install iris-agentic-dev
+# macOS (Apple Silicon)
+curl -fsSL https://github.com/intersystems-ib/iris-interop-dev/releases/latest/download/iris-interop-dev-macos-arm64 \
+  -o /usr/local/bin/iris-interop-dev && chmod +x /usr/local/bin/iris-interop-dev
+xattr -d com.apple.quarantine /usr/local/bin/iris-interop-dev 2>/dev/null
 
-# Mac direct download (Apple Silicon)
-curl -fsSL https://github.com/intersystems-community/iris-agentic-dev/releases/latest/download/iris-agentic-dev-macos-arm64 \
-  -o /usr/local/bin/iris-agentic-dev && chmod +x /usr/local/bin/iris-agentic-dev
-xattr -d com.apple.quarantine /usr/local/bin/iris-agentic-dev 2>/dev/null
-
-# Linux x86_64
-curl -fsSL https://github.com/intersystems-community/iris-agentic-dev/releases/latest/download/iris-agentic-dev-linux-x86_64 \
-  -o /usr/local/bin/iris-agentic-dev && chmod +x /usr/local/bin/iris-agentic-dev
+# Linux x64
+curl -fsSL https://github.com/intersystems-ib/iris-interop-dev/releases/latest/download/iris-interop-dev-linux-x64 \
+  -o /usr/local/bin/iris-interop-dev && chmod +x /usr/local/bin/iris-interop-dev
 ```
 
-**Windows**: Download `iris-agentic-dev-windows-x86_64.exe` from the [releases page](https://github.com/intersystems-community/iris-agentic-dev/releases/latest) and place it on your PATH.
+**Windows**: download `iris-interop-dev-windows-x64.exe` from the
+[releases page](https://github.com/intersystems-ib/iris-interop-dev/releases/latest), rename it to
+`iris-interop-dev.exe`, and put it somewhere on disk (e.g. `C:\iris-interop-dev\iris-interop-dev.exe`).
 
-**Configure Claude Code** — add to `~/.claude/settings.json`:
+**2. Register it as an MCP server.** The one-line form (works from any directory, user scope):
+
+```bash
+claude mcp add --scope user iris-interop-dev \
+  --env IRIS_HOST=localhost --env IRIS_WEB_PORT=80 --env IRIS_WEB_PREFIX=irishealth \
+  --env IRIS_USERNAME=_SYSTEM --env IRIS_PASSWORD=SYS --env IRIS_NAMESPACE=USER \
+  -- /usr/local/bin/iris-interop-dev mcp
+```
+
+Or add it by hand to `~/.claude/settings.json`:
 
 ```json
 {
   "mcpServers": {
-    "iris-agentic-dev": {
-      "command": "iris-agentic-dev",
+    "iris-interop-dev": {
+      "command": "iris-interop-dev",
       "args": ["mcp"],
       "env": {
         "IRIS_HOST": "localhost",
@@ -67,34 +63,11 @@ curl -fsSL https://github.com/intersystems-community/iris-agentic-dev/releases/l
 }
 ```
 
-**Configure OpenCode** — add to `~/.config/opencode/config.json`:
+Restart Claude and **verify with the `check_config` tool** that it connects and the tools appear.
 
-```json
-{
-  "mcp": {
-    "iris-agentic-dev": {
-      "type": "local",
-      "command": ["/usr/local/bin/iris-agentic-dev", "mcp"],
-      "enabled": true,
-      "environment": {
-        "IRIS_HOST": "localhost",
-        "IRIS_WEB_PORT": "52773",
-        "IRIS_USERNAME": "_SYSTEM",
-        "IRIS_PASSWORD": "SYS",
-        "IRIS_NAMESPACE": "USER"
-      }
-    }
-  }
-}
-```
-
-Note: OpenCode uses `"type": "local"` and `"environment"` (not `"type": "stdio"` and `"env"`).
-
-**WSL2**: The Windows OpenCode GUI cannot spawn Linux ELF binaries. Use the Windows `.exe` or invoke the Linux binary via `wsl.exe`:
-
-```json
-"command": ["wsl.exe", "-e", "/usr/local/bin/iris-agentic-dev", "mcp"]
-```
+> **VS Code + GitHub Copilot?** The VS Code extension path is provided by the upstream community tool —
+> see [`intersystems-community/iris-agentic-dev`](https://github.com/intersystems-community/iris-agentic-dev).
+> This fork is packaged for Claude Code as the `iris-interop-dev` binary.
 
 ---
 
@@ -102,7 +75,8 @@ Note: OpenCode uses `"type": "local"` and `"environment"` (not `"type": "stdio"`
 
 ### Native IRIS on Windows or Linux (no Docker)
 
-Add a `.iris-agentic-dev.toml` file to your project root:
+Add a `.iris-agentic-dev.toml` file to your project root (the config filename is unchanged from the
+upstream codebase):
 
 ```toml
 host = "localhost"
@@ -122,24 +96,25 @@ password = "SYS"
 
 #### Windows IIS: `/api` web application required
 
-This is the most common failure on Windows. IIS needs an explicit `/api` web application mapped to the IRIS Web Gateway module. Without it, `/api/atelier` returns 404 — even when the Management Portal loads correctly.
+This is the most common failure on Windows. IIS needs an explicit `/api` web application mapped to the
+IRIS Web Gateway module. Without it, `/api/atelier` returns 404 — even when the Management Portal loads.
 
 **To fix:**
 1. Open **IIS Manager** → expand your server → **Sites** → **Default Web Site**
-2. Right-click → **Add Application**. Set alias: `api`, physical path: `C:\InterSystems\IRIS\CSP\bin` (adjust to your install path)
+2. Right-click → **Add Application**. Alias: `api`, physical path: `C:\InterSystems\IRIS\CSP\bin` (adjust to your install path)
 3. Add a wildcard script handler mapping: executable = `CSPms.dll`, no verb restriction
 4. Verify `CSP.ini` contains an `[APP_PATH:/api]` section
 
-See the [`iris-windows-iis-setup` skill](./light-skills/skills/iris-windows-iis-setup/SKILL.md) for full step-by-step instructions with verification commands.
+**`localhost` vs `127.0.0.1`**: on some older Web Gateway builds, `localhost` causes a brief connection
+error before each request. If you see delays, set `host = "127.0.0.1"`.
 
-**`localhost` vs `127.0.0.1`**: On some older Web Gateway builds, using `localhost` causes a brief connection error before each request. If you see connection delays, change the config to `host = "127.0.0.1"`.
+### Docker
 
-### Docker (community image)
-
-Run `iris-agentic-dev init` in your project directory — it detects any running IRIS containers and writes `.iris-agentic-dev.toml` automatically:
+Run `iris-interop-dev init` in your project directory — it detects running IRIS containers and writes
+`.iris-agentic-dev.toml` automatically:
 
 ```bash
-iris-agentic-dev init
+iris-interop-dev init
 ```
 
 Or configure manually:
@@ -149,34 +124,18 @@ container = "myapp-iris"
 namespace = "MYAPP"
 ```
 
-### Docker (enterprise image)
-
-Enterprise IRIS images (`intersystems/iris`, `intersystems/irishealth`) ship without a built-in web server. Run the ISC Web Gateway container alongside IRIS:
-
-```yaml
-services:
-  iris:
-    image: containers.intersystems.com/intersystems/iris:2026.1
-    ports: ["4972:1972"]
-  webgateway:
-    image: containers.intersystems.com/intersystems/webgateway:2026.1
-    ports: ["52773:80"]
-    entrypoint: ["/bin/sh", "/init.sh"]
-    volumes: ["./webgateway-init.sh:/init.sh:ro"]
-```
-
-See the [`iris-vscode-objectscript` skill](./light-skills/skills/iris-vscode-objectscript/SKILL.md) for a working `webgateway-init.sh`.
+Enterprise IRIS images (`intersystems/iris`, `intersystems/irishealth`) ship without a built-in web
+server — run the ISC Web Gateway container alongside IRIS and point `web_port` at it.
 
 ### Connection discovery order
 
-iris-agentic-dev resolves the IRIS connection in this order — first match wins:
+`iris-interop-dev` resolves the IRIS connection in this order — first match wins:
 
 1. CLI flags (`--host`, `--web-port`, `--scheme`)
 2. `.iris-agentic-dev.toml` in the workspace root
 3. Environment variables (`IRIS_HOST`, etc.)
-4. VS Code `settings.json` (`objectscript.conn` / `intersystems.servers`)
-5. Running Docker containers (scored by workspace name similarity)
-6. Localhost port scan (52773, 41773, 51773, 8080)
+4. Running Docker containers (scored by workspace name similarity)
+5. Localhost port scan (52773, 41773, 51773, 8080)
 
 ### Environment variables
 
@@ -185,7 +144,7 @@ iris-agentic-dev resolves the IRIS connection in this order — first match wins
 | `IRIS_HOST` | `localhost` | IRIS web gateway hostname |
 | `IRIS_WEB_PORT` | `52773` | Web gateway port |
 | `IRIS_SCHEME` | `http` | `http` or `https` |
-| `IRIS_WEB_PREFIX` | _(empty)_ | URL path prefix for non-root gateway installs |
+| `IRIS_WEB_PREFIX` | _(empty)_ | URL path prefix for non-root gateway installs (e.g. `irishealth`) |
 | `IRIS_USERNAME` | `_SYSTEM` | IRIS username |
 | `IRIS_PASSWORD` | `SYS` | IRIS password |
 | `IRIS_NAMESPACE` | `USER` | Default namespace |
@@ -194,121 +153,36 @@ iris-agentic-dev resolves the IRIS connection in this order — first match wins
 
 ---
 
-## Skills — improve AI output for ObjectScript
+## The interop skills
 
-Skills are concise instruction files that teach your AI assistant ObjectScript-specific patterns and common mistakes. They work with or without the MCP server.
+This server is the runtime for the **[`intersystems-ib/iris-interop-skills`](https://github.com/intersystems-ib/iris-interop-skills)**
+Claude Code plugin — 20 skills that steer Claude when building IRIS For Health Interoperability
+productions (messages, BS/BP/BO, BPL, DTL, HL7 schemas, SOAP/REST/FHIR/DICOM, alerting, security,
+lifecycle), plus governance hooks, subagents and a post-build conformance review. Install it with:
 
-Tested with Claude Sonnet 4.6 on 41 tasks from real ISC codebases:
-
-| Benchmark suite | Baseline | With top skill | Lift |
-|-----------------|----------|----------------|------|
-| ObjectScript repair (22 tasks) | 73% | **100%** | +27% |
-| Multi-file repair (5 tasks) | 80% | **100%** | +20% |
-| IRIS SQL quirks (14 tasks) | 93% | **100%** | +7% |
-
-The top skill is **`objectscript-review`** — a 205-word checklist that catches the 10 most common ObjectScript mistakes before the AI writes any code.
-
-**VS Code Copilot:** Skills are included automatically when you install the extension.
-
-**Claude Code:**
-```bash
-mkdir -p ~/.claude/skills
-for skill in objectscript-review objectscript-guardrails objectscript-sql-patterns; do
-  mkdir -p ~/.claude/skills/$skill
-  curl -sL https://raw.githubusercontent.com/intersystems-community/iris-agentic-dev/master/light-skills/skills/$skill/SKILL.md \
-    > ~/.claude/skills/$skill/SKILL.md
-done
+```text
+/plugin marketplace add intersystems-ib/iris-interop-skills
+/plugin install iris-interop-skills@iris-interop-skills
 ```
-
-**OpenCode:**
-```bash
-mkdir -p ~/.config/opencode/skills
-for skill in objectscript-review objectscript-guardrails objectscript-sql-patterns; do
-  mkdir -p ~/.config/opencode/skills/$skill
-  curl -sL https://raw.githubusercontent.com/intersystems-community/iris-agentic-dev/master/light-skills/skills/$skill/SKILL.md \
-    > ~/.config/opencode/skills/$skill/SKILL.md
-done
-```
-
-### Skill inventory
-
-| Skill | What it does | Benchmark |
-|-------|-------------|-----------|
-| `objectscript-review` | Hard-gate checklist: 10 most common AI mistakes in ObjectScript | 🥇 100% repair |
-| `objectscript-guardrails` | All-in-one hard gate, works without MCP | 86% repair |
-| `objectscript-sql-patterns` | IRIS SQL quirks: reserved words, SQLCODE, table naming, NULL handling | 100% SQL |
-| `objectscript-unit-test` | Generates `%UnitTest` scaffolding from live class introspection | 86% repair |
-| `objectscript-list-patterns` | `%List`, `$LISTBUILD`, `$LISTNEXT`, `$LISTTOSTRING` patterns | 91% repair |
-| `objectscript-navigation` | Codebase discovery using MCP introspection tools | 82% repair |
-| `objectscript-tdd` | Compile-test-fix loop for iterative development | |
-| `objectscript-debugging` | Maps `.INT` offsets to `.CLS` source lines, reads error logs | |
-| `objectscript-repair` | Coordinated fixes across multiple dependent classes | |
-| `iris-docs` | Fetches live IRIS class reference before implementing any API — eliminates hallucinated methods | |
-| `iris-vector-ai` | IRIS vector search syntax (HNSW, `VECTOR_COSINE`, `TO_VECTOR`) | domain |
-| `iris-connectivity` | IRIS connection APIs from Python, Java, JDBC, ODBC | domain |
-| `ensemble-production` | Interoperability production lifecycle, logs, queues | domain |
-| `iris-devtester` | `IRISContainer` factory methods and test fixture patterns | domain |
-
-See [`light-skills/`](./light-skills/) for the full list, benchmark results, and how to contribute a skill.
-
-> **Note**: some skills hurt if loaded globally. `objectscript-loop-patterns` measured −19% lift when loaded for all tasks. Domain skills (`iris-vector-ai`, `iris-connectivity`, `ensemble-production`) should only be loaded when working in those areas. See [BENCHMARKING.md](./light-skills/BENCHMARKING.md).
 
 ---
 
-## Tools
+## Tools (interop profile)
 
-Most tools work over the Atelier REST API and connect to any IRIS instance. Tools marked ✦ require `IRIS_CONTAINER` to be set.
+Most tools work over the Atelier REST API against any IRIS instance; Docker-only tools accept an
+`IRIS_CONTAINER` but also run over HTTP/Atelier against native/remote IRIS.
 
-**Code**
+**Code & data** — `iris_doc` (read/write/delete documents), `iris_compile` (compile, errors with line
+numbers), `iris_execute` (run ObjectScript), `iris_query` (SQL → JSON rows), `iris_test` (run
+`%UnitTest`, structured pass/fail), `iris_get_log` (fetch a truncated result by `log_id`).
 
-| Tool | What it does |
-|------|-------------|
-| `iris_compile` | Compile a class, routine, or wildcard. Returns errors with line numbers. |
-| `iris_doc` | Read, write, delete, or check any IRIS document. |
-| `iris_execute` | Run ObjectScript, return output. |
-| `iris_query` | Execute SQL, return rows as JSON. |
-| `iris_test` | Run `%UnitTest` tests, return structured pass/fail results. |
-| `iris_source_control` ✦ | Check lock status, checkout, execute SCM actions. |
+**Introspection** — `docs_introspect` (methods/properties/XData/superclasses), `iris_symbols` (search
+classes/methods), `iris_table_info` (real projected table + columns), `check_config` (active connection state).
 
-**Search and introspection**
-
-| Tool | What it does |
-|------|-------------|
-| `iris_symbols` | Search classes and methods via `%Dictionary`. |
-| `docs_introspect` | Deep class inspection: methods, properties, XData, superclasses. |
-| `iris_search` | Full-text search across the namespace. Supports regex and category filters. |
-| `iris_info` | Namespace discovery: documents, jobs, CSP apps, metadata. |
-| `iris_macro` | Macro inspection: list, signature, definition, expand. |
-
-**Debugging**
-
-| Tool | What it does |
-|------|-------------|
-| `iris_debug` | Map INT offsets to source lines, fetch error logs, capture error state. |
-| `iris_get_log` | Retrieve a full result by `log_id` when a tool returns `truncated: true`. |
-| `check_config` | Show active connection state — host, container, config file, write tool status. |
-
-**Generation**
-
-| Tool | What it does |
-|------|-------------|
-| `iris_generate` | Build a context-rich prompt for generating ObjectScript. No API key required. |
-| `iris_generate_class` | Generate and compile a class from a description (requires LLM API key). |
-| `iris_generate_test` | Generate `%UnitTest` scaffolding for an existing class. |
-
-**Interoperability** ✦
-
-| Tool | What it does |
-|------|-------------|
-| `iris_production` | Start, stop, update, check, or recover a production. |
-| `iris_interop_query` | Query production logs, queue depths, or message archive. |
-
-**Administration**
-
-| Tool | What it does |
-|------|-------------|
-| `iris_admin` | List namespaces, databases, users, roles, web apps; create/delete users (requires `IRIS_ADMIN_TOOLS=1`). |
-| `iris_containers` ✦ | List, select, or start IRIS Docker containers. Hot-swaps the active connection without a session restart. |
+**Interoperability** — `iris_production` (start/stop/update/status/recover), `iris_production_item`
+(item get/set settings), `iris_interop_query` (logs, queues, message archive/trace),
+`iris_lookup_manage` / `iris_lookup_transfer` (lookup tables), `iris_credential_list` /
+`iris_credential_manage` (SSL/credentials).
 
 ---
 
@@ -316,37 +190,34 @@ Most tools work over the Atelier REST API and connect to any IRIS instance. Tool
 
 | Symptom | Likely cause | Fix |
 |---------|-------------|-----|
-| 404 on `/api/atelier` (Windows) | IIS missing `/api` web application | See [Windows IIS setup](#windows-iis-api-web-application-required) above |
+| 404 on `/api/atelier` (Windows) | IIS missing `/api` web application | See Windows IIS setup above |
 | `check_config` works but compile/search fail | Atelier web app `Recurse=0` | Management Portal → Security → Web Apps → `/api/atelier` → enable **Recurse** |
-| All tools fail, namespace listing works | API version mismatch | Verify IRIS supports Atelier v8 (`iris-agentic-dev --verbose` shows detected version) |
+| `iris_execute` returns empty output | HTTP CodeMode only returns what your code `write`s | Use `write <expr>,!`, or wrap side effects as a `[SqlProc]` and read via `iris_query` |
+| `DOCKER_REQUIRED` on native IRIS | `IRIS_CONTAINER` set unnecessarily | Retry without `IRIS_CONTAINER` — the interop tools run over HTTP |
 | 403 on write operations | Insufficient permissions | Use a user with `%DB_USER` or `%All` role |
 | Connection delays on Windows | `localhost` DNS issue | Use `host = "127.0.0.1"` in `.iris-agentic-dev.toml` |
 
-For verbose HTTP logging:
-
-```bash
-iris-agentic-dev mcp --verbose 2>debug.log
-```
-
-A 404 on `/api/atelier/v8/...` usually indicates the Recurse setting or a missing `/api` web application. A 401/403 is an authentication issue. Connection refused means the host or port is wrong.
+Verbose HTTP logging: `iris-interop-dev mcp --verbose 2>debug.log`.
 
 ---
 
 ## Commands
 
 ```bash
-iris-agentic-dev mcp                     # Start the MCP server
-iris-agentic-dev compile MyApp.Foo.cls   # Compile from the terminal
-iris-agentic-dev init                    # Generate .iris-agentic-dev.toml from running containers
-iris-agentic-dev --version               # Print version
+iris-interop-dev mcp                     # Start the MCP server
+iris-interop-dev compile MyApp.Foo.cls   # Compile from the terminal
+iris-interop-dev init                    # Generate .iris-agentic-dev.toml from running containers
+iris-interop-dev --version               # Print version
 ```
 
 ---
 
 ## Contributing
 
-Issues and pull requests are welcome. File bugs at the [Issues tab](https://github.com/intersystems-community/iris-agentic-dev/issues).
+Issues and pull requests welcome — file bugs at the
+[Issues tab](https://github.com/intersystems-ib/iris-interop-dev/issues).
 
-To contribute a skill — write a `SKILL.md`, run the benchmark, submit a PR with your results. See [BENCHMARKING.md](./light-skills/BENCHMARKING.md).
-
-Questions: [thomas.dyar@intersystems.com](mailto:thomas.dyar@intersystems.com)
+This is an interop-focused fork of the community
+[`intersystems-community/iris-agentic-dev`](https://github.com/intersystems-community/iris-agentic-dev);
+upstream fixes to the shared codebase flow from there. The repositories in `intersystems-ib` are
+community utilities and examples — **not** covered by official InterSystems support.


### PR DESCRIPTION
Fork-specific README: install from the intersystems-ib release, `iris-interop-dev` server key/command, companion `iris-interop-skills` plugin, and the download links now resolve (the v0.7.0-interop Release is published). Keeps `.iris-agentic-dev.toml` (the binary reads that name).

🤖 Generated with [Claude Code](https://claude.com/claude-code)