### PR TITLE
fix(namespace): omitted namespace resolves to the connection namespace + NAMESPACE_NOT_INTEROP preflight

### DIFF
--- a/crates/iris-agentic-dev-core/src/tools/interop.rs
+++ b/crates/iris-agentic-dev-core/src/tools/interop.rs
@@ -31,6 +31,112 @@ fn default_true() -> bool {
     true
 }
 
+// ═══ issue #5: namespace resolution + self-describing interop preflight ═══
+
+/// `namespace` is optional on the interop tools: an omitted or empty value
+/// resolves to the CONNECTION's namespace (IRIS_NAMESPACE / discovery), never
+/// a hardcoded "USER" — on interop-configured servers "USER" is almost never
+/// the namespace the caller means, which made omission fail 95% of the time.
+pub fn resolve_namespace(requested: Option<&str>, iris: Option<&IrisConnection>) -> String {
+    match requested {
+        Some(ns) if !ns.trim().is_empty() => ns.to_string(),
+        _ => iris
+            .map(|i| i.namespace.clone())
+            .unwrap_or_else(|| "USER".to_string()),
+    }
+}
+
+/// Positive probe results, keyed "base_url|namespace". Never invalidated: a
+/// namespace does not lose Interoperability within a server process lifetime.
+/// Negatives are NOT cached — a namespace can gain interop (or be created)
+/// while the server runs.
+static INTEROP_NS_CACHE: std::sync::OnceLock<std::sync::Mutex<std::collections::HashSet<String>>> =
+    std::sync::OnceLock::new();
+
+/// Enumerate interop-enabled namespaces for the error hint (best effort).
+/// `$EXTRACT(tNs)'="%"` skips system namespaces; `Continue` is deliberately
+/// avoided — it must be the last command on its line, which a one-line For
+/// body cannot honor.
+async fn list_interop_namespaces(
+    iris: &IrisConnection,
+    ns: &str,
+    client: &reqwest::Client,
+) -> Option<String> {
+    const CODE: &str = r#"Set tSaved=$NAMESPACE,tOut=""
+Try { Do ##class(%SYS.Namespace).ListAll(.arr) } Catch ex {}
+Set tNs="" For { Set tNs=$ORDER(arr(tNs)) Quit:tNs=""  If $EXTRACT(tNs)'="%" { Try { Set $NAMESPACE=tNs If ##class(%Dictionary.CompiledClass).%ExistsId("Ens.Director") { Set tOut=tOut_$SELECT(tOut="":"",1:",")_tNs } } Catch ex {} } }
+Set $NAMESPACE=tSaved
+Write tOut"#;
+    iris.execute_via_generator(CODE, ns, client)
+        .await
+        .ok()
+        .map(|out| out.trim().to_string())
+        .filter(|out| !out.is_empty())
+}
+
+/// Issue #5: fail fast and self-describing when the target namespace has no
+/// Interoperability. Without this, the underlying calls surface raw internals
+/// ("Table 'ENS_CONFIG.CREDENTIALS' not found", <CLASS DOES NOT EXIST>) that
+/// never name the cause. Probes %Dictionary.CompiledClass for Ens.Director —
+/// one SELECT round trip, positives cached per process. Returns Some(error)
+/// only on a definitive "no interop here"; any probe failure returns None so
+/// the tool's own error surfaces instead.
+pub async fn ensure_interop_namespace(
+    iris: &IrisConnection,
+    ns: &str,
+) -> Option<Result<CallToolResult, McpError>> {
+    let key = format!("{}|{}", iris.base_url, ns);
+    let cache = INTEROP_NS_CACHE.get_or_init(Default::default);
+    if cache.lock().map(|c| c.contains(&key)).unwrap_or(false) {
+        return None;
+    }
+    let client = IrisConnection::http_client().ok()?;
+    let probe = iris
+        .query(
+            "SELECT COUNT(*) AS n FROM %Dictionary.CompiledClass WHERE Name = 'Ens.Director'",
+            vec![],
+            ns,
+            &client,
+        )
+        .await;
+    let n = match &probe {
+        Ok(resp) => resp["result"]["content"][0]["n"].as_i64()?,
+        Err(_) => return None,
+    };
+    if n >= 1 {
+        if let Ok(mut c) = cache.lock() {
+            c.insert(key);
+        }
+        return None;
+    }
+    let available = list_interop_namespaces(iris, ns, &client).await;
+    let hint = match &available {
+        Some(list) => format!(
+            "Pass namespace= one of the interop-enabled namespaces on this instance: {list}. \
+             Omitting namespace targets the connection namespace '{}'.",
+            iris.namespace
+        ),
+        None => format!(
+            "Pass namespace= an interop-enabled namespace. \
+             Omitting namespace targets the connection namespace '{}'.",
+            iris.namespace
+        ),
+    };
+    Some(ok_json(serde_json::json!({
+        "success": false,
+        "error_code": "NAMESPACE_NOT_INTEROP",
+        "error": format!(
+            "Namespace '{ns}' has no Interoperability enabled — the Ens.* classes and \
+             Ens_* tables do not exist there, so interop tools cannot run in it."
+        ),
+        "hint": hint,
+        "namespace": ns,
+        "interop_namespaces": available
+            .map(|l| l.split(',').map(str::to_string).collect::<Vec<_>>())
+            .unwrap_or_default(),
+    })))
+}
+
 #[derive(Debug, Deserialize, JsonSchema)]
 pub struct ProductionStatusParams {
     #[serde(default = "default_ns")]
@@ -1708,6 +1814,42 @@ mod tests {
             !code.contains("\\\""),
             "generated code must never use C-style quote escaping"
         );
+    }
+
+    // ─── issue #5: omitted namespace resolves to the connection's, not "USER" ───
+
+    fn test_connection(ns: &str) -> IrisConnection {
+        IrisConnection {
+            base_url: "http://localhost:43080".into(),
+            namespace: ns.into(),
+            username: "_SYSTEM".into(),
+            password: "SYS".into(),
+            version: None,
+            atelier_version: crate::iris::connection::AtelierVersion::V1,
+            source: crate::iris::connection::DiscoverySource::EnvVar,
+            port_superserver: None,
+            system_mode: crate::iris::connection::SystemMode::Development,
+        }
+    }
+
+    #[test]
+    fn resolve_namespace_prefers_explicit_param() {
+        let conn = test_connection("APP");
+        assert_eq!(resolve_namespace(Some("EJ3"), Some(&conn)), "EJ3");
+    }
+
+    #[test]
+    fn resolve_namespace_falls_back_to_connection() {
+        let conn = test_connection("APP");
+        assert_eq!(resolve_namespace(None, Some(&conn)), "APP");
+        assert_eq!(resolve_namespace(Some(""), Some(&conn)), "APP");
+        assert_eq!(resolve_namespace(Some("  "), Some(&conn)), "APP");
+    }
+
+    #[test]
+    fn resolve_namespace_user_only_without_connection() {
+        assert_eq!(resolve_namespace(None, None), "USER");
+        assert_eq!(resolve_namespace(Some("EJ3"), None), "EJ3");
     }
 
     // ─── issue #6: lookup import died with <SYNTAX> on quote-heavy XML ───

--- a/crates/iris-agentic-dev-core/src/tools/mod.rs
+++ b/crates/iris-agentic-dev-core/src/tools/mod.rs
@@ -4219,7 +4219,7 @@ Methods:
     // Note: iris_debug already exists above as a real tool — it IS the merged debug dispatcher.
 
     #[tool(
-        description = "Interoperability production lifecycle (merged). action: status=get current state, start=start named production, stop=stop production, restart=recycle ONE config item (pass item=<config item name>), update=hot-apply config, check=check if update needed, recover=recover troubled production."
+        description = "Interoperability production lifecycle (merged). action: status=get current state, start=start named production, stop=stop production, restart=recycle ONE config item (pass item=<config item name>), update=hot-apply config, check=check if update needed, recover=recover troubled production. namespace: optional — defaults to the connection namespace (IRIS_NAMESPACE); must be an interop-enabled namespace."
     )]
     async fn iris_production(
         &self,
@@ -4228,16 +4228,20 @@ Methods:
         let action = p.get("action").and_then(|v| v.as_str()).unwrap_or("status");
         let _iris_arc_hold = self.iris_arc();
         let iris_opt = _iris_arc_hold.as_deref();
+        let namespace =
+            interop::resolve_namespace(p.get("namespace").and_then(|v| v.as_str()), iris_opt);
+        if let Some(iris) = iris_opt {
+            if let Some(blocked) = interop::ensure_interop_namespace(iris, &namespace).await {
+                self.record_call("iris_production", false);
+                return blocked;
+            }
+        }
         let result = match action {
             "status" => {
                 interop::interop_production_status_impl(
                     iris_opt,
                     interop::ProductionStatusParams {
-                        namespace: p
-                            .get("namespace")
-                            .and_then(|v| v.as_str())
-                            .unwrap_or("USER")
-                            .to_string(),
+                        namespace: namespace.clone(),
                         full_status: p.get("full").and_then(|v| v.as_bool()).unwrap_or(false),
                     },
                 )
@@ -4251,11 +4255,7 @@ Methods:
                             .get("production_name")
                             .and_then(|v| v.as_str())
                             .map(|s| s.to_string()),
-                        namespace: p
-                            .get("namespace")
-                            .and_then(|v| v.as_str())
-                            .unwrap_or("USER")
-                            .to_string(),
+                        namespace: namespace.clone(),
                     },
                 )
                 .await
@@ -4268,11 +4268,7 @@ Methods:
                             .get("production_name")
                             .and_then(|v| v.as_str())
                             .map(|s| s.to_string()),
-                        namespace: p
-                            .get("namespace")
-                            .and_then(|v| v.as_str())
-                            .unwrap_or("USER")
-                            .to_string(),
+                        namespace: namespace.clone(),
                         timeout: p.get("timeout").and_then(|v| v.as_u64()).unwrap_or(30) as u32,
                         force: p.get("force").and_then(|v| v.as_bool()).unwrap_or(false),
                     },
@@ -4283,11 +4279,7 @@ Methods:
                 interop::interop_production_update_impl(
                     iris_opt,
                     interop::ProductionUpdateParams {
-                        namespace: p
-                            .get("namespace")
-                            .and_then(|v| v.as_str())
-                            .unwrap_or("USER")
-                            .to_string(),
+                        namespace: namespace.clone(),
                         timeout: 30,
                         force: false,
                     },
@@ -4298,11 +4290,7 @@ Methods:
                 interop::interop_production_needs_update_impl(
                     iris_opt,
                     interop::ProductionNeedsUpdateParams {
-                        namespace: p
-                            .get("namespace")
-                            .and_then(|v| v.as_str())
-                            .unwrap_or("USER")
-                            .to_string(),
+                        namespace: namespace.clone(),
                     },
                 )
                 .await
@@ -4311,11 +4299,7 @@ Methods:
                 interop::interop_production_recover_impl(
                     iris_opt,
                     interop::ProductionRecoverParams {
-                        namespace: p
-                            .get("namespace")
-                            .and_then(|v| v.as_str())
-                            .unwrap_or("USER")
-                            .to_string(),
+                        namespace: namespace.clone(),
                     },
                 )
                 .await
@@ -4325,7 +4309,7 @@ Methods:
                     iris_opt,
                     &interop::ProductionAutostartParams {
                         action: "get_autostart".into(),
-                        namespace: p.get("namespace").and_then(|v| v.as_str()).unwrap_or("USER").to_string(),
+                        namespace: namespace.clone(),
                         enabled: None,
                         production: None,
                     },
@@ -4336,7 +4320,7 @@ Methods:
                     iris_opt,
                     &interop::ProductionAutostartParams {
                         action: "set_autostart".into(),
-                        namespace: p.get("namespace").and_then(|v| v.as_str()).unwrap_or("USER").to_string(),
+                        namespace: namespace.clone(),
                         enabled: p.get("enabled").and_then(|v| v.as_bool()),
                         production: p.get("production").and_then(|v| v.as_str()).map(|s| s.to_string()),
                     },
@@ -4344,10 +4328,7 @@ Methods:
             }
             "restart" => {
                 // B: recycle ONE config item (disable+enable, each with UpdateProduction).
-                let ns = p
-                    .get("namespace")
-                    .and_then(|v| v.as_str())
-                    .unwrap_or("USER");
+                let ns = namespace.as_str();
                 let item = p
                     .get("item")
                     .or_else(|| p.get("component"))
@@ -4542,7 +4523,7 @@ Methods:
     // ─── 024-interop-depth: Production item control (US1) ───
 
     #[tool(
-        description = "Add, remove, enable, disable, or inspect/modify settings of an Interoperability production config item — the typed way to build/manipulate a production without hand-rolling ##class(Ens.Config.*) ObjectScript. action: add|remove|enable|disable|get_settings|set_settings. item: exact config item name. For add: class_name (the BS/BO/BP/adapter class the item runs, required), optional enabled (default true), production (defaults to the running one), pool_size, category, and settings (key-value; prefix a key with 'Adapter.' to target the adapter, e.g. 'Adapter.FilePath', otherwise it targets the Host). For remove: item (+ optional production). settings: key-value map for set_settings. Changes apply live via Ens.Director.UpdateProduction when the target production is running (set_settings honours apply=false to batch). Works via HTTP, no Docker required."
+        description = "Add, remove, enable, disable, or inspect/modify settings of an Interoperability production config item — the typed way to build/manipulate a production without hand-rolling ##class(Ens.Config.*) ObjectScript. action: add|remove|enable|disable|get_settings|set_settings. item: exact config item name. For add: class_name (the BS/BO/BP/adapter class the item runs, required), optional enabled (default true), production (defaults to the running one), pool_size, category, and settings (key-value; prefix a key with 'Adapter.' to target the adapter, e.g. 'Adapter.FilePath', otherwise it targets the Host). For remove: item (+ optional production). settings: key-value map for set_settings. namespace: optional — defaults to the connection namespace (IRIS_NAMESPACE); must be an interop-enabled namespace, and it is the parameter that matters when an item is 'not found'. Changes apply live via Ens.Director.UpdateProduction when the target production is running (set_settings honours apply=false to batch). Works via HTTP, no Docker required."
     )]
     async fn iris_production_item(
         &self,
@@ -4558,11 +4539,17 @@ Methods:
             .and_then(|v| v.as_str())
             .unwrap_or("")
             .to_string();
-        let namespace = p
-            .get("namespace")
-            .and_then(|v| v.as_str())
-            .unwrap_or("USER")
-            .to_string();
+        let _iris_arc_hold = self.iris_arc();
+        let namespace = interop::resolve_namespace(
+            p.get("namespace").and_then(|v| v.as_str()),
+            _iris_arc_hold.as_deref(),
+        );
+        if let Some(iris) = _iris_arc_hold.as_deref() {
+            if let Some(blocked) = interop::ensure_interop_namespace(iris, &namespace).await {
+                self.record_call("iris_production_item", false);
+                return blocked;
+            }
+        }
         let settings: std::collections::HashMap<String, String> = p
             .get("settings")
             .and_then(|v| v.as_object())
@@ -4612,19 +4599,25 @@ Methods:
     // ─── 024-interop-depth: Ensemble credentials (US2) ───
 
     #[tool(
-        description = "List all Ensemble credentials (IDs and usernames only — passwords never returned). namespace: optional."
+        description = "List all Ensemble credentials (IDs and usernames only — passwords never returned). namespace: optional — defaults to the connection namespace (IRIS_NAMESPACE); must be an interop-enabled namespace."
     )]
     async fn iris_credential_list(
         &self,
         Parameters(p): Parameters<AnyParams>,
     ) -> Result<CallToolResult, McpError> {
-        let namespace = p
-            .get("namespace")
-            .and_then(|v| v.as_str())
-            .unwrap_or("USER")
-            .to_string();
+        let _iris_arc_hold = self.iris_arc();
+        let namespace = interop::resolve_namespace(
+            p.get("namespace").and_then(|v| v.as_str()),
+            _iris_arc_hold.as_deref(),
+        );
+        if let Some(iris) = _iris_arc_hold.as_deref() {
+            if let Some(blocked) = interop::ensure_interop_namespace(iris, &namespace).await {
+                self.record_call("iris_credential_list", false);
+                return blocked;
+            }
+        }
         let result = interop::interop_credential_list_impl(
-            self.iris_arc().as_deref(),
+            _iris_arc_hold.as_deref(),
             interop::CredentialListParams { namespace },
         )
         .await;
@@ -4633,14 +4626,25 @@ Methods:
     }
 
     #[tool(
-        description = "Create, update, or delete an Ensemble credential. action: create|update|delete. id: credential ID (required). username/password: required for create, optional for update. namespace: optional. Write-gated: suppressed on Live instances unless IRIS_ALLOW_PROD=1."
+        description = "Create, update, or delete an Ensemble credential. action: create|update|delete. id: credential ID (required). username/password: required for create, optional for update. namespace: optional — defaults to the connection namespace (IRIS_NAMESPACE); must be an interop-enabled namespace. Write-gated: suppressed on Live instances unless IRIS_ALLOW_PROD=1."
     )]
     async fn iris_credential_manage(
         &self,
         Parameters(p): Parameters<AnyParams>,
     ) -> Result<CallToolResult, McpError> {
+        let _iris_arc_hold = self.iris_arc();
+        let namespace = interop::resolve_namespace(
+            p.get("namespace").and_then(|v| v.as_str()),
+            _iris_arc_hold.as_deref(),
+        );
+        if let Some(iris) = _iris_arc_hold.as_deref() {
+            if let Some(blocked) = interop::ensure_interop_namespace(iris, &namespace).await {
+                self.record_call("iris_credential_manage", false);
+                return blocked;
+            }
+        }
         let result = interop::interop_credential_manage_impl(
-            self.iris_arc().as_deref(),
+            _iris_arc_hold.as_deref(),
             interop::CredentialManageParams {
                 action: p
                     .get("action")
@@ -4660,11 +4664,7 @@ Methods:
                     .get("password")
                     .and_then(|v| v.as_str())
                     .map(|s| s.to_string()),
-                namespace: p
-                    .get("namespace")
-                    .and_then(|v| v.as_str())
-                    .unwrap_or("USER")
-                    .to_string(),
+                namespace: namespace.clone(),
             },
         )
         .await;
@@ -4675,14 +4675,25 @@ Methods:
     // ─── 024-interop-depth: Lookup tables (US3) ───
 
     #[tool(
-        description = "Read, write, delete, or list Ensemble lookup table entries. action: get|set|delete|list_keys|list_tables. table: table name (required except list_tables). key: required for get/set/delete. value: required for set. namespace: optional. get/list_keys/list_tables always available; set/delete write-gated."
+        description = "Read, write, delete, or list Ensemble lookup table entries. action: get|set|delete|list_keys|list_tables. table: table name (required except list_tables). key: required for get/set/delete. value: required for set. namespace: optional — defaults to the connection namespace (IRIS_NAMESPACE); must be an interop-enabled namespace. get/list_keys/list_tables always available; set/delete write-gated."
     )]
     async fn iris_lookup_manage(
         &self,
         Parameters(p): Parameters<AnyParams>,
     ) -> Result<CallToolResult, McpError> {
+        let _iris_arc_hold = self.iris_arc();
+        let namespace = interop::resolve_namespace(
+            p.get("namespace").and_then(|v| v.as_str()),
+            _iris_arc_hold.as_deref(),
+        );
+        if let Some(iris) = _iris_arc_hold.as_deref() {
+            if let Some(blocked) = interop::ensure_interop_namespace(iris, &namespace).await {
+                self.record_call("iris_lookup_manage", false);
+                return blocked;
+            }
+        }
         let result = interop::interop_lookup_manage_impl(
-            self.iris_arc().as_deref(),
+            _iris_arc_hold.as_deref(),
             interop::LookupManageParams {
                 action: p
                     .get("action")
@@ -4698,11 +4709,7 @@ Methods:
                     .get("value")
                     .and_then(|v| v.as_str())
                     .map(|s| s.to_string()),
-                namespace: p
-                    .get("namespace")
-                    .and_then(|v| v.as_str())
-                    .unwrap_or("USER")
-                    .to_string(),
+                namespace: namespace.clone(),
             },
         )
         .await;
@@ -4711,14 +4718,25 @@ Methods:
     }
 
     #[tool(
-        description = "Export or import an Ensemble lookup table as XML. action: export|import. table: table name. xml: XML string (required for import). namespace: optional. export always available; import write-gated."
+        description = "Export or import an Ensemble lookup table as XML. action: export|import. table: table name. xml: XML string (required for import). namespace: optional — defaults to the connection namespace (IRIS_NAMESPACE); must be an interop-enabled namespace. export always available; import write-gated."
     )]
     async fn iris_lookup_transfer(
         &self,
         Parameters(p): Parameters<AnyParams>,
     ) -> Result<CallToolResult, McpError> {
+        let _iris_arc_hold = self.iris_arc();
+        let namespace = interop::resolve_namespace(
+            p.get("namespace").and_then(|v| v.as_str()),
+            _iris_arc_hold.as_deref(),
+        );
+        if let Some(iris) = _iris_arc_hold.as_deref() {
+            if let Some(blocked) = interop::ensure_interop_namespace(iris, &namespace).await {
+                self.record_call("iris_lookup_transfer", false);
+                return blocked;
+            }
+        }
         let result = interop::interop_lookup_transfer_impl(
-            self.iris_arc().as_deref(),
+            _iris_arc_hold.as_deref(),
             interop::LookupTransferParams {
                 action: p
                     .get("action")
@@ -4731,11 +4749,7 @@ Methods:
                     .unwrap_or("")
                     .to_string(),
                 xml: p.get("xml").and_then(|v| v.as_str()).map(|s| s.to_string()),
-                namespace: p
-                    .get("namespace")
-                    .and_then(|v| v.as_str())
-                    .unwrap_or("USER")
-                    .to_string(),
+                namespace: namespace.clone(),
             },
         )
         .await;

--- a/crates/iris-agentic-dev-core/tests/interop_e2e_tests.rs
+++ b/crates/iris-agentic-dev-core/tests/interop_e2e_tests.rs
@@ -469,3 +469,55 @@ fn test_production_autostart() {
         );
     }
 }
+
+#[test]
+#[ignore = "requires live IRIS with Interoperability"]
+fn test_namespace_default_and_interop_hint() {
+    // Issue #5: omitting `namespace` failed 95% of the time because it fell
+    // back to a hardcoded "USER" instead of the connection namespace, and the
+    // failure surfaced as raw internals ("Table 'ENS_CONFIG.CREDENTIALS' not
+    // found") that never named the cause.
+    let iris_host = std::env::var("IRIS_HOST").unwrap_or_default();
+    assert!(!iris_host.is_empty(), "IRIS_HOST must be set");
+    let conn_ns = std::env::var("IRIS_NAMESPACE").unwrap_or_else(|_| "USER".to_string());
+    assert_ne!(
+        conn_ns, "USER",
+        "run with IRIS_NAMESPACE pointing at an interop-enabled namespace"
+    );
+
+    // 1. No namespace argument at all → must target the connection namespace
+    //    and succeed (this exact call failed 14/14 in the workshop data).
+    let responses = mcp_exchange(&[
+        serde_json::json!({"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2024-11-05","capabilities":{},"clientInfo":{"name":"e2e","version":"0.1"}}}),
+        serde_json::json!({"jsonrpc":"2.0","method":"notifications/initialized","params":{}}),
+        serde_json::json!({"jsonrpc":"2.0","id":2,"method":"tools/call","params":{"name":"iris_credential_list","arguments":{}}}),
+    ]);
+    let r = parse_tool_text(&find_response(&responses, 2).expect("no response"));
+    assert_eq!(r["success"], true, "credential_list without namespace: {r}");
+
+    // 2. Explicit non-interop namespace → self-describing error with a hint,
+    //    not a raw SQL/table error.
+    let responses = mcp_exchange(&[
+        serde_json::json!({"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2024-11-05","capabilities":{},"clientInfo":{"name":"e2e","version":"0.1"}}}),
+        serde_json::json!({"jsonrpc":"2.0","method":"notifications/initialized","params":{}}),
+        serde_json::json!({"jsonrpc":"2.0","id":2,"method":"tools/call","params":{"name":"iris_credential_list","arguments":{"namespace":"USER"}}}),
+    ]);
+    let r = parse_tool_text(&find_response(&responses, 2).expect("no response"));
+    assert_eq!(r["success"], false, "USER must be rejected: {r}");
+    assert_eq!(
+        r["error_code"], "NAMESPACE_NOT_INTEROP",
+        "self-describing code, got: {r}"
+    );
+    let hint = r["hint"].as_str().unwrap_or("");
+    assert!(
+        hint.contains("namespace="),
+        "hint must name the parameter: {hint}"
+    );
+    assert!(
+        r["interop_namespaces"]
+            .as_array()
+            .map(|a| a.iter().any(|v| v.as_str() == Some(conn_ns.as_str())))
+            .unwrap_or(false),
+        "hint must list the interop namespaces: {r}"
+    );
+}


### PR DESCRIPTION
Fixes #5.

## What

Omitting the optional `namespace` fell back to a hardcoded `"USER"` in 14 wrapper sites — never the connection's configured namespace — which is why it failed 37/39 times in the workshop telemetry, with raw internals (`Table 'ENS_CONFIG.CREDENTIALS' not found`) that never named the cause. Notably `iris_interop_query` already had the correct semantic (fall back to `iris.namespace`), which is why it was the one interop tool that barely failed; this PR brings the other six tools to the same behavior.

- **`resolve_namespace()`** — explicit param wins; otherwise the connection namespace (`IRIS_NAMESPACE` / discovery); `"USER"` only when there is no connection at all.
- **`ensure_interop_namespace()` preflight** on `iris_production`, `iris_production_item`, `iris_credential_list`, `iris_credential_manage`, `iris_lookup_manage`, `iris_lookup_transfer`: probes `%Dictionary.CompiledClass` for `Ens.Director` (one SELECT round trip, positives cached per process, negatives never cached) and fails fast with `error_code: NAMESPACE_NOT_INTEROP`, a `hint` naming the `namespace=` parameter, and `interop_namespaces` listing the interop-enabled namespaces on the instance. Any probe failure passes through so the tool's own error still surfaces.
- **Descriptions** now state the real default; `iris_production_item` explicitly documents `namespace` (its silence was called out in the issue).

## Verification

- 154 unit tests green (new: `resolve_namespace` precedence cases); clippy `-D warnings` clean.
- New live e2e `test_namespace_default_and_interop_hint`: `iris_credential_list` with **no** namespace succeeds against the connection namespace (the exact 14/14 failure), and `namespace=USER` returns `NAMESPACE_NOT_INTEROP` with the hint list containing the connection namespace.
- `test_lookup_crud` e2e still green through the new preflight.

🤖 Generated with [Claude Code](https://claude.com/claude-code)