### PR TITLE
chore: bump to 0.6.23 — escaping (#7) + namespace resolution (#8) fixes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -970,7 +970,7 @@ dependencies = [
 
 [[package]]
 name = "iris-agentic-dev"
-version = "0.6.22"
+version = "0.6.23"
 dependencies = [
  "anyhow",
  "clap",
@@ -987,7 +987,7 @@ dependencies = [
 
 [[package]]
 name = "iris-agentic-dev-core"
-version = "0.6.22"
+version = "0.6.23"
 dependencies = [
  "anyhow",
  "bollard",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "0.6.22"
+version = "0.6.23"
 edition = "2021"
 authors = ["Thomas Dyar <thomas.dyar@intersystems.com>"]
 license = "MIT"


### PR DESCRIPTION
Version bump so deployed binaries carrying the two merged fixes are identifiable (the stale-binary confusion this morning was diagnosed via the version string).

🤖 Generated with [Claude Code](https://claude.com/claude-code)