### PR TITLE
chore: bump to 0.6.24 — error envelope + isError (#10)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -970,7 +970,7 @@ dependencies = [
 
 [[package]]
 name = "iris-agentic-dev"
-version = "0.6.23"
+version = "0.6.24"
 dependencies = [
  "anyhow",
  "clap",
@@ -987,7 +987,7 @@ dependencies = [
 
 [[package]]
 name = "iris-agentic-dev-core"
-version = "0.6.23"
+version = "0.6.24"
 dependencies = [
  "anyhow",
  "bollard",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "0.6.23"
+version = "0.6.24"
 edition = "2021"
 authors = ["Thomas Dyar <thomas.dyar@intersystems.com>"]
 license = "MIT"


### PR DESCRIPTION
🤖 Generated with [Claude Code](https://claude.com/claude-code)