### PR TITLE
feat(interop_query): typed search on message content — body join + Search Tables

### DIFF
--- a/crates/iris-agentic-dev-core/src/tools/interop.rs
+++ b/crates/iris-agentic-dev-core/src/tools/interop.rs
@@ -234,6 +234,38 @@ pub struct MessageSearchParams {
     pub since_id: Option<i64>,
     #[serde(default = "default_msg_limit")]
     pub limit: u32,
+    /// Issue #4: body-class join — search on what the message SAYS. The body
+    /// class whose table is joined on h.MessageBodyId = r.ID; required when
+    /// body_where / body_select are used.
+    pub body_class: Option<String>,
+    /// SQL WHERE fragment over the body table's columns, e.g. "PacienteId = '4003'".
+    pub body_where: Option<String>,
+    /// Body columns to return alongside the header fields.
+    #[serde(default)]
+    pub body_select: Vec<String>,
+    /// Issue #4: search by indexed Search Table field.
+    pub search_table: Option<SearchTableFilter>,
+}
+
+/// Search-Table filter (issue #4). Every subclass of a virtual-document search
+/// table shares its BASE extent's SQL table (rows are told apart by PropId), so
+/// `class` scopes props via Ens_Config.SearchTableProp.ClassDerivation — never
+/// via a table name of its own.
+#[derive(Debug, Deserialize, JsonSchema)]
+pub struct SearchTableFilter {
+    /// Search-table subclass (e.g. "Hospital.Search.HL7") — scopes props to
+    /// the ones that subclass defines or inherits.
+    pub class: Option<String>,
+    /// Base extent class (default "EnsLib.HL7.SearchTable"; other families:
+    /// EnsLib.EDI.X12.SearchTable, EnsLib.EDI.XML.SearchTable, …, or an
+    /// Ens.CustomSearchTable subclass, which is its own extent).
+    pub extent: Option<String>,
+    /// Search Table property name, e.g. "PatientID".
+    pub prop: String,
+    /// Exact PropValue match. Exactly one of value / value_like is required.
+    pub value: Option<String>,
+    /// LIKE pattern for PropValue, e.g. "AMOX%".
+    pub value_like: Option<String>,
 }
 fn default_msg_limit() -> u32 {
     20
@@ -567,6 +599,162 @@ pub async fn interop_queues_impl(
     }
 }
 
+/// Header-level filters, prefixed so they survive a JOIN (`pfx` = "h." there,
+/// "" for the plain query).
+fn header_filters(params: &MessageSearchParams, pfx: &str) -> Vec<String> {
+    let mut filters = vec![];
+    if let Some(src) = &params.source {
+        filters.push(format!(
+            "{pfx}SourceConfigName = '{}'",
+            src.replace('\'', "''")
+        ));
+    }
+    if let Some(tgt) = &params.target {
+        filters.push(format!(
+            "{pfx}TargetConfigName = '{}'",
+            tgt.replace('\'', "''")
+        ));
+    }
+    if let Some(cls) = &params.class_name {
+        filters.push(format!(
+            "{pfx}MessageBodyClassName = '{}'",
+            cls.replace('\'', "''")
+        ));
+    }
+    // session_id / since_id are numeric (i64) — safe to inline.
+    if let Some(sid) = params.session_id {
+        filters.push(format!("{pfx}SessionId = {}", sid));
+    }
+    if let Some(since) = params.since_id {
+        filters.push(format!("{pfx}ID > {}", since));
+    }
+    filters
+}
+
+const HEADER_COLS: &str =
+    "ID, TimeCreated, SourceConfigName, TargetConfigName, MessageBodyClassName, SessionId, Status";
+
+/// A plausible SQL column/identifier — the only thing body_select accepts.
+fn is_sql_identifier(s: &str) -> bool {
+    !s.is_empty()
+        && s.chars()
+            .all(|c| c.is_ascii_alphanumeric() || c == '_' || c == '%')
+}
+
+/// Body-class join (issue #4). The join also pins h.MessageBodyClassName to
+/// the body class: MessageBodyId is only unique per body table, so without it
+/// same-numbered rows of OTHER body classes would match.
+fn build_body_join_sql(
+    limit: u32,
+    mut filters: Vec<String>,
+    body_class: &str,
+    body_table: &str,
+    body_where: Option<&str>,
+    body_select: &[String],
+) -> String {
+    filters.push(format!(
+        "h.MessageBodyClassName = '{}'",
+        body_class.replace('\'', "''")
+    ));
+    if let Some(w) = body_where {
+        filters.push(format!("({w})"));
+    }
+    let header_cols = HEADER_COLS
+        .split(", ")
+        .map(|c| format!("h.{c}"))
+        .collect::<Vec<_>>()
+        .join(", ");
+    let body_cols = body_select
+        .iter()
+        .map(|c| format!(", r.{c}"))
+        .collect::<String>();
+    format!(
+        "SELECT TOP {limit} {header_cols}{body_cols} FROM Ens.MessageHeader h JOIN {body_table} r ON h.MessageBodyId = r.ID WHERE {} ORDER BY h.ID DESC",
+        filters.join(" AND ")
+    )
+}
+
+/// Search-Table join (issue #4) — the canonical shape from the issue: DocId IS
+/// MessageBodyId, and PropId must be resolved through Ens_Config.SearchTableProp
+/// first (PropId is only unique within one extent).
+fn build_search_table_sql(
+    limit: u32,
+    mut filters: Vec<String>,
+    extent_table: &str,
+    prop_ids: &[i64],
+    value: Option<&str>,
+    value_like: Option<&str>,
+) -> String {
+    let ids = prop_ids
+        .iter()
+        .map(|i| i.to_string())
+        .collect::<Vec<_>>()
+        .join(",");
+    filters.push(format!("st.PropId IN ({ids})"));
+    if let Some(v) = value {
+        filters.push(format!("st.PropValue = '{}'", v.replace('\'', "''")));
+    } else if let Some(v) = value_like {
+        filters.push(format!("st.PropValue LIKE '{}'", v.replace('\'', "''")));
+    }
+    let header_cols = HEADER_COLS
+        .split(", ")
+        .map(|c| format!("h.{c}"))
+        .collect::<Vec<_>>()
+        .join(", ");
+    format!(
+        "SELECT TOP {limit} {header_cols}, st.PropValue FROM Ens.MessageHeader h JOIN {extent_table} st ON st.DocId = h.MessageBodyId WHERE {} ORDER BY h.ID DESC",
+        filters.join(" AND ")
+    )
+}
+
+/// SQL projection of a class via the dictionary (handles SqlTableName
+/// overrides the dots→underscores rule would get wrong). Ok(None) = class not
+/// compiled in that namespace.
+async fn resolve_sql_table(
+    iris: &IrisConnection,
+    ns: &str,
+    client: &reqwest::Client,
+    class: &str,
+) -> Result<Option<String>, String> {
+    let sql = format!(
+        "SELECT SqlSchemaName, SqlTableName FROM %Dictionary.CompiledClass WHERE Name = '{}'",
+        class.replace('\'', "''")
+    );
+    let resp = iris
+        .query(&sql, vec![], ns, client)
+        .await
+        .map_err(|e| e.to_string())?;
+    let row = &resp["result"]["content"][0];
+    match (row["SqlSchemaName"].as_str(), row["SqlTableName"].as_str()) {
+        (Some(s), Some(t)) if !s.is_empty() && !t.is_empty() => Ok(Some(format!("{s}.{t}"))),
+        _ => Ok(None),
+    }
+}
+
+/// Distinct body classes present in the namespace — the discovery hint when a
+/// body_class is missing or wrong.
+async fn list_body_classes(
+    iris: &IrisConnection,
+    ns: &str,
+    client: &reqwest::Client,
+) -> Option<Vec<String>> {
+    // %EXACT beats the column's SQLUPPER collation — the hint must show the
+    // case-sensitive class name the body_class parameter needs.
+    let sql = "SELECT DISTINCT TOP 20 %EXACT(MessageBodyClassName) AS MessageBodyClassName FROM Ens.MessageHeader WHERE MessageBodyClassName IS NOT NULL ORDER BY 1";
+    let resp = iris.query(sql, vec![], ns, client).await.ok()?;
+    let names: Vec<String> = resp["result"]["content"]
+        .as_array()?
+        .iter()
+        .filter_map(|r| r["MessageBodyClassName"].as_str())
+        .map(str::to_string)
+        .collect();
+    if names.is_empty() {
+        None
+    } else {
+        Some(names)
+    }
+}
+
 pub async fn interop_message_search_impl(
     iris: Option<&IrisConnection>,
     params: MessageSearchParams,
@@ -576,49 +764,268 @@ pub async fn interop_message_search_impl(
         None => return err_json("IRIS_UNREACHABLE", "No IRIS connection"),
     };
     let client = IrisConnection::http_client().map_err(|_| iris_unreachable())?;
-    let mut filters = vec![];
-    if let Some(src) = &params.source {
-        filters.push(format!("SourceConfigName = '{}'", src.replace('\'', "''")));
-    }
-    if let Some(tgt) = &params.target {
-        filters.push(format!("TargetConfigName = '{}'", tgt.replace('\'', "''")));
-    }
-    if let Some(cls) = &params.class_name {
-        filters.push(format!(
-            "MessageBodyClassName = '{}'",
-            cls.replace('\'', "''")
-        ));
-    }
-    // session_id / since_id are numeric (i64) — safe to inline.
-    if let Some(sid) = params.session_id {
-        filters.push(format!("SessionId = {}", sid));
-    }
-    if let Some(since) = params.since_id {
-        filters.push(format!("ID > {}", since));
-    }
-    let where_clause = if filters.is_empty() {
-        String::new()
-    } else {
-        format!("WHERE {}", filters.join(" AND "))
-    };
-    let sql = format!("SELECT TOP {} ID, TimeCreated, SourceConfigName, TargetConfigName, MessageBodyClassName, SessionId, Status FROM Ens.MessageHeader {} ORDER BY ID DESC", params.limit, where_clause);
     // A6: query the requested production namespace, not the connection default.
     let ns = params
         .namespace
         .as_deref()
         .unwrap_or(iris.namespace.as_str());
+    let net_err = |e: &str| {
+        if is_network_error(e) {
+            "IRIS_UNREACHABLE"
+        } else {
+            "INTEROP_ERROR"
+        }
+    };
+
+    let body_mode = params.body_class.is_some()
+        || params.body_where.is_some()
+        || !params.body_select.is_empty();
+    if body_mode && params.search_table.is_some() {
+        return err_json(
+            "INVALID_PARAMS",
+            "body_class/body_where and search_table are separate search modes — pass one or the other",
+        );
+    }
+
+    // ── Mode 1 (issue #4): body-class join ───────────────────────────────
+    if body_mode {
+        let body_class = match &params.body_class {
+            Some(c) => c.clone(),
+            None => {
+                let known = list_body_classes(iris, ns, &client).await;
+                let hint = match known {
+                    Some(names) => format!(
+                        "body_where/body_select need body_class. Body classes present in '{}': {}.",
+                        ns,
+                        names.join(", ")
+                    ),
+                    None => format!(
+                        "body_where/body_select need body_class (no messages found in '{}' to list candidates from).",
+                        ns
+                    ),
+                };
+                return crate::tools::envelope::fail_with(
+                    "INVALID_PARAMS",
+                    "body_where/body_select require body_class",
+                    serde_json::json!({"hint": hint}),
+                );
+            }
+        };
+        if let Some(w) = &params.body_where {
+            if w.contains(';') {
+                return err_json(
+                    "INVALID_PARAMS",
+                    "body_where must be a WHERE fragment, not a statement (no ';')",
+                );
+            }
+        }
+        if let Some(bad) = params.body_select.iter().find(|c| !is_sql_identifier(c)) {
+            return err_json(
+                "INVALID_PARAMS",
+                &format!("body_select entries must be plain column names; '{bad}' is not"),
+            );
+        }
+        let body_table = match resolve_sql_table(iris, ns, &client, &body_class).await {
+            Err(e) => return err_json(net_err(&e), &e),
+            Ok(Some(t)) => t,
+            Ok(None) => {
+                let known = list_body_classes(iris, ns, &client).await;
+                let hint = match known {
+                    Some(names) => format!(
+                        "Body classes actually present in '{}': {}. Class names are case-sensitive and must be compiled in the namespace.",
+                        ns,
+                        names.join(", ")
+                    ),
+                    None => "Class names are case-sensitive and must be compiled in the namespace."
+                        .to_string(),
+                };
+                return crate::tools::envelope::fail_with(
+                    "BODY_CLASS_NOT_FOUND",
+                    &format!(
+                        "Class '{}' is not compiled in namespace '{}'",
+                        body_class, ns
+                    ),
+                    serde_json::json!({"hint": hint, "body_class": body_class, "namespace": ns}),
+                );
+            }
+        };
+        let sql = build_body_join_sql(
+            params.limit,
+            header_filters(&params, "h."),
+            &body_class,
+            &body_table,
+            params.body_where.as_deref(),
+            &params.body_select,
+        );
+        return match iris.query(&sql, vec![], ns, &client).await {
+            Ok(resp) => ok_json(serde_json::json!({
+                "success": true,
+                "messages": resp["result"]["content"],
+                "count": resp["result"]["content"].as_array().map(|a| a.len()).unwrap_or(0),
+                "body_table": body_table,
+                "sql": sql,
+            })),
+            Err(e) => crate::tools::envelope::fail_with(
+                net_err(&e.to_string()),
+                &e.to_string(),
+                serde_json::json!({"hint": format!(
+                    "body_where/body_select must use the SQL column names of {} (the SQL projection of {}). Check them with iris_table_info.",
+                    body_table, body_class
+                ), "sql": sql}),
+            ),
+        };
+    }
+
+    // ── Mode 2 (issue #4): Search-Table filter ───────────────────────────
+    if let Some(st) = &params.search_table {
+        if st.value.is_some() == st.value_like.is_some() {
+            return err_json(
+                "INVALID_PARAMS",
+                "search_table needs exactly one of value (exact) or value_like (LIKE pattern)",
+            );
+        }
+        // Resolve the base extent: explicit > derived from `class` > HL7 default.
+        let extent = match (&st.extent, &st.class) {
+            (Some(e), _) => e.clone(),
+            (None, Some(class)) => {
+                let c = class.replace('\'', "''");
+                let sql = format!(
+                    "SELECT TOP 1 ClassExtent FROM Ens_Config.SearchTableProp WHERE ClassDerivation = '{c}' OR ClassDerivation LIKE '{c}~%'"
+                );
+                match iris.query(&sql, vec![], ns, &client).await {
+                    Err(e) => return err_json(net_err(&e.to_string()), &e.to_string()),
+                    Ok(resp) => match resp["result"]["content"][0]["ClassExtent"].as_str() {
+                        Some(e) => e.to_string(),
+                        None => {
+                            return crate::tools::envelope::fail_with(
+                                "SEARCH_TABLE_NOT_FOUND",
+                                &format!(
+                                    "No Search Table class '{}' is registered in namespace '{}'",
+                                    class, ns
+                                ),
+                                serde_json::json!({"hint": "The class must extend a search-table family (EnsLib.HL7.SearchTable, …) and be compiled; registration happens on first index build. Check Ens_Config.SearchTableProp."}),
+                            )
+                        }
+                    },
+                }
+            }
+            (None, None) => "EnsLib.HL7.SearchTable".to_string(),
+        };
+        // Resolve prop name -> PropId set within the extent (PropId is only
+        // unique per extent; `class` additionally scopes via ClassDerivation).
+        let e_esc = extent.replace('\'', "''");
+        let scope = match &st.class {
+            Some(class) => {
+                let c = class.replace('\'', "''");
+                format!(" AND (ClassDerivation = '{c}' OR ClassDerivation LIKE '{c}~%')")
+            }
+            None => String::new(),
+        };
+        let prop_sql = format!(
+            "SELECT PropId FROM Ens_Config.SearchTableProp WHERE ClassExtent = '{e_esc}' AND Name = '{}'{scope}",
+            st.prop.replace('\'', "''")
+        );
+        let prop_ids: Vec<i64> = match iris.query(&prop_sql, vec![], ns, &client).await {
+            Err(e) => return err_json(net_err(&e.to_string()), &e.to_string()),
+            Ok(resp) => resp["result"]["content"]
+                .as_array()
+                .map(|rows| rows.iter().filter_map(|r| r["PropId"].as_i64()).collect())
+                .unwrap_or_default(),
+        };
+        if prop_ids.is_empty() {
+            // Issue #4 hint: list what IS searchable instead of returning empty.
+            let names_sql = format!(
+                "SELECT DISTINCT Name FROM Ens_Config.SearchTableProp WHERE ClassExtent = '{e_esc}' ORDER BY Name"
+            );
+            let names = iris
+                .query(&names_sql, vec![], ns, &client)
+                .await
+                .ok()
+                .and_then(|resp| {
+                    resp["result"]["content"].as_array().map(|rows| {
+                        rows.iter()
+                            .filter_map(|r| r["Name"].as_str().map(str::to_string))
+                            .collect::<Vec<_>>()
+                    })
+                })
+                .unwrap_or_default();
+            return crate::tools::envelope::fail_with(
+                "SEARCH_PROP_NOT_FOUND",
+                &format!(
+                    "No Search Table property '{}' in extent '{}'",
+                    st.prop, extent
+                ),
+                serde_json::json!({
+                    "hint": if names.is_empty() {
+                        format!("Extent '{}' has no registered properties in namespace '{}' — is a SearchTableClass configured on any item?", extent, ns)
+                    } else {
+                        format!("Searchable properties of '{}': {}.", extent, names.join(", "))
+                    },
+                    "available_props": names,
+                }),
+            );
+        }
+        let extent_table = match resolve_sql_table(iris, ns, &client, &extent).await {
+            Err(e) => return err_json(net_err(&e), &e),
+            Ok(Some(t)) => t,
+            Ok(None) => {
+                return err_json(
+                    "SEARCH_TABLE_NOT_FOUND",
+                    &format!(
+                        "Extent class '{}' is not compiled in namespace '{}'",
+                        extent, ns
+                    ),
+                )
+            }
+        };
+        let sql = build_search_table_sql(
+            params.limit,
+            header_filters(&params, "h."),
+            &extent_table,
+            &prop_ids,
+            st.value.as_deref(),
+            st.value_like.as_deref(),
+        );
+        return match iris.query(&sql, vec![], ns, &client).await {
+            Ok(resp) => {
+                let rows = resp["result"]["content"].clone();
+                let count = rows.as_array().map(|a| a.len()).unwrap_or(0);
+                let mut out = serde_json::json!({
+                    "success": true,
+                    "messages": rows,
+                    "count": count,
+                    "extent": extent,
+                    "prop_ids": prop_ids,
+                    "sql": sql,
+                });
+                if count == 0 {
+                    // Issue #4: valid prop + zero rows is usually a config-time effect.
+                    out["hint"] = serde_json::Value::String(
+                        "A Search Table indexes only messages received AFTER SearchTableClass was configured on the item — existing messages are not back-indexed. Also check the value: PropValue matching is exact unless value_like is used.".into(),
+                    );
+                }
+                ok_json(out)
+            }
+            Err(e) => err_json(net_err(&e.to_string()), &e.to_string()),
+        };
+    }
+
+    // ── Plain header search (unchanged behavior) ─────────────────────────
+    let filters = header_filters(&params, "");
+    let where_clause = if filters.is_empty() {
+        String::new()
+    } else {
+        format!("WHERE {}", filters.join(" AND "))
+    };
+    let sql = format!(
+        "SELECT TOP {} {HEADER_COLS} FROM Ens.MessageHeader {} ORDER BY ID DESC",
+        params.limit, where_clause
+    );
     match iris.query(&sql, vec![], ns, &client).await {
         Ok(resp) => ok_json(
             serde_json::json!({"success": true, "messages": resp["result"]["content"], "count": resp["result"]["content"].as_array().map(|a| a.len()).unwrap_or(0)}),
         ),
-        Err(e) => err_json(
-            if is_network_error(&e.to_string()) {
-                "IRIS_UNREACHABLE"
-            } else {
-                "INTEROP_ERROR"
-            },
-            &e.to_string(),
-        ),
+        Err(e) => err_json(net_err(&e.to_string()), &e.to_string()),
     }
 }
 
@@ -1851,6 +2258,96 @@ mod tests {
     fn resolve_namespace_user_only_without_connection() {
         assert_eq!(resolve_namespace(None, None), "USER");
         assert_eq!(resolve_namespace(Some("EJ3"), None), "EJ3");
+    }
+
+    // ─── issue #4: typed message-content search ───
+
+    fn msg_params(source: Option<&str>) -> MessageSearchParams {
+        MessageSearchParams {
+            namespace: None,
+            source: source.map(str::to_string),
+            target: None,
+            class_name: None,
+            session_id: None,
+            since_id: None,
+            limit: 5,
+            body_class: None,
+            body_where: None,
+            body_select: vec![],
+            search_table: None,
+        }
+    }
+
+    #[test]
+    fn body_join_sql_matches_issue_shape() {
+        let p = msg_params(Some("Router.Censo"));
+        let sql = build_body_join_sql(
+            5,
+            header_filters(&p, "h."),
+            "Ejercicio3.MSG.MenuReq",
+            "Ejercicio3_MSG.MenuReq",
+            Some("PacienteId = '4003'"),
+            &["PacienteId".to_string(), "FechaNacimiento".to_string()],
+        );
+        assert!(sql.starts_with("SELECT TOP 5 h.ID, h.TimeCreated"));
+        assert!(sql.contains(", r.PacienteId, r.FechaNacimiento"));
+        assert!(sql.contains("JOIN Ejercicio3_MSG.MenuReq r ON h.MessageBodyId = r.ID"));
+        assert!(sql.contains("h.SourceConfigName = 'Router.Censo'"));
+        // MessageBodyId is only unique per body table — the class pin is what
+        // stops same-numbered rows of other classes matching.
+        assert!(sql.contains("h.MessageBodyClassName = 'Ejercicio3.MSG.MenuReq'"));
+        assert!(sql.contains("(PacienteId = '4003')"));
+        assert!(sql.ends_with("ORDER BY h.ID DESC"));
+    }
+
+    #[test]
+    fn search_table_sql_matches_issue_shape() {
+        let sql = build_search_table_sql(
+            10,
+            header_filters(&msg_params(None), "h."),
+            "EnsLib_HL7.SearchTable",
+            &[4],
+            Some("16284718"),
+            None,
+        );
+        assert!(sql.contains("JOIN EnsLib_HL7.SearchTable st ON st.DocId = h.MessageBodyId"));
+        assert!(sql.contains("st.PropId IN (4)"));
+        assert!(sql.contains("st.PropValue = '16284718'"));
+        assert!(sql.contains(", st.PropValue FROM"));
+        let like = build_search_table_sql(
+            10,
+            vec![],
+            "EnsLib_HL7.SearchTable",
+            &[12, 14],
+            None,
+            Some("AMOX%"),
+        );
+        assert!(like.contains("st.PropId IN (12,14)"));
+        assert!(like.contains("st.PropValue LIKE 'AMOX%'"));
+    }
+
+    #[test]
+    fn sql_identifier_gate() {
+        assert!(is_sql_identifier("PacienteId"));
+        assert!(is_sql_identifier("%ID"));
+        assert!(!is_sql_identifier("a b"));
+        assert!(!is_sql_identifier("x; DROP"));
+        assert!(!is_sql_identifier(""));
+    }
+
+    #[test]
+    fn search_params_deserialize_new_filters() {
+        let p: MessageSearchParams = serde_json::from_str(
+            r#"{"body_class":"E.MSG.R","body_where":"X=1","body_select":["X"],
+                "search_table":{"prop":"PatientID","value":"1"}}"#,
+        )
+        .unwrap();
+        assert_eq!(p.body_class.as_deref(), Some("E.MSG.R"));
+        assert_eq!(p.body_select, vec!["X"]);
+        let st = p.search_table.unwrap();
+        assert_eq!(st.prop, "PatientID");
+        assert_eq!(st.value.as_deref(), Some("1"));
+        assert!(st.extent.is_none());
     }
 
     // ─── issue #6: lookup import died with <SYNTAX> on quote-heavy XML ───

--- a/crates/iris-agentic-dev-core/src/tools/mod.rs
+++ b/crates/iris-agentic-dev-core/src/tools/mod.rs
@@ -4349,7 +4349,7 @@ Methods:
     }
 
     #[tool(
-        description = "Interoperability query dispatcher (merged). what (REQUIRED): logs=Event Log entries, queues=message queue depths, messages=message archive (Ens.MessageHeader), trace=ALL of one session (MessageHeader chain + Event Log events) by session_id, partners=configured Ens.Config.BusinessPartner rows. Filters: component=<config item> and session_id=<n> narrow logs/messages to one item/session; since_id=<n> tails only rows after a watermark (no MAX(ID) round-trip). Pass namespace=<production namespace> for a specific interop namespace (defaults to the connection's). For SQL-Gateway connections (no SQL table), use iris_table_info / the introspect-dont-guess agent."
+        description = "Interoperability query dispatcher (merged). what (REQUIRED): logs=Event Log entries, queues=message queue depths, messages=message archive (Ens.MessageHeader), trace=ALL of one session (MessageHeader chain + Event Log events) by session_id, partners=configured Ens.Config.BusinessPartner rows. Filters: component=<config item> and session_id=<n> narrow logs/messages to one item/session; since_id=<n> tails only rows after a watermark (no MAX(ID) round-trip). what=messages can also search message CONTENT — the typed replacement for hand SQL against Ens.MessageHeader: (a) body_class=<msg class> + body_where=<SQL fragment on the body table> + body_select=[cols] joins the body table server-side (SQL name resolved for you); (b) search_table={prop, value|value_like, class?, extent?} searches an indexed Search Table field (extent default EnsLib.HL7.SearchTable; errors list the searchable props). Pass namespace=<production namespace> for a specific interop namespace (defaults to the connection's). For SQL-Gateway connections (no SQL table), use iris_table_info / the introspect-dont-guess agent."
     )]
     async fn iris_interop_query(
         &self,
@@ -4437,6 +4437,27 @@ Methods:
                                 .or_else(|| v.as_str().and_then(|s| s.parse::<i64>().ok()))
                         }),
                         limit: p.get("limit").and_then(|v| v.as_u64()).unwrap_or(50) as u32,
+                        body_class: p
+                            .get("body_class")
+                            .and_then(|v| v.as_str())
+                            .map(|s| s.to_string()),
+                        body_where: p
+                            .get("body_where")
+                            .and_then(|v| v.as_str())
+                            .map(|s| s.to_string()),
+                        body_select: p
+                            .get("body_select")
+                            .and_then(|v| v.as_array())
+                            .map(|a| {
+                                a.iter()
+                                    .filter_map(|v| v.as_str().map(|s| s.to_string()))
+                                    .collect()
+                            })
+                            .unwrap_or_default(),
+                        search_table: p
+                            .get("search_table")
+                            .cloned()
+                            .and_then(|v| serde_json::from_value(v).ok()),
                     },
                 )
                 .await

--- a/crates/iris-agentic-dev-core/tests/interop_e2e_tests.rs
+++ b/crates/iris-agentic-dev-core/tests/interop_e2e_tests.rs
@@ -613,3 +613,122 @@ fn test_error_envelope_and_is_error_flag() {
         "iris_doc",
     );
 }
+
+#[test]
+#[ignore = "requires live IRIS with Interoperability"]
+fn test_message_content_search() {
+    // Issue #4: typed search on message CONTENT — body-class join and Search
+    // Tables — replacing the hand SQL that produced 57 <SYNTAX> errors in one
+    // workshop day.
+    let iris_host = std::env::var("IRIS_HOST").unwrap_or_default();
+    assert!(!iris_host.is_empty(), "IRIS_HOST must be set");
+    let ns = std::env::var("IRIS_NAMESPACE").unwrap_or_else(|_| "USER".to_string());
+
+    let call = |tool: &str, args: serde_json::Value| {
+        let responses = mcp_exchange(&[
+            serde_json::json!({"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2024-11-05","capabilities":{},"clientInfo":{"name":"e2e","version":"0.1"}}}),
+            serde_json::json!({"jsonrpc":"2.0","method":"notifications/initialized","params":{}}),
+            serde_json::json!({"jsonrpc":"2.0","id":2,"method":"tools/call","params":{"name":tool,"arguments":args}}),
+        ]);
+        parse_tool_text(&find_response(&responses, 2).expect("no response"))
+    };
+
+    // Seed one header+body fixture (no production needed — plain %Persistent rows).
+    let needle = "e2e-needle-content-search";
+    let seed = format!(
+        "Set body=##class(Ens.StringContainer).%New()\n\
+         Set body.StringValue=\"{needle}\"\n\
+         Set tSC=body.%Save()\n\
+         If $$$ISERR(tSC) {{ Write \"BODYFAIL\" Quit }}\n\
+         Set hdr=##class(Ens.MessageHeader).%New()\n\
+         Set hdr.MessageBodyClassName=\"Ens.StringContainer\"\n\
+         Set hdr.MessageBodyId=body.%Id()\n\
+         Set hdr.SourceConfigName=\"E2E.Source\"\n\
+         Set tSC2=hdr.%Save()\n\
+         If $$$ISERR(tSC2) {{ Write \"HDRFAIL\" Quit }}\n\
+         Write \"OK:\"_hdr.%Id()_\":\"_body.%Id()"
+    );
+    let r = call(
+        "iris_execute",
+        serde_json::json!({"namespace": ns, "code": seed}),
+    );
+    let out = r["output"].as_str().unwrap_or("");
+    assert!(out.starts_with("OK:"), "fixture seed failed: {r}");
+    let ids: Vec<&str> = out.trim_start_matches("OK:").split(':').collect();
+    let (hdr_id, body_id) = (ids[0].to_string(), ids[1].to_string());
+
+    // 1. body-class join finds the needle and returns the body column.
+    let r = call(
+        "iris_interop_query",
+        serde_json::json!({"what":"messages","namespace":ns,
+            "body_class":"Ens.StringContainer",
+            "body_where": format!("StringValue = '{needle}'"),
+            "body_select":["StringValue"]}),
+    );
+    assert_eq!(r["success"], true, "body join failed: {r}");
+    assert_eq!(r["count"], 1, "expected exactly the fixture: {r}");
+    assert_eq!(r["messages"][0]["StringValue"], needle, "{r}");
+    assert!(r["messages"][0]["SourceConfigName"].is_string(), "{r}");
+
+    // 2. body_where without body_class → error that lists the real classes.
+    let r = call(
+        "iris_interop_query",
+        serde_json::json!({"what":"messages","namespace":ns,"body_where":"X=1"}),
+    );
+    assert_eq!(r["error_code"], "INVALID_PARAMS", "{r}");
+    assert!(
+        r["hint"]
+            .as_str()
+            .unwrap_or("")
+            .contains("Ens.StringContainer"),
+        "hint must list case-exact body classes: {r}"
+    );
+
+    // 3. unknown body class → BODY_CLASS_NOT_FOUND.
+    let r = call(
+        "iris_interop_query",
+        serde_json::json!({"what":"messages","namespace":ns,
+            "body_class":"No.Such.Class","body_where":"X=1"}),
+    );
+    assert_eq!(r["error_code"], "BODY_CLASS_NOT_FOUND", "{r}");
+
+    // 4. unknown search-table prop → the searchable props are listed.
+    let r = call(
+        "iris_interop_query",
+        serde_json::json!({"what":"messages","namespace":ns,
+            "search_table":{"prop":"NoSuchProp","value":"x"}}),
+    );
+    assert_eq!(r["error_code"], "SEARCH_PROP_NOT_FOUND", "{r}");
+    assert!(
+        r["available_props"]
+            .as_array()
+            .map(|a| a.iter().any(|v| v.as_str() == Some("PatientID")))
+            .unwrap_or(false),
+        "available_props must list the extent's fields: {r}"
+    );
+
+    // 5. valid prop, zero rows → success with the config-time indexing hint.
+    let r = call(
+        "iris_interop_query",
+        serde_json::json!({"what":"messages","namespace":ns,
+            "search_table":{"prop":"MSHControlID","value":"e2e-no-such-value"}}),
+    );
+    assert_eq!(r["success"], true, "{r}");
+    assert_eq!(r["count"], 0, "{r}");
+    assert!(
+        r["hint"].as_str().unwrap_or("").contains("back-indexed"),
+        "zero rows must explain config-time indexing: {r}"
+    );
+
+    // Clean up the fixture.
+    let cleanup = format!(
+        "Do ##class(Ens.MessageHeader).%DeleteId({hdr_id})\n\
+         Do ##class(Ens.StringContainer).%DeleteId({body_id})\n\
+         Write \"CLEAN\""
+    );
+    let r = call(
+        "iris_execute",
+        serde_json::json!({"namespace": ns, "code": cleanup}),
+    );
+    assert_eq!(r["output"].as_str(), Some("CLEAN"), "cleanup failed: {r}");
+}

--- a/crates/iris-agentic-dev-core/tests/interop_unit_tests.rs
+++ b/crates/iris-agentic-dev-core/tests/interop_unit_tests.rs
@@ -243,6 +243,10 @@ mod interop_message_search {
                 session_id: None,
                 since_id: None,
                 limit: 20,
+                body_class: None,
+                body_where: None,
+                body_select: vec![],
+                search_table: None,
             },
         ));
         let result = r.unwrap();


### PR DESCRIPTION
Fixes #4.

## What

`what=messages` gains the two typed content filters proposed in the issue — the replacement for the 295 hand-written SQL attempts (57 `<SYNTAX>` failures) in the workshop data:

**Body-class join**
```jsonc
iris_interop_query(what="messages", body_class="Ejercicio3.MSG.MenuReq",
                   body_where="PacienteId = '4003'", body_select=["PacienteId","FechaNacimiento"])
```
The body table's SQL name is resolved from `%Dictionary.CompiledClass` (correct even under `SqlTableName` overrides, and validates the class — unknown class → `BODY_CLASS_NOT_FOUND` with the case-exact body classes present, via `%EXACT` to beat the SQLUPPER collation). The join additionally pins `h.MessageBodyClassName` — `MessageBodyId` is only unique per body table, a correctness detail the issue's hand-written example silently relied on filters for. `body_where` without `body_class` fails with the class-list hint (covering the discovery need behind the issue's grouped-join idea in two calls instead of a speculative N-way join).

**Search Table**
```jsonc
iris_interop_query(what="messages", search_table={"prop":"PatientID","value":"16284718"})
iris_interop_query(what="messages", search_table={"class":"Hospital.Search.HL7","prop":"Medication","value_like":"AMOX%"})
```
Exactly the canonical join from the issue: `DocId = MessageBodyId`, `PropId` resolved through `Ens_Config.SearchTableProp` scoped by `ClassExtent` (PropId is only unique per extent — the issue's zero-rows trap #2), and `class` resolved via `ClassDerivation = c OR LIKE 'c~%'` — never via a table name (trap #1). Extent is parameterisable (`extent`), default `EnsLib.HL7.SearchTable`; custom `Ens.CustomSearchTable` subclasses work by passing themselves as extent.

All three suggested hints are in: unknown prop → the extent's searchable `available_props` instead of an empty result; zero rows on a valid prop → the config-time indexing explanation (trap #3); missing/unknown `body_class` → real class list. Responses carry the emitted `sql` for transparency.

## Verification

- 163 unit tests green — new ones assert the emitted SQL matches the issue's canonical shapes exactly, identifier gating, and param deserialization.
- New live e2e `test_message_content_search` (fixture header+body seeded via ObjectScript, cleaned after): positive body hit returning body columns, both discovery errors, prop listing (against the 10 real `SearchTableProp` rows), and the zero-rows hint.
- clippy `-D warnings` clean; full e2e suite (7 live tests) green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)