### PR TITLE
chore(release): bump to 0.7.0 + version-consistency guard in release workflow (fixes #3)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -33,6 +33,20 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v4
+      # Provenance guard (issue #3): a release where the tag name, Cargo.toml and the
+      # binary's --version disagree must never publish. Check tag vs Cargo.toml before
+      # spending a build; the built binary is checked in "guard: binary --version" below.
+      - name: "guard: tag matches Cargo.toml version"
+        if: startsWith(github.ref, 'refs/tags/')
+        shell: bash
+        run: |
+          tag_version="${GITHUB_REF_NAME#v}"; tag_version="${tag_version%%-*}"
+          cargo_version=$(sed -n 's/^version = "\(.*\)"$/\1/p' Cargo.toml | head -1)
+          echo "tag=$GITHUB_REF_NAME → $tag_version, Cargo.toml=$cargo_version"
+          if [ "$tag_version" != "$cargo_version" ]; then
+            echo "::error::tag $GITHUB_REF_NAME declares $tag_version but Cargo.toml says $cargo_version — refusing to release"
+            exit 1
+          fi
       - uses: dtolnay/rust-toolchain@stable
         with:
           targets: ${{ matrix.target }}
@@ -47,6 +61,17 @@ jobs:
       - name: ad-hoc codesign (macOS — avoids Gatekeeper quarantine hang)
         if: runner.os == 'macOS'
         run: codesign --force --deep --sign - "${{ matrix.asset }}"
+      # All three targets are native to their runner, so the staged asset is executable here.
+      - name: "guard: binary --version matches Cargo.toml"
+        shell: bash
+        run: |
+          cargo_version=$(sed -n 's/^version = "\(.*\)"$/\1/p' Cargo.toml | head -1)
+          bin_version=$("./${{ matrix.asset }}" --version | awk '{print $NF}')
+          echo "binary=$bin_version, Cargo.toml=$cargo_version"
+          if [ "$bin_version" != "$cargo_version" ]; then
+            echo "::error::built binary reports $bin_version but Cargo.toml says $cargo_version — refusing to release"
+            exit 1
+          fi
       - uses: actions/upload-artifact@v4
         with:
           name: ${{ matrix.asset }}

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -970,7 +970,7 @@ dependencies = [
 
 [[package]]
 name = "iris-agentic-dev"
-version = "0.6.25"
+version = "0.7.0"
 dependencies = [
  "anyhow",
  "clap",
@@ -987,7 +987,7 @@ dependencies = [
 
 [[package]]
 name = "iris-agentic-dev-core"
-version = "0.6.25"
+version = "0.7.0"
 dependencies = [
  "anyhow",
  "bollard",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "0.6.25"
+version = "0.7.0"
 edition = "2021"
 authors = ["Thomas Dyar <thomas.dyar@intersystems.com>"]
 license = "MIT"

--- a/crates/iris-agentic-dev-core/tests/interop_unit_tests.rs
+++ b/crates/iris-agentic-dev-core/tests/interop_unit_tests.rs
@@ -88,11 +88,14 @@ mod production_item_codegen {
     }
 
     #[test]
-    fn codegen_escapes_single_quotes() {
-        let code = build_add_item_code("P'x", "It'm", "Cls'", true, None, None, &HashMap::new());
-        assert!(code.contains("It''m"));
-        assert!(code.contains("Cls''"));
-        assert!(code.contains("P''x"));
+    fn codegen_escapes_quotes_objectscript_style() {
+        // ObjectScript literals escape `"` by doubling; `'` needs no escaping (#6).
+        let code =
+            build_add_item_code("P\"x", "It'\"m", "Cls\"", true, None, None, &HashMap::new());
+        assert!(code.contains(r#""It'""m""#));
+        assert!(code.contains(r#""Cls""""#));
+        assert!(code.contains(r#""P""x""#));
+        assert!(!code.contains("''"));
     }
 }
 


### PR DESCRIPTION
## What

Fixes #3 (part 1 of 2 — the code side; the retag/re-release follows once this merges).

- **Bump `Cargo.toml` to `0.7.0`** so the release name, the source version and the
  binary's `--version` can finally agree. Master was `0.6.25`; the next release is cut
  as `v0.7.0-interop` from this commit.
- **Version-consistency guard in `release.yml`** — the CI check suggested in #3:
  - *pre-build*: on a tag push, the tag (`v<semver>[-suffix]`) must match the
    `Cargo.toml` workspace version, else the job fails before spending a build;
  - *post-build*: the staged (and, on macOS, signed) asset's `--version` must match
    `Cargo.toml`, else nothing is uploaded.

  Either check alone would have caught all three mismatches in the original
  `v0.7.0-interop` release.

## After merge

1. Delete the inconsistent `v0.7.0-interop` tag + release (old tag SHA recorded in #3
   for provenance).
2. Re-tag `v0.7.0-interop` at master → release workflow publishes assets that
   self-report `0.7.0`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)