### PR TITLE
fix(namespace): general tools default to the connection namespace, not USER (fixes #15)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -970,7 +970,7 @@ dependencies = [
 
 [[package]]
 name = "iris-agentic-dev"
-version = "0.7.0"
+version = "0.7.1"
 dependencies = [
  "anyhow",
  "clap",
@@ -987,7 +987,7 @@ dependencies = [
 
 [[package]]
 name = "iris-agentic-dev-core"
-version = "0.7.0"
+version = "0.7.1"
 dependencies = [
  "anyhow",
  "bollard",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "0.7.0"
+version = "0.7.1"
 edition = "2021"
 authors = ["Thomas Dyar <thomas.dyar@intersystems.com>"]
 license = "MIT"

--- a/crates/iris-agentic-dev-core/src/tools/dict.rs
+++ b/crates/iris-agentic-dev-core/src/tools/dict.rs
@@ -46,10 +46,6 @@ fn err_json(code: &str, msg: &str) -> Result<rmcp::model::CallToolResult, rmcp::
     crate::tools::envelope::fail(code, msg)
 }
 
-fn default_namespace() -> String {
-    "USER".to_string()
-}
-
 // ── Tool 1: resolve_dynamic_dispatch ─────────────────────────────────────────
 
 #[derive(Debug, Deserialize, JsonSchema)]
@@ -58,9 +54,9 @@ pub struct ResolveDynamicDispatchParams {
     pub method_name: String,
     /// Optional package prefix to restrict search (e.g. "EnsLib", "HS").
     pub package_prefix: Option<String>,
-    /// IRIS namespace. Defaults to "USER".
-    #[serde(default = "default_namespace")]
-    pub namespace: String,
+    /// IRIS namespace. Defaults to the connection namespace (IRIS_NAMESPACE).
+    #[serde(default)]
+    pub namespace: Option<String>,
     /// Max candidates to return. Defaults to 50.
     pub limit: Option<usize>,
 }
@@ -71,11 +67,12 @@ pub async fn handle_resolve_dynamic_dispatch(
     p: ResolveDynamicDispatchParams,
     cache: &MetadataCache,
 ) -> Result<rmcp::model::CallToolResult, rmcp::ErrorData> {
+    let namespace = crate::tools::interop::resolve_namespace(p.namespace.as_deref(), Some(iris));
     let prefix = p.package_prefix.as_deref().unwrap_or("");
     let limit = p.limit.unwrap_or(50);
     let cache_key = format!(
         "resolve_dynamic_dispatch:{}:{}:{}",
-        p.method_name, prefix, p.namespace
+        p.method_name, prefix, namespace
     );
     if let Some(cached) = metadata_cache_get(cache, &cache_key) {
         return ok_json(cached);
@@ -117,7 +114,7 @@ pub async fn handle_resolve_dynamic_dispatch(
     let code = lines.join("\n");
 
     let output = iris
-        .execute_via_generator(&code, &p.namespace, client)
+        .execute_via_generator(&code, &namespace, client)
         .await
         .map_err(|e| rmcp::ErrorData::internal_error(format!("execute failed: {e}"), None))?;
     let trimmed = output.trim();
@@ -142,7 +139,7 @@ pub async fn handle_resolve_dynamic_dispatch(
             c
         })
         .collect();
-    let r = serde_json::json!({"success":true,"method_name":p.method_name,"package_prefix":p.package_prefix,"namespace":p.namespace,"candidates":annotated,"candidate_count":n,"confidence":confidence,"truncated":n==limit});
+    let r = serde_json::json!({"success":true,"method_name":p.method_name,"package_prefix":p.package_prefix,"namespace":namespace,"candidates":annotated,"candidate_count":n,"confidence":confidence,"truncated":n==limit});
     metadata_cache_set(cache, cache_key, r.clone());
     ok_json(r)
 }
@@ -153,9 +150,9 @@ pub async fn handle_resolve_dynamic_dispatch(
 pub struct ExtractMessageMapParams {
     /// Fully qualified Ensemble class name (e.g. "HS.Flash.Router").
     pub class_name: String,
-    /// IRIS namespace. Defaults to "USER".
-    #[serde(default = "default_namespace")]
-    pub namespace: String,
+    /// IRIS namespace. Defaults to the connection namespace (IRIS_NAMESPACE).
+    #[serde(default)]
+    pub namespace: Option<String>,
 }
 
 fn build_message_map_code(cls: &str) -> String {
@@ -197,14 +194,15 @@ pub async fn handle_extract_message_map_routing(
     p: ExtractMessageMapParams,
     cache: &MetadataCache,
 ) -> Result<rmcp::model::CallToolResult, rmcp::ErrorData> {
-    let cache_key = format!("extract_message_map:{}:{}", p.class_name, p.namespace);
+    let namespace = crate::tools::interop::resolve_namespace(p.namespace.as_deref(), Some(iris));
+    let cache_key = format!("extract_message_map:{}:{}", p.class_name, namespace);
     if let Some(cached) = metadata_cache_get(cache, &cache_key) {
         return ok_json(cached);
     }
 
     let code = build_message_map_code(&p.class_name);
     let output = iris
-        .execute_via_generator(&code, &p.namespace, client)
+        .execute_via_generator(&code, &namespace, client)
         .await
         .map_err(|e| rmcp::ErrorData::internal_error(format!("execute failed: {e}"), None))?;
     let trimmed = output.trim();
@@ -223,7 +221,7 @@ pub async fn handle_extract_message_map_routing(
     let has_mm = inner["has_message_map"].as_bool().unwrap_or(false);
     let routes = inner["routes"].as_array().cloned().unwrap_or_default();
     let route_count = routes.len();
-    let r = serde_json::json!({"success":true,"class_name":p.class_name,"namespace":p.namespace,"has_message_map":has_mm,"routes":routes,"route_count":route_count});
+    let r = serde_json::json!({"success":true,"class_name":p.class_name,"namespace":namespace,"has_message_map":has_mm,"routes":routes,"route_count":route_count});
     metadata_cache_set(cache, cache_key, r.clone());
     ok_json(r)
 }
@@ -236,9 +234,9 @@ pub struct FindSubclassImplementationsParams {
     pub method_name: String,
     /// Base classes to expand — all descendants searched (e.g. ["Ens.BusinessProcess"]).
     pub base_classes: Vec<String>,
-    /// IRIS namespace. Defaults to "USER".
-    #[serde(default = "default_namespace")]
-    pub namespace: String,
+    /// IRIS namespace. Defaults to the connection namespace (IRIS_NAMESPACE).
+    #[serde(default)]
+    pub namespace: Option<String>,
     /// Max results. Defaults to 100.
     pub limit: Option<usize>,
 }
@@ -275,6 +273,7 @@ pub async fn handle_find_subclass_implementations(
     p: FindSubclassImplementationsParams,
     cache: &MetadataCache,
 ) -> Result<rmcp::model::CallToolResult, rmcp::ErrorData> {
+    let namespace = crate::tools::interop::resolve_namespace(p.namespace.as_deref(), Some(iris));
     if p.base_classes.is_empty() {
         return err_json("INVALID_PARAMS", "base_classes must not be empty");
     }
@@ -285,7 +284,7 @@ pub async fn handle_find_subclass_implementations(
         "find_subclass:{}:{}:{}",
         p.method_name,
         sorted.join(","),
-        p.namespace
+        namespace
     );
     if let Some(cached) = metadata_cache_get(cache, &cache_key) {
         return ok_json(cached);
@@ -294,7 +293,7 @@ pub async fn handle_find_subclass_implementations(
     let limit = p.limit.unwrap_or(100);
     let expand_code = build_expand_hierarchy_code(&p.base_classes);
     let desc_raw = iris
-        .execute_via_generator(&expand_code, &p.namespace, client)
+        .execute_via_generator(&expand_code, &namespace, client)
         .await
         .map_err(|e| {
             rmcp::ErrorData::internal_error(format!("hierarchy expansion failed: {e}"), None)
@@ -307,7 +306,7 @@ pub async fn handle_find_subclass_implementations(
         .map(|s| s.to_string())
         .collect();
     if descendants.is_empty() {
-        let r = serde_json::json!({"success":true,"method_name":p.method_name,"base_classes":p.base_classes,"namespace":p.namespace,"implementations":[],"implementation_count":0,"confidence":0.0});
+        let r = serde_json::json!({"success":true,"method_name":p.method_name,"base_classes":p.base_classes,"namespace":namespace,"implementations":[],"implementation_count":0,"confidence":0.0});
         metadata_cache_set(cache, cache_key, r.clone());
         return ok_json(r);
     }
@@ -334,7 +333,7 @@ pub async fn handle_find_subclass_implementations(
     let code = lines.join("\n");
 
     let output = iris
-        .execute_via_generator(&code, &p.namespace, client)
+        .execute_via_generator(&code, &namespace, client)
         .await
         .map_err(|e| rmcp::ErrorData::internal_error(format!("method query failed: {e}"), None))?;
     let trimmed = output.trim();
@@ -353,7 +352,7 @@ pub async fn handle_find_subclass_implementations(
             i
         })
         .collect();
-    let r = serde_json::json!({"success":true,"method_name":p.method_name,"base_classes":p.base_classes,"namespace":p.namespace,"implementations":annotated,"implementation_count":n,"confidence":confidence});
+    let r = serde_json::json!({"success":true,"method_name":p.method_name,"base_classes":p.base_classes,"namespace":namespace,"implementations":annotated,"implementation_count":n,"confidence":confidence});
     metadata_cache_set(cache, cache_key, r.clone());
     ok_json(r)
 }

--- a/crates/iris-agentic-dev-core/src/tools/doc.rs
+++ b/crates/iris-agentic-dev-core/src/tools/doc.rs
@@ -30,8 +30,8 @@ pub struct IrisDocParams {
     pub names: Vec<String>,
     /// Source content (required for mode=put)
     pub content: Option<String>,
-    #[serde(default = "default_namespace")]
-    pub namespace: String,
+    #[serde(default)]
+    pub namespace: Option<String>,
     /// Elicitation resume ID (from a prior elicitation_required response)
     pub elicitation_id: Option<String>,
     /// User's answer to the elicitation question ("yes" or "no")
@@ -49,9 +49,6 @@ pub struct IrisDocParams {
     pub offset: usize,
 }
 
-fn default_namespace() -> String {
-    "USER".to_string()
-}
 use crate::iris::connection::IrisConnection;
 
 fn ok_json(v: serde_json::Value) -> Result<rmcp::model::CallToolResult, rmcp::ErrorData> {
@@ -144,6 +141,7 @@ async fn handle_get(
     client: &reqwest::Client,
     p: IrisDocParams,
 ) -> Result<rmcp::model::CallToolResult, rmcp::ErrorData> {
+    let namespace = crate::tools::interop::resolve_namespace(p.namespace.as_deref(), Some(iris));
     // Batch get — Bug 19: fetch concurrently instead of sequentially.
     if !p.names.is_empty() {
         // Build a fresh client for batch gets with a shorter timeout so concurrent
@@ -160,7 +158,7 @@ async fn handle_get(
         let mut set = tokio::task::JoinSet::new();
         for name in &p.names {
             let url =
-                iris.versioned_ns_url(&p.namespace, &format!("/doc/{}", urlencoding::encode(name)));
+                iris.versioned_ns_url(&namespace, &format!("/doc/{}", urlencoding::encode(name)));
             let username = iris.username.clone();
             let password = iris.password.clone();
             let name = name.clone();
@@ -198,7 +196,7 @@ async fn handle_get(
     }
 
     let name = p.name.as_deref().unwrap_or("");
-    let url = iris.versioned_ns_url(&p.namespace, &format!("/doc/{}", urlencoding::encode(name)));
+    let url = iris.versioned_ns_url(&namespace, &format!("/doc/{}", urlencoding::encode(name)));
     let resp = client
         .get(&url)
         .basic_auth(&iris.username, Some(&iris.password))
@@ -255,7 +253,8 @@ async fn handle_put(
     elicitation_store: &crate::elicitation::ElicitationStore,
 ) -> Result<rmcp::model::CallToolResult, rmcp::ErrorData> {
     let name = p.name.as_deref().unwrap_or("");
-    let ns = &p.namespace;
+    let namespace = crate::tools::interop::resolve_namespace(p.namespace.as_deref(), Some(iris));
+    let ns = &namespace;
 
     // Elicitation resume — user answered a prior SCM dialog
     if let (Some(eid), Some(answer)) = (&p.elicitation_id, &p.elicitation_answer) {
@@ -516,13 +515,14 @@ async fn handle_delete(
     client: &reqwest::Client,
     p: IrisDocParams,
 ) -> Result<rmcp::model::CallToolResult, rmcp::ErrorData> {
+    let namespace = crate::tools::interop::resolve_namespace(p.namespace.as_deref(), Some(iris));
     // Batch delete
     if !p.names.is_empty() {
         let mut deleted = vec![];
         let mut errors = vec![];
         for name in &p.names {
             let url =
-                iris.versioned_ns_url(&p.namespace, &format!("/doc/{}", urlencoding::encode(name)));
+                iris.versioned_ns_url(&namespace, &format!("/doc/{}", urlencoding::encode(name)));
             match client
                 .delete(&url)
                 .basic_auth(&iris.username, Some(&iris.password))
@@ -542,7 +542,7 @@ async fn handle_delete(
     }
 
     let name = p.name.as_deref().unwrap_or("");
-    let url = iris.versioned_ns_url(&p.namespace, &format!("/doc/{}", urlencoding::encode(name)));
+    let url = iris.versioned_ns_url(&namespace, &format!("/doc/{}", urlencoding::encode(name)));
     let resp = client
         .delete(&url)
         .basic_auth(&iris.username, Some(&iris.password))
@@ -564,8 +564,9 @@ async fn handle_head(
     client: &reqwest::Client,
     p: IrisDocParams,
 ) -> Result<rmcp::model::CallToolResult, rmcp::ErrorData> {
+    let namespace = crate::tools::interop::resolve_namespace(p.namespace.as_deref(), Some(iris));
     let name = p.name.as_deref().unwrap_or("");
-    let url = iris.versioned_ns_url(&p.namespace, &format!("/doc/{}", urlencoding::encode(name)));
+    let url = iris.versioned_ns_url(&namespace, &format!("/doc/{}", urlencoding::encode(name)));
     let resp = client
         .head(&url)
         .basic_auth(&iris.username, Some(&iris.password))

--- a/crates/iris-agentic-dev-core/src/tools/info.rs
+++ b/crates/iris-agentic-dev-core/src/tools/info.rs
@@ -17,9 +17,6 @@ fn ok_json(v: serde_json::Value) -> Result<rmcp::model::CallToolResult, rmcp::Er
 fn err_json(code: &str, msg: &str) -> Result<rmcp::model::CallToolResult, rmcp::ErrorData> {
     crate::tools::envelope::fail(code, msg)
 }
-fn default_namespace() -> String {
-    "USER".to_string()
-}
 fn default_limit() -> usize {
     20
 }
@@ -34,8 +31,8 @@ pub struct InfoParams {
     pub doc_type: Option<String>,
     /// Schema/cube name for what=sa_schema
     pub name: Option<String>,
-    #[serde(default = "default_namespace")]
-    pub namespace: String,
+    #[serde(default)]
+    pub namespace: Option<String>,
     /// If true, bypass the log store and return all results inline regardless of count.
     #[serde(default)]
     pub inline: bool,
@@ -47,7 +44,8 @@ pub async fn handle_iris_info(
     p: InfoParams,
     log_store: Arc<Mutex<log_store::LogStore>>,
 ) -> Result<rmcp::model::CallToolResult, rmcp::ErrorData> {
-    let ns = &p.namespace;
+    let namespace = crate::tools::interop::resolve_namespace(p.namespace.as_deref(), Some(iris));
+    let ns = &namespace;
     let url = match p.what.as_str() {
         "documents" => {
             // Bug 14: use versioned_ns_url so future API versions are used automatically.
@@ -85,7 +83,7 @@ pub async fn handle_iris_info(
     }
 
     let body: serde_json::Value = resp.json().await.unwrap_or_default();
-    let mut result_json = serde_json::json!({"success": true, "what": p.what, "namespace": p.namespace, "result": body["result"]});
+    let mut result_json = serde_json::json!({"success": true, "what": p.what, "namespace": namespace, "result": body["result"]});
 
     // Progressive disclosure (027): for what=documents, truncate the document list.
     // The document names are in result["content"] — flatten to a top-level "documents" key.
@@ -116,8 +114,8 @@ pub struct MacroParams {
     pub name: Option<String>,
     #[serde(default)]
     pub args: Vec<String>,
-    #[serde(default = "default_namespace")]
-    pub namespace: String,
+    #[serde(default)]
+    pub namespace: Option<String>,
 }
 
 pub async fn handle_iris_macro(
@@ -125,10 +123,11 @@ pub async fn handle_iris_macro(
     client: &reqwest::Client,
     p: MacroParams,
 ) -> Result<rmcp::model::CallToolResult, rmcp::ErrorData> {
+    let namespace = crate::tools::interop::resolve_namespace(p.namespace.as_deref(), Some(iris));
     match p.action.as_str() {
         "list" => {
             // Bug 14: use versioned_ns_url instead of hardcoded /v1/.
-            let url = iris.versioned_ns_url(&p.namespace, "/docnames/INC");
+            let url = iris.versioned_ns_url(&namespace, "/docnames/INC");
             let resp = client
                 .get(&url)
                 .basic_auth(&iris.username, Some(&iris.password))
@@ -157,7 +156,7 @@ pub async fn handle_iris_macro(
         }
         action @ ("signature" | "location" | "definition" | "expand") => {
             let name = p.name.as_deref().unwrap_or("");
-            let url = iris.versioned_ns_url(&p.namespace, "/action/getmacro");
+            let url = iris.versioned_ns_url(&namespace, "/action/getmacro");
             let arg_count = p.args.len();
             let resp = client
                 .post(&url)
@@ -197,8 +196,8 @@ pub struct DebugParams {
     pub class_name: Option<String>,
     #[serde(default = "default_limit")]
     pub limit: usize,
-    #[serde(default = "default_namespace")]
-    pub namespace: String,
+    #[serde(default)]
+    pub namespace: Option<String>,
 }
 
 pub async fn handle_iris_debug(
@@ -206,7 +205,8 @@ pub async fn handle_iris_debug(
     _client: &reqwest::Client,
     p: DebugParams,
 ) -> Result<rmcp::model::CallToolResult, rmcp::ErrorData> {
-    let _query_url = iris.versioned_ns_url(&p.namespace, "/action/query");
+    let namespace = crate::tools::interop::resolve_namespace(p.namespace.as_deref(), Some(iris));
+    let _query_url = iris.versioned_ns_url(&namespace, "/action/query");
 
     match p.action.as_str() {
         "map_int" => {
@@ -215,7 +215,7 @@ pub async fn handle_iris_debug(
                 "set err=\"{}\" set routine=$piece($piece(err,\"^\",2),\".\",1) set offset=$piece(err,\"+\",2) set offset=$piece(offset,\"^\",1) write ##class(%Studio.Debugger).SourceLine(routine,+offset)",
                 err.replace('"', "\\\"")
             );
-            match iris.execute(&code, &p.namespace).await {
+            match iris.execute(&code, &namespace).await {
                 Ok(output) => ok_json(
                     serde_json::json!({"success": true, "error_string": err, "source_location": output.trim()}),
                 ),
@@ -238,7 +238,7 @@ pub async fn handle_iris_debug(
         }
         "capture" => {
             let code = "set err=$ZERROR write \"error:\"_err,! set loc=$ZPOSITION write \"position:\"_loc,!";
-            match iris.execute(code, &p.namespace).await {
+            match iris.execute(code, &namespace).await {
                 Ok(output) => {
                     ok_json(serde_json::json!({"success": true, "capture": output.trim()}))
                 }
@@ -255,7 +255,7 @@ pub async fn handle_iris_debug(
                 "set map=\"\" set line=1 do {{set int=##class(%Studio.Debugger).MapToINT({cls},line,.intline) if int=\"\" quit set map=map_line_\"->\"_intline_\",\" set line=line+1 }} while 1 write map",
                 cls = crate::objectscript::os_str_expr(cls)
             );
-            match iris.execute(&code, &p.namespace).await {
+            match iris.execute(&code, &namespace).await {
                 Ok(output) => ok_json(
                     serde_json::json!({"success": true, "class": cls, "mapping": output.trim()}),
                 ),
@@ -291,8 +291,8 @@ pub struct GenerateParams {
     pub gen_type: String,
     /// Existing class name to generate tests for (gen_type=test only)
     pub class_name: Option<String>,
-    #[serde(default = "default_namespace")]
-    pub namespace: String,
+    #[serde(default)]
+    pub namespace: Option<String>,
 }
 
 fn default_type() -> String {
@@ -304,7 +304,8 @@ pub async fn handle_iris_generate(
     client: &reqwest::Client,
     p: GenerateParams,
 ) -> Result<rmcp::model::CallToolResult, rmcp::ErrorData> {
-    let ns = &p.namespace;
+    let namespace = crate::tools::interop::resolve_namespace(p.namespace.as_deref(), Some(iris));
+    let ns = &namespace;
     let query_url = iris.versioned_ns_url(ns, "/action/query");
 
     match p.gen_type.as_str() {
@@ -412,9 +413,9 @@ pub async fn handle_iris_generate(
 pub struct TableInfoParams {
     /// SQL table name in Schema.Table format (e.g. "SQLUser.MyTable" or "MyApp.Orders").
     pub table: String,
-    /// IRIS namespace to query. Defaults to "USER".
-    #[serde(default = "crate::tools::default_namespace")]
-    pub namespace: String,
+    /// IRIS namespace to query. Defaults to the connection namespace (IRIS_NAMESPACE).
+    #[serde(default)]
+    pub namespace: Option<String>,
     /// Include approximate row count (runs SELECT COUNT(*) — may be slow on large tables).
     #[serde(default)]
     pub include_row_count: bool,
@@ -425,6 +426,7 @@ pub async fn handle_iris_table_info(
     client: &reqwest::Client,
     p: TableInfoParams,
 ) -> Result<rmcp::model::CallToolResult, rmcp::ErrorData> {
+    let namespace = crate::tools::interop::resolve_namespace(p.namespace.as_deref(), Some(iris));
     // Split "Schema.Table" → (schema, table). Tables with no dot use SQLUser schema.
     let (sql_schema, sql_table) = match p.table.find('.') {
         Some(idx) => (p.table[..idx].to_string(), p.table[idx + 1..].to_string()),
@@ -455,7 +457,7 @@ if rs.%Next() {{
     );
 
     let output = iris
-        .execute_via_generator(&lookup_code, &p.namespace, client)
+        .execute_via_generator(&lookup_code, &namespace, client)
         .await
         .map_err(|e| rmcp::ErrorData::internal_error(format!("execute failed: {e}"), None))?;
 
@@ -465,11 +467,8 @@ if rs.%Next() {{
     if output.trim() == "NOT_FOUND" {
         return crate::tools::envelope::fail_with(
             "TABLE_NOT_FOUND",
-            &format!(
-                "Table '{}' not found in namespace '{}'",
-                p.table, p.namespace
-            ),
-            serde_json::json!({"table": p.table, "namespace": p.namespace}),
+            &format!("Table '{}' not found in namespace '{}'", p.table, namespace),
+            serde_json::json!({"table": p.table, "namespace": namespace}),
         );
     }
 
@@ -483,14 +482,14 @@ if rs.%Next() {{
             "table": p.table,
             "type": "class_projection",
             "class": class_name,
-            "namespace": p.namespace,
+            "namespace": namespace,
             "data_global": if data_global.is_empty() { serde_json::Value::Null } else { data_global.into() },
             "index_global": if index_global.is_empty() { serde_json::Value::Null } else { index_global.into() },
             "accessible_from_embedded_python": true,
         });
 
         if p.include_row_count {
-            let count = get_row_count(iris, client, &p.namespace, &sql_schema, &sql_table).await;
+            let count = get_row_count(iris, client, &namespace, &sql_schema, &sql_table).await;
             obj["row_count"] = count;
         }
         obj
@@ -503,7 +502,7 @@ if rs.%Next() {{
         let mut obj = serde_json::json!({
             "table": p.table,
             "type": "ddl_table",
-            "namespace": p.namespace,
+            "namespace": namespace,
             "data_global": data_global,
             "index_global": index_global,
             "id_counter_global": id_counter_global,
@@ -511,7 +510,7 @@ if rs.%Next() {{
         });
 
         if p.include_row_count {
-            let count = get_row_count(iris, client, &p.namespace, &sql_schema, &sql_table).await;
+            let count = get_row_count(iris, client, &namespace, &sql_schema, &sql_table).await;
             obj["row_count"] = count;
         }
         obj

--- a/crates/iris-agentic-dev-core/src/tools/mod.rs
+++ b/crates/iris-agentic-dev-core/src/tools/mod.rs
@@ -689,8 +689,8 @@ pub struct CompileParams {
     pub target: String,
     #[serde(default = "default_flags")]
     pub flags: String,
-    #[serde(default = "default_namespace")]
-    pub namespace: String,
+    #[serde(default)]
+    pub namespace: Option<String>,
     #[serde(default)]
     pub force_writable: bool,
     /// If true, bypass the log store and return all errors/warnings inline regardless of count.
@@ -700,8 +700,8 @@ pub struct CompileParams {
 #[derive(Debug, Deserialize, JsonSchema)]
 pub struct TestParams {
     pub pattern: String,
-    #[serde(default = "default_namespace")]
-    pub namespace: String,
+    #[serde(default)]
+    pub namespace: Option<String>,
     #[serde(default = "default_test_timeout")]
     pub timeout: u64,
 }
@@ -714,14 +714,14 @@ pub struct SymbolsParams {
     pub query: String,
     #[serde(default = "default_limit")]
     pub limit: usize,
-    #[serde(default = "default_namespace")]
-    pub namespace: String,
+    #[serde(default)]
+    pub namespace: Option<String>,
 }
 #[derive(Debug, Deserialize, JsonSchema)]
 pub struct IntrospectParams {
     pub class_name: String,
-    #[serde(default = "default_namespace")]
-    pub namespace: String,
+    #[serde(default)]
+    pub namespace: Option<String>,
 }
 #[derive(Debug, Deserialize, JsonSchema)]
 pub struct DebugMapParams {
@@ -731,22 +731,22 @@ pub struct DebugMapParams {
     pub offset: i64,
     #[serde(default)]
     pub error_string: String,
-    #[serde(default = "default_namespace")]
-    pub namespace: String,
+    #[serde(default)]
+    pub namespace: Option<String>,
 }
 #[derive(Debug, Deserialize, JsonSchema)]
 pub struct GenerateClassParams {
     pub description: String,
     #[serde(default)]
     pub overwrite: bool,
-    #[serde(default = "default_namespace")]
-    pub namespace: String,
+    #[serde(default)]
+    pub namespace: Option<String>,
 }
 #[derive(Debug, Deserialize, JsonSchema)]
 pub struct GenerateTestParams {
     pub class_name: String,
-    #[serde(default = "default_namespace")]
-    pub namespace: String,
+    #[serde(default)]
+    pub namespace: Option<String>,
 }
 #[derive(Debug, Deserialize, JsonSchema)]
 pub struct SkillNameParams {
@@ -785,13 +785,13 @@ fn default_symbols_local_limit() -> usize {
 }
 #[derive(Debug, Deserialize, JsonSchema)]
 pub struct CapturePacketParams {
-    #[serde(default = "default_namespace")]
-    pub namespace: String,
+    #[serde(default)]
+    pub namespace: Option<String>,
 }
 #[derive(Debug, Deserialize, JsonSchema)]
 pub struct ErrorLogsParams {
-    #[serde(default = "default_namespace")]
-    pub namespace: String,
+    #[serde(default)]
+    pub namespace: Option<String>,
     #[serde(default = "default_max_entries")]
     pub max_entries: usize,
     /// If true, bypass the log store and return all entries inline regardless of count.
@@ -824,14 +824,14 @@ pub struct SourceMapParams {
     #[serde(default)]
     pub cls_text: Option<String>,
     pub workspace_path: Option<String>,
-    #[serde(default = "default_namespace")]
-    pub namespace: String,
+    #[serde(default)]
+    pub namespace: Option<String>,
 }
 #[derive(Debug, Deserialize, JsonSchema)]
 pub struct ExecuteParams {
     pub code: String,
-    #[serde(default = "default_namespace")]
-    pub namespace: String,
+    #[serde(default)]
+    pub namespace: Option<String>,
     #[serde(default = "default_execute_timeout")]
     pub timeout: u64,
     #[serde(default)]
@@ -850,8 +850,8 @@ pub struct QueryParams {
     /// Query parameters as strings (e.g. ["Alice", "42"])
     #[serde(default)]
     pub parameters: Vec<String>,
-    #[serde(default = "default_namespace")]
-    pub namespace: String,
+    #[serde(default)]
+    pub namespace: Option<String>,
     /// If true, bypass SQL safety validation. Use only for intentional administrative queries.
     /// Has no effect on production IRIS instances (where write tools are disabled).
     #[serde(default)]
@@ -864,8 +864,8 @@ pub struct ListContainersParams {
 #[derive(Debug, Deserialize, JsonSchema)]
 pub struct SelectContainerParams {
     pub name: String,
-    #[serde(default = "default_namespace")]
-    pub namespace: String,
+    #[serde(default)]
+    pub namespace: Option<String>,
     #[serde(default = "default_username")]
     pub username: String,
     #[serde(default = "default_password")]
@@ -881,9 +881,6 @@ pub struct StartSandboxParams {
 
 fn default_flags() -> String {
     "cuk".to_string()
-}
-fn default_namespace() -> String {
-    "USER".to_string()
 }
 fn default_limit() -> usize {
     20
@@ -1844,7 +1841,8 @@ impl IrisTools {
         Parameters(p): Parameters<CompileParams>,
     ) -> Result<CallToolResult, McpError> {
         let iris = self.get_iris_reloaded().await?;
-        tracing::info!(namespace = %p.namespace, target = %p.target, "iris_compile");
+        let namespace = interop::resolve_namespace(p.namespace.as_deref(), Some(&iris));
+        tracing::info!(namespace = %namespace, target = %p.target, "iris_compile");
         let client = self.http_client();
 
         // Local file path support: if target looks like a file path (contains / or \,
@@ -1878,7 +1876,7 @@ impl IrisTools {
                     });
                 // Upload via Atelier PUT
                 let put_url = iris.versioned_ns_url(
-                    &p.namespace,
+                    &namespace,
                     &format!("/doc/{}?ignoreConflict=1", urlencoding::encode(&doc_name)),
                 );
                 let lines: Vec<&str> = content.lines().collect();
@@ -1909,7 +1907,7 @@ impl IrisTools {
                 // Compile via shared compile_document helper
                 let local_src = p.target.clone();
                 let cr = iris
-                    .compile_document(&doc_name, &p.namespace, &p.flags, client)
+                    .compile_document(&doc_name, &namespace, &p.flags, client)
                     .await
                     .map_err(|e| McpError::internal_error(e.to_string(), None))?;
                 let errors: Vec<serde_json::Value> = cr
@@ -1929,7 +1927,7 @@ impl IrisTools {
                     "target": doc_name,
                     "uploaded_from": local_src,
                     "targets_compiled": 1,
-                    "namespace": p.namespace,
+                    "namespace": namespace,
                     "errors": errors,
                     "warnings": [],
                     "console": console,
@@ -1938,9 +1936,9 @@ impl IrisTools {
         }
 
         // Expand wildcards: resolve "MyApp.*.cls" to a list of matching class names.
-        // Bug 8: use p.namespace (not iris.namespace) and the correct /docnames/CLS endpoint.
+        // Bug 8: use namespace (not iris.namespace) and the correct /docnames/CLS endpoint.
         let targets: Vec<String> = if p.target.contains('*') {
-            let list_url = iris.versioned_ns_url(&p.namespace, "/docnames/CLS");
+            let list_url = iris.versioned_ns_url(&namespace, "/docnames/CLS");
             match client
                 .get(&list_url)
                 .basic_auth(&iris.username, Some(&iris.password))
@@ -1979,15 +1977,15 @@ impl IrisTools {
         if p.force_writable {
             let code = format!(
                 "do ##class(%Library.EnsembleMgr).EnableNamespace(\"{}\",1)",
-                p.namespace
+                namespace
             );
-            let _ = iris.execute(&code, &p.namespace).await;
+            let _ = iris.execute(&code, &namespace).await;
         }
 
         // Atelier compile: POST with JSON array of document names (with extensions)
         // e.g. ["MyApp.Patient.cls", "MyApp.Utils.cls"]
         let compile_url = iris.versioned_ns_url(
-            &p.namespace,
+            &namespace,
             &format!("/action/compile?flags={}", urlencoding::encode(&p.flags)),
         );
 
@@ -2107,8 +2105,8 @@ impl IrisTools {
 
         // Write open hint for single non-wildcard successful compile
         let open_uri = if success && !p.target.contains('*') && targets.len() == 1 {
-            write_open_hint(&p.namespace, &p.target);
-            Some(format!("isfs://{}/{}", p.namespace, p.target))
+            write_open_hint(&namespace, &p.target);
+            Some(format!("isfs://{}/{}", namespace, p.target))
         } else {
             None
         };
@@ -2117,7 +2115,7 @@ impl IrisTools {
             "success": success,
             "target": p.target,
             "targets_compiled": targets.len(),
-            "namespace": p.namespace,
+            "namespace": namespace,
             "errors": errors,
             "warnings": warnings,
             "console": console,
@@ -2156,7 +2154,7 @@ impl IrisTools {
         &self,
         Parameters(p): Parameters<TestParams>,
     ) -> Result<CallToolResult, McpError> {
-        tracing::info!(namespace = %p.namespace, pattern = %p.pattern, "iris_test");
+        tracing::info!(requested_namespace = ?p.namespace, pattern = %p.pattern, "iris_test");
         let timeout = std::time::Duration::from_secs(p.timeout);
 
         // HTTP path only — docker exec path removed (#46: /noload/run assumed pre-loaded
@@ -2166,12 +2164,13 @@ impl IrisTools {
         // present and docker-exec succeeds, else "http" (Atelier REST). Set below.
         let mut path_label = "http";
         let iris = self.get_iris()?;
+        let namespace = interop::resolve_namespace(p.namespace.as_deref(), Some(&iris));
         let client = self.http_client();
 
         // US3: namespace existence check before running tests.
         let ns_check_code = format!(
             "write ##class(%SYS.Namespace).Exists(\"{}\")",
-            p.namespace.replace('"', "\\\"")
+            namespace.replace('"', "\\\"")
         );
         let ns_exists = tokio::time::timeout(
             std::time::Duration::from_secs(10),
@@ -2189,9 +2188,9 @@ impl IrisTools {
                 ERR_NAMESPACE_NOT_FOUND,
                 &format!(
                     "Namespace '{}' does not exist on this IRIS instance",
-                    p.namespace
+                    namespace
                 ),
-                serde_json::json!({"namespace": p.namespace}),
+                serde_json::json!({"namespace": namespace}),
             );
         }
 
@@ -2260,7 +2259,7 @@ do ##class(%UnitTest.Manager).RunTest("{pattern}","{flags}","{token}")"#,
             iris.query(
                 "SELECT MAX(ID) AS m FROM %UnitTest_Result.TestInstance",
                 vec![],
-                &p.namespace,
+                &namespace,
                 client,
             ),
         )
@@ -2289,7 +2288,7 @@ do ##class(%UnitTest.Manager).RunTest("{pattern}","{flags}","{token}")"#,
 
         let run_output = if has_container {
             // Docker exec: full filesystem access, captures terminal output from RunTest
-            match tokio::time::timeout(timeout, iris.execute(&run_code, &p.namespace)).await {
+            match tokio::time::timeout(timeout, iris.execute(&run_code, &namespace)).await {
                 Err(_) => {
                     self.record_call("iris_test", false);
                     return envelope::fail(
@@ -2301,7 +2300,7 @@ do ##class(%UnitTest.Manager).RunTest("{pattern}","{flags}","{token}")"#,
                     // Docker exec unavailable — fall through to HTTP
                     match tokio::time::timeout(
                         timeout,
-                        iris.execute_via_generator(&run_code, &p.namespace, client),
+                        iris.execute_via_generator(&run_code, &namespace, client),
                     )
                     .await
                     {
@@ -2324,7 +2323,7 @@ do ##class(%UnitTest.Manager).RunTest("{pattern}","{flags}","{token}")"#,
             // HTTP path: works for remote IRIS without docker
             match tokio::time::timeout(
                 timeout,
-                iris.execute_via_generator(&run_code, &p.namespace, client),
+                iris.execute_via_generator(&run_code, &namespace, client),
             )
             .await
             {
@@ -2374,7 +2373,7 @@ do ##class(%UnitTest.Manager).RunTest("{pattern}","{flags}","{token}")"#,
             );
             if let Ok(Ok(body)) = tokio::time::timeout(
                 std::time::Duration::from_secs(10),
-                iris.query(&read_sql, vec![], &p.namespace, client),
+                iris.query(&read_sql, vec![], &namespace, client),
             )
             .await
             {
@@ -2535,7 +2534,7 @@ do ##class(%UnitTest.Manager).RunTest("{pattern}","{flags}","{token}")"#,
             let probe_sql = "SELECT TOP 25 Name FROM %Dictionary.CompiledClass WHERE PrimarySuper LIKE '%UnitTest.TestCase%' AND Name NOT LIKE 'EnsLib.%' AND Name NOT LIKE 'HS.%' AND Name NOT LIKE 'Ens.%' AND Name NOT LIKE '\\%%' ESCAPE '\\' ORDER BY Name";
             let candidates: Vec<String> = match tokio::time::timeout(
                 std::time::Duration::from_secs(10),
-                iris.query(probe_sql, vec![], &p.namespace, client),
+                iris.query(probe_sql, vec![], &namespace, client),
             )
             .await
             {
@@ -2552,9 +2551,9 @@ do ##class(%UnitTest.Manager).RunTest("{pattern}","{flags}","{token}")"#,
                 _ => vec![],
             };
             let hint = if candidates.is_empty() {
-                format!("No compiled %UnitTest.TestCase classes were found in namespace '{}'. Your test class must Extend %UnitTest.TestCase and be compiled. Compile it first (iris_compile), or pass a directory path to load .cls from disk.", p.namespace)
+                format!("No compiled %UnitTest.TestCase classes were found in namespace '{}'. Your test class must Extend %UnitTest.TestCase and be compiled. Compile it first (iris_compile), or pass a directory path to load .cls from disk.", namespace)
             } else {
-                format!("Pattern '{}' matched no runnable tests, but {} compiled %UnitTest.TestCase class(es) exist in '{}': {}. Pass one of these as the pattern (class names use /noload automatically), or a directory path to load from disk.", p.pattern, candidates.len(), p.namespace, candidates.join(", "))
+                format!("Pattern '{}' matched no runnable tests, but {} compiled %UnitTest.TestCase class(es) exist in '{}': {}. Pass one of these as the pattern (class names use /noload automatically), or a directory path to load from disk.", p.pattern, candidates.len(), namespace, candidates.join(", "))
             };
             // Issue #2: NO_TESTS_FOUND is a genuine tool failure (nothing ran),
             // unlike a red run below, which is a valid result and stays non-error.
@@ -2565,7 +2564,7 @@ do ##class(%UnitTest.Manager).RunTest("{pattern}","{flags}","{token}")"#,
                     "hint": hint,
                     "candidates": candidates,
                     "pattern": p.pattern,
-                    "namespace": p.namespace,
+                    "namespace": namespace,
                     "total": 0,
                     "passed": 0,
                     "failed": 0,
@@ -2636,20 +2635,21 @@ do ##class(%UnitTest.Manager).RunTest("{pattern}","{flags}","{token}")"#,
             "path": path_label,
             "log_id": log_id,
             "pattern": p.pattern,
-            "namespace": p.namespace,
+            "namespace": namespace,
             "test_suites": test_suites,
         }))
     }
 
     #[tool(
-        description = "Execute arbitrary ObjectScript code on IRIS and return stdout. Uses pure-HTTP execution via CodeMode=objectgenerator (write temp class, compile, query result, delete). Falls back to docker exec if IRIS_CONTAINER env var is set and HTTP fails. &sql(...) embedded SQL macros are automatically translated to %SQL.Statement calls (set translate_sql: false to disable). When translation fires, response includes sql_translated: true and translated_code. Example: code='write $ZVERSION,!' returns the IRIS version string. Use this for side-effecting ObjectScript only — for SELECTs use iris_query, for class/table introspection use docs_introspect/iris_symbols/iris_table_info, for production state use iris_production/iris_interop_query, and to create+compile a class use iris_doc(put,compile) over Atelier (never $SYSTEM.OBJ.Load from a file path — that needs IRIS to share this host's disk). When the code matches one of those, the response includes a `hint` naming the typed tool."
+        description = "Execute arbitrary ObjectScript code on IRIS and return stdout. Uses pure-HTTP execution via CodeMode=objectgenerator (write temp class, compile, query result, delete). Falls back to docker exec if IRIS_CONTAINER env var is set and HTTP fails. &sql(...) embedded SQL macros are automatically translated to %SQL.Statement calls (set translate_sql: false to disable). When translation fires, response includes sql_translated: true and translated_code. Example: code='write $ZVERSION,!' returns the IRIS version string. Use this for side-effecting ObjectScript only — for SELECTs use iris_query, for class/table introspection use docs_introspect/iris_symbols/iris_table_info, for production state use iris_production/iris_interop_query, and to create+compile a class use iris_doc(put,compile) over Atelier (never $SYSTEM.OBJ.Load from a file path — that needs IRIS to share this host's disk). When the code matches one of those, the response includes a `hint` naming the typed tool. namespace: optional — defaults to the connection namespace (IRIS_NAMESPACE), never a hardcoded USER; the response echoes the namespace it ran in."
     )]
     async fn iris_execute(
         &self,
         Parameters(p): Parameters<ExecuteParams>,
     ) -> Result<CallToolResult, McpError> {
         let iris = self.get_iris_reloaded().await?;
-        tracing::info!(namespace = %p.namespace, translate_sql = p.translate_sql, "iris_execute");
+        let namespace = interop::resolve_namespace(p.namespace.as_deref(), Some(&iris));
+        tracing::info!(namespace = %namespace, translate_sql = p.translate_sql, "iris_execute");
         let client = self.http_client();
         let timeout = std::time::Duration::from_secs(p.timeout);
 
@@ -2674,7 +2674,7 @@ do ##class(%UnitTest.Manager).RunTest("{pattern}","{flags}","{token}")"#,
         // Try pure-HTTP execution first (write-compile-query via CodeMode=objectgenerator).
         let gen_result = tokio::time::timeout(
             timeout,
-            iris.execute_via_generator(code_to_run, &p.namespace, client),
+            iris.execute_via_generator(code_to_run, &namespace, client),
         )
         .await;
 
@@ -2695,7 +2695,7 @@ do ##class(%UnitTest.Manager).RunTest("{pattern}","{flags}","{token}")"#,
                 let mut resp = serde_json::json!({
                     "success": !is_runtime_error,
                     "output": trimmed,
-                    "namespace": p.namespace,
+                    "namespace": namespace,
                     "method": "http",
                 });
                 if is_runtime_error {
@@ -2748,7 +2748,7 @@ do ##class(%UnitTest.Manager).RunTest("{pattern}","{flags}","{token}")"#,
 
         // Fallback: docker exec (requires IRIS_CONTAINER env var).
         let docker_result =
-            tokio::time::timeout(timeout, iris.execute(code_to_run, &p.namespace)).await;
+            tokio::time::timeout(timeout, iris.execute(code_to_run, &namespace)).await;
         match docker_result {
             Err(_) => {
                 self.record_call("iris_execute", false);
@@ -2777,7 +2777,7 @@ do ##class(%UnitTest.Manager).RunTest("{pattern}","{flags}","{token}")"#,
                 let mut resp = serde_json::json!({
                     "success": !is_runtime_error,
                     "output": trimmed,
-                    "namespace": p.namespace,
+                    "namespace": namespace,
                     "method": "docker",
                 });
                 if is_runtime_error {
@@ -2819,7 +2819,8 @@ do ##class(%UnitTest.Manager).RunTest("{pattern}","{flags}","{token}")"#,
         Parameters(p): Parameters<IrisDocParams>,
     ) -> Result<CallToolResult, McpError> {
         let iris = self.get_iris_reloaded().await?;
-        tracing::info!(namespace = %p.namespace, "iris_doc");
+        let namespace = interop::resolve_namespace(p.namespace.as_deref(), Some(&iris));
+        tracing::info!(namespace = %namespace, "iris_doc");
         let client = self.http_client();
         let result = doc::handle_iris_doc(&iris, client, p, &self.elicitation_store).await;
         self.record_call("iris_doc", Self::call_ok(&result));
@@ -2827,13 +2828,13 @@ do ##class(%UnitTest.Manager).RunTest("{pattern}","{flags}","{token}")"#,
     }
 
     #[tool(
-        description = "Execute a SQL SELECT query on IRIS via Atelier REST. Returns rows as a JSON array with column names as keys. By default, destructive SQL (DROP, DELETE, INSERT, UPDATE, ALTER, CREATE, MERGE, TRUNCATE, EXEC, EXECUTE, BULK, LOAD, KILL, LOCK, SELECT INTO) is blocked before reaching IRIS. Set force: true to bypass validation for intentional administrative queries — has no effect on production instances where write tools are disabled. For table/column discovery call iris_table_info first instead of guessing system tables; ObjectScript (set/write/do/##class/&sql/^globals) must use iris_execute, not iris_query. No Python required."
+        description = "Execute a SQL SELECT query on IRIS via Atelier REST. Returns rows as a JSON array with column names as keys. By default, destructive SQL (DROP, DELETE, INSERT, UPDATE, ALTER, CREATE, MERGE, TRUNCATE, EXEC, EXECUTE, BULK, LOAD, KILL, LOCK, SELECT INTO) is blocked before reaching IRIS. Set force: true to bypass validation for intentional administrative queries — has no effect on production instances where write tools are disabled. For table/column discovery call iris_table_info first instead of guessing system tables; ObjectScript (set/write/do/##class/&sql/^globals) must use iris_execute, not iris_query. No Python required. namespace: optional — defaults to the connection namespace (IRIS_NAMESPACE), never a hardcoded USER; the response echoes the namespace it ran in."
     )]
     async fn iris_query(
         &self,
         Parameters(p): Parameters<QueryParams>,
     ) -> Result<CallToolResult, McpError> {
-        tracing::info!(namespace = %p.namespace, force = p.force, "iris_query");
+        tracing::info!(requested_namespace = ?p.namespace, force = p.force, "iris_query");
 
         // Pre-flight: ObjectScript typed into a SQL tool — fail fast with a clear redirect
         // (28/447 workshop iris_query calls were ObjectScript, not SQL).
@@ -2875,8 +2876,9 @@ do ##class(%UnitTest.Manager).RunTest("{pattern}","{flags}","{token}")"#,
         }
 
         let iris = self.get_iris_reloaded().await?;
+        let namespace = interop::resolve_namespace(p.namespace.as_deref(), Some(&iris));
         let client = self.http_client();
-        let query_url = iris.versioned_ns_url(&p.namespace, "/action/query");
+        let query_url = iris.versioned_ns_url(&namespace, "/action/query");
         let resp = client
             .post(&query_url)
             .basic_auth(&iris.username, Some(&iris.password))
@@ -2928,7 +2930,7 @@ do ##class(%UnitTest.Manager).RunTest("{pattern}","{flags}","{token}")"#,
             .unwrap_or_default();
         let count = rows.len();
         self.record_call("iris_query", true);
-        let mut resp = serde_json::json!({"success": true, "rows": rows, "count": count, "namespace": p.namespace});
+        let mut resp = serde_json::json!({"success": true, "rows": rows, "count": count, "namespace": namespace});
         if !sql_warnings.is_empty() {
             resp["warnings"] = serde_json::Value::Array(
                 sql_warnings
@@ -3067,6 +3069,8 @@ do ##class(%UnitTest.Manager).RunTest("{pattern}","{flags}","{token}")"#,
     ) -> Result<CallToolResult, McpError> {
         self.check_reload().await;
         let workspace_basename = String::new();
+        let namespace =
+            interop::resolve_namespace(p.namespace.as_deref(), self.iris_arc().as_deref());
 
         let containers = list_iris_containers(&workspace_basename).await;
         let found = containers
@@ -3094,7 +3098,7 @@ do ##class(%UnitTest.Manager).RunTest("{pattern}","{flags}","{token}")"#,
 
         let mut new_conn = crate::iris::connection::IrisConnection::new(
             &base_url,
-            &p.namespace,
+            &namespace,
             &p.username,
             &p.password,
             crate::iris::connection::DiscoverySource::Docker {
@@ -3132,7 +3136,7 @@ do ##class(%UnitTest.Manager).RunTest("{pattern}","{flags}","{token}")"#,
             "container": p.name,
             "port_superserver": port_superserver,
             "port_web": port_web,
-            "namespace": p.namespace,
+            "namespace": namespace,
             "version": version,
             "write_tools_enabled": write_tools_enabled,
         }))
@@ -3328,7 +3332,8 @@ do ##class(%UnitTest.Manager).RunTest("{pattern}","{flags}","{token}")"#,
         let iris = self.get_iris_reloaded().await?;
         let client = self.http_client();
         let (sql, params) = translate_symbols_query(p.limit, &p.query);
-        match iris.query(&sql, params, &p.namespace, client).await {
+        let namespace = interop::resolve_namespace(p.namespace.as_deref(), Some(&iris));
+        match iris.query(&sql, params, &namespace, client).await {
             Ok(resp) => ok_json(serde_json::json!({
                 "source": "iris_dictionary",
                 "symbols": resp["result"]["content"],
@@ -3400,17 +3405,18 @@ do ##class(%UnitTest.Manager).RunTest("{pattern}","{flags}","{token}")"#,
         let iris = self.get_iris_reloaded().await?;
         let client = self.http_client();
         // Bug 15: use parameterized queries instead of manual string escaping.
+        let namespace = interop::resolve_namespace(p.namespace.as_deref(), Some(&iris));
         let methods = iris.query(
             "SELECT Name,FormalSpec,ReturnType FROM %Dictionary.CompiledMethod WHERE parent=? ORDER BY Name",
             vec![serde_json::Value::String(p.class_name.clone())],
-            &p.namespace,
+            &namespace,
             client,
         ).await.unwrap_or_default();
         let props = iris
             .query(
                 "SELECT Name,Type FROM %Dictionary.CompiledProperty WHERE parent=? ORDER BY Name",
                 vec![serde_json::Value::String(p.class_name.clone())],
-                &p.namespace,
+                &namespace,
                 client,
             )
             .await
@@ -3434,13 +3440,14 @@ do ##class(%UnitTest.Manager).RunTest("{pattern}","{flags}","{token}")"#,
             }
         }
         let iris = self.get_iris_reloaded().await?;
+        let namespace = interop::resolve_namespace(p.namespace.as_deref(), Some(&iris));
         let _client = self.http_client();
         let code = format!(
             "Write ##class(%Studio.Debugger).SourceLine(\"{}\",{})",
             p.routine.replace('"', "\\\""),
             p.offset
         );
-        match iris.execute(&code, &p.namespace).await {
+        match iris.execute(&code, &namespace).await {
             Ok(raw) => {
                 let (cls_name, cls_line) = parse_source_line(raw.trim());
                 ok_json(
@@ -3461,8 +3468,9 @@ do ##class(%UnitTest.Manager).RunTest("{pattern}","{flags}","{token}")"#,
         Parameters(_p): Parameters<CapturePacketParams>,
     ) -> Result<CallToolResult, McpError> {
         let iris = self.get_iris_reloaded().await?;
+        let namespace = interop::resolve_namespace(_p.namespace.as_deref(), Some(&iris));
         let client = self.http_client();
-        match iris.query("SELECT TOP 20 ErrorCode,ErrorText,TimeStamp FROM %SYSTEM.Error ORDER BY TimeStamp DESC", vec![], &_p.namespace, client).await {
+        match iris.query("SELECT TOP 20 ErrorCode,ErrorText,TimeStamp FROM %SYSTEM.Error ORDER BY TimeStamp DESC", vec![], &namespace, client).await {
             Ok(resp) => ok_json(serde_json::json!({"success": true, "errors": resp["result"]["content"]})),
             Err(e) => {
                 let msg = e.to_string();
@@ -3484,9 +3492,10 @@ do ##class(%UnitTest.Manager).RunTest("{pattern}","{flags}","{token}")"#,
         let iris = self.get_iris_reloaded().await?;
         let client = self.http_client();
         // FR-012: cap max_entries to prevent runaway queries.
+        let namespace = interop::resolve_namespace(p.namespace.as_deref(), Some(&iris));
         let max_entries = p.max_entries.min(1000);
         let sql = format!("SELECT TOP {} ErrorCode,ErrorText,TimeStamp FROM %SYSTEM.Error ORDER BY TimeStamp DESC", max_entries);
-        match iris.query(&sql, vec![], &p.namespace, client).await {
+        match iris.query(&sql, vec![], &namespace, client).await {
             Ok(resp) => {
                 let mut result =
                     serde_json::json!({"success": true, "logs": resp["result"]["content"]});
@@ -3528,13 +3537,14 @@ do ##class(%UnitTest.Manager).RunTest("{pattern}","{flags}","{token}")"#,
         let iris = self.get_iris_reloaded().await?;
         let _client = self.http_client();
         let cls_name = p.cls_name.trim_end_matches(".cls");
+        let namespace = interop::resolve_namespace(p.namespace.as_deref(), Some(&iris));
         // Build source map by querying %Studio.Debugger for each .INT method
         let code = format!(
             "set cls=\"{}\" set rtn=$translate(cls,\".\",\".\") set map=\"{{\" set first=1 set method=\"\" for {{ set method=$order(^rIndex(rtn,method)) quit:method=\"\"  set intline=$get(^rIndex(rtn,method)) if 'first {{ set map=map_\",\" }} set map=map_\"\\\"\"_method_\"\\\":\\\"\"_intline_\"\\\"\" set first=0 }} set map=map_\"}}\" write map",
             cls_name.replace('"', "\\\"")
         );
-        // Bug 23: use p.namespace, not the hardcoded "USER".
-        match iris.execute(&code, &p.namespace).await {
+        // Bug 23: use namespace, not the hardcoded "USER".
+        match iris.execute(&code, &namespace).await {
             Ok(output) => {
                 let map: serde_json::Value =
                     serde_json::from_str(output.trim()).unwrap_or(serde_json::json!({}));
@@ -3589,12 +3599,13 @@ do ##class(%UnitTest.Manager).RunTest("{pattern}","{flags}","{token}")"#,
 
         if let Some(iris) = self.iris_arc().as_deref() {
             let _client = self.http_client();
+            let namespace = interop::resolve_namespace(p.namespace.as_deref(), Some(iris));
             let code = format!(
                 "Set sc=$SYSTEM.OBJ.Compile(\"{}\",\"ck-d\") Write $System.Status.IsOK(sc)",
                 class_name
             );
             let compile_ok = iris
-                .execute(&code, &p.namespace)
+                .execute(&code, &namespace)
                 .await
                 .map(|o| o.trim() == "1")
                 .unwrap_or(false);
@@ -3619,7 +3630,7 @@ Original: {}",
                         fixed_name
                     );
                     let ok2 = iris
-                        .execute(&code2, &p.namespace)
+                        .execute(&code2, &namespace)
                         .await
                         .map(|o| o.trim() == "1")
                         .unwrap_or(false);
@@ -3655,12 +3666,13 @@ Original: {}",
         })?;
 
         let introspection_context = if let Some(iris) = self.iris_arc().as_deref() {
+            let namespace = interop::resolve_namespace(p.namespace.as_deref(), Some(iris));
             let client = self.http_client();
             // FR-001/C1: use parameterized query to prevent SQL injection via class_name.
             iris.query(
                 "SELECT Name,FormalSpec,ReturnType FROM %Dictionary.CompiledMethod WHERE parent=? ORDER BY Name",
                 vec![serde_json::Value::String(p.class_name.clone())],
-                &p.namespace,
+                &namespace,
                 client,
             )
                 .await
@@ -4521,7 +4533,7 @@ Methods:
             "select" => {
                 let params = SelectContainerParams {
                     name: name.unwrap_or_default(),
-                    namespace: default_namespace(),
+                    namespace: None,
                     username: default_username(),
                     password: default_password(),
                 };

--- a/crates/iris-agentic-dev-core/src/tools/scm.rs
+++ b/crates/iris-agentic-dev-core/src/tools/scm.rs
@@ -13,9 +13,6 @@ fn ok_json(v: serde_json::Value) -> Result<rmcp::model::CallToolResult, rmcp::Er
 fn err_json(code: &str, msg: &str) -> Result<rmcp::model::CallToolResult, rmcp::ErrorData> {
     crate::tools::envelope::fail(code, msg)
 }
-fn default_namespace() -> String {
-    "USER".to_string()
-}
 
 /// Known menu item names to probe via OnMenuItem.
 pub const KNOWN_MENU_ITEMS: &[&str] = &[
@@ -38,8 +35,8 @@ pub struct ScmParams {
     /// Elicitation resume answer
     pub answer: Option<String>,
     pub elicitation_id: Option<String>,
-    #[serde(default = "default_namespace")]
-    pub namespace: String,
+    #[serde(default)]
+    pub namespace: Option<String>,
 }
 
 async fn xecute(
@@ -76,8 +73,9 @@ pub async fn handle_iris_source_control(
     p: ScmParams,
     elicitation_store: &ElicitationStore,
 ) -> Result<rmcp::model::CallToolResult, rmcp::ErrorData> {
+    let namespace = crate::tools::interop::resolve_namespace(p.namespace.as_deref(), Some(iris));
     let doc = p.document.as_deref().unwrap_or("");
-    let ns = &p.namespace;
+    let ns = &namespace;
 
     // Handle elicitation resume
     if let (Some(eid), Some(answer)) = (&p.elicitation_id, &p.answer) {

--- a/crates/iris-agentic-dev-core/src/tools/search.rs
+++ b/crates/iris-agentic-dev-core/src/tools/search.rs
@@ -18,15 +18,11 @@ pub struct SearchParams {
     /// Wildcard document scopes e.g. ["HS.FHIR.*.cls"]
     #[serde(default)]
     pub documents: Vec<String>,
-    #[serde(default = "default_namespace")]
-    pub namespace: String,
+    #[serde(default)]
+    pub namespace: Option<String>,
     /// If true, bypass the log store and return all results inline regardless of count.
     #[serde(default)]
     pub inline: bool,
-}
-
-fn default_namespace() -> String {
-    "USER".to_string()
 }
 
 fn ok_json(v: serde_json::Value) -> Result<rmcp::model::CallToolResult, rmcp::ErrorData> {
@@ -41,6 +37,7 @@ pub async fn handle_iris_search(
     p: SearchParams,
     log_store: Arc<Mutex<log_store::LogStore>>,
 ) -> Result<rmcp::model::CallToolResult, rmcp::ErrorData> {
+    let namespace = crate::tools::interop::resolve_namespace(p.namespace.as_deref(), Some(iris));
     let category = p.category.as_deref().unwrap_or("ALL");
     let mut query_string = format!(
         "query={}&regex={}&sys=false&category={}",
@@ -52,7 +49,7 @@ pub async fn handle_iris_search(
         query_string.push_str("&case=1");
     }
 
-    let sync_url = iris.versioned_ns_url(&p.namespace, &format!("/action/search?{}", query_string));
+    let sync_url = iris.versioned_ns_url(&namespace, &format!("/action/search?{}", query_string));
 
     // Try sync search with 2s timeout
     let sync_client = reqwest::Client::builder()
@@ -76,19 +73,13 @@ pub async fn handle_iris_search(
             }
             let work_id = body["result"]["workId"].as_str().unwrap_or("").to_string();
             poll_async_search(
-                iris,
-                client,
-                &work_id,
-                &p.namespace,
-                &p.query,
-                p.inline,
-                &log_store,
+                iris, client, &work_id, &namespace, &p.query, p.inline, &log_store,
             )
             .await
         }
         _ => {
             // Timeout or error — fall back to async POST
-            let post_url = iris.versioned_ns_url(&p.namespace, "/action/search");
+            let post_url = iris.versioned_ns_url(&namespace, "/action/search");
             let post_body = serde_json::json!({
                 "query": p.query,
                 "regex": p.regex,
@@ -108,13 +99,7 @@ pub async fn handle_iris_search(
             let body: serde_json::Value = resp.json().await.unwrap_or_default();
             if let Some(work_id) = body["result"]["workId"].as_str() {
                 poll_async_search(
-                    iris,
-                    client,
-                    work_id,
-                    &p.namespace,
-                    &p.query,
-                    p.inline,
-                    &log_store,
+                    iris, client, work_id, &namespace, &p.query, p.inline, &log_store,
                 )
                 .await
             } else {
@@ -228,11 +213,14 @@ mod tests {
     // ── parse_search_results ──────────────────────────────────────────────────
     // parse_search_results is private — test indirectly via known behaviour
     #[test]
-    fn test_search_params_namespace_required_field() {
-        // namespace has no serde default in search.rs — it's required or has default
+    fn test_search_params_namespace_optional_field() {
+        // Explicit namespace is kept; omitted resolves to the connection
+        // namespace at call time (issue #15).
         let result: Result<SearchParams, _> =
             serde_json::from_str(r#"{"query":"x","namespace":"MYNS"}"#);
         assert!(result.is_ok());
-        assert_eq!(result.unwrap().namespace, "MYNS");
+        assert_eq!(result.unwrap().namespace.as_deref(), Some("MYNS"));
+        let omitted: SearchParams = serde_json::from_str(r#"{"query":"x"}"#).unwrap();
+        assert_eq!(omitted.namespace, None);
     }
 }

--- a/crates/iris-agentic-dev-core/tests/interop_e2e_tests.rs
+++ b/crates/iris-agentic-dev-core/tests/interop_e2e_tests.rs
@@ -523,6 +523,63 @@ fn test_namespace_default_and_interop_hint() {
 }
 
 #[test]
+#[ignore = "requires live IRIS"]
+fn test_execute_and_query_namespace_defaults_to_connection() {
+    // Issue #15: iris_execute (and the other general tools) with no `namespace`
+    // argument ran in a hardcoded USER — never the server's configured
+    // IRIS_NAMESPACE — and succeeded silently against the wrong database.
+    let iris_host = std::env::var("IRIS_HOST").unwrap_or_default();
+    assert!(!iris_host.is_empty(), "IRIS_HOST must be set");
+    let conn_ns = std::env::var("IRIS_NAMESPACE").unwrap_or_else(|_| "USER".to_string());
+    assert_ne!(
+        conn_ns, "USER",
+        "run with IRIS_NAMESPACE pointing at a non-USER namespace"
+    );
+
+    let exchange = |args: serde_json::Value, tool: &str| {
+        let responses = mcp_exchange(&[
+            serde_json::json!({"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2024-11-05","capabilities":{},"clientInfo":{"name":"e2e","version":"0.1"}}}),
+            serde_json::json!({"jsonrpc":"2.0","method":"notifications/initialized","params":{}}),
+            serde_json::json!({"jsonrpc":"2.0","id":2,"method":"tools/call","params":{"name":tool,"arguments":args}}),
+        ]);
+        find_response(&responses, 2).expect("no response")
+    };
+
+    // 1. iris_execute without namespace → runs in the connection namespace,
+    //    and the response names the namespace it ran in.
+    let v = parse_tool_text(&exchange(
+        serde_json::json!({"code":"WRITE $NAMESPACE"}),
+        "iris_execute",
+    ));
+    assert_eq!(v["success"], true, "{v}");
+    assert_eq!(
+        v["output"],
+        conn_ns.as_str(),
+        "iris_execute ran in the wrong namespace: {v}"
+    );
+    assert_eq!(
+        v["namespace"],
+        conn_ns.as_str(),
+        "response must name the namespace it ran in: {v}"
+    );
+
+    // 2. iris_query without namespace → connection namespace too. The probe
+    //    class Ens.Director exists in the (interop-enabled) connection
+    //    namespace and not in USER, so the count distinguishes them.
+    let v = parse_tool_text(&exchange(
+        serde_json::json!({"query":"SELECT COUNT(*) AS n FROM %Dictionary.CompiledClass WHERE Name = 'Ens.Director'"}),
+        "iris_query",
+    ));
+    assert_eq!(v["success"], true, "{v}");
+    assert_eq!(v["namespace"], conn_ns.as_str(), "{v}");
+    let n = v["rows"][0]["n"]
+        .as_i64()
+        .or_else(|| v["rows"][0]["n"].as_str().and_then(|s| s.parse().ok()))
+        .unwrap_or(-1);
+    assert_eq!(n, 1, "iris_query ran in the wrong namespace: {v}");
+}
+
+#[test]
 #[ignore = "requires live IRIS with Interoperability"]
 fn test_error_envelope_and_is_error_flag() {
     // Issue #2: genuine tool failures must set isError on the CallToolResult

--- a/crates/iris-agentic-dev-core/tests/unit/test_compile_params.rs
+++ b/crates/iris-agentic-dev-core/tests/unit/test_compile_params.rs
@@ -9,7 +9,7 @@ mod tests {
         let p: CompileParams = serde_json::from_str(r#"{"target":"MyApp.Patient.cls"}"#).unwrap();
         assert_eq!(p.target, "MyApp.Patient.cls");
         assert_eq!(p.flags, "cuk");
-        assert_eq!(p.namespace, "USER");
+        assert_eq!(p.namespace, None); // omitted -> resolved to the connection namespace at call time
         assert!(!p.force_writable);
     }
 
@@ -28,7 +28,7 @@ mod tests {
             r#"{"target":"HS.FHIR.*.cls","flags":"cuk","namespace":"HSLIB","force_writable":true}"#,
         )
         .unwrap();
-        assert_eq!(p.namespace, "HSLIB");
+        assert_eq!(p.namespace.as_deref(), Some("HSLIB"));
         assert!(p.force_writable);
     }
 }

--- a/crates/iris-agentic-dev-core/tests/unit/test_info_unit.rs
+++ b/crates/iris-agentic-dev-core/tests/unit/test_info_unit.rs
@@ -14,14 +14,14 @@ fn test_info_params_what_field_metadata() {
 #[test]
 fn test_info_params_namespace_default() {
     let p: InfoParams = serde_json::from_str(r#"{"what": "documents"}"#).unwrap();
-    assert_eq!(p.namespace, "USER");
+    assert_eq!(p.namespace, None); // omitted -> resolved to the connection namespace at call time
 }
 
 #[test]
 fn test_info_params_namespace_override() {
     let p: InfoParams =
         serde_json::from_str(r#"{"what": "namespace", "namespace": "MYNS"}"#).unwrap();
-    assert_eq!(p.namespace, "MYNS");
+    assert_eq!(p.namespace.as_deref(), Some("MYNS"));
 }
 
 #[test]
@@ -93,14 +93,14 @@ fn test_macro_params_action_signature() {
 #[test]
 fn test_macro_params_namespace_default() {
     let p: MacroParams = serde_json::from_str(r#"{"action": "list"}"#).unwrap();
-    assert_eq!(p.namespace, "USER");
+    assert_eq!(p.namespace, None); // omitted -> resolved to the connection namespace at call time
 }
 
 #[test]
 fn test_macro_params_namespace_override() {
     let p: MacroParams =
         serde_json::from_str(r#"{"action": "list", "namespace": "PROD"}"#).unwrap();
-    assert_eq!(p.namespace, "PROD");
+    assert_eq!(p.namespace.as_deref(), Some("PROD"));
 }
 
 #[test]
@@ -150,7 +150,7 @@ fn test_debug_params_action_map_int() {
 #[test]
 fn test_debug_params_namespace_default() {
     let p: DebugParams = serde_json::from_str(r#"{"action": "error_logs"}"#).unwrap();
-    assert_eq!(p.namespace, "USER");
+    assert_eq!(p.namespace, None); // omitted -> resolved to the connection namespace at call time
 }
 
 #[test]
@@ -231,14 +231,14 @@ fn test_generate_params_gen_type_test() {
 #[test]
 fn test_generate_params_namespace_default() {
     let p: GenerateParams = serde_json::from_str(r#"{"description": "something"}"#).unwrap();
-    assert_eq!(p.namespace, "USER");
+    assert_eq!(p.namespace, None); // omitted -> resolved to the connection namespace at call time
 }
 
 #[test]
 fn test_generate_params_namespace_override() {
     let p: GenerateParams =
         serde_json::from_str(r#"{"description": "x", "namespace": "PROD"}"#).unwrap();
-    assert_eq!(p.namespace, "PROD");
+    assert_eq!(p.namespace.as_deref(), Some("PROD"));
 }
 
 #[test]

--- a/crates/iris-agentic-dev-core/tests/unit/test_scm_unit.rs
+++ b/crates/iris-agentic-dev-core/tests/unit/test_scm_unit.rs
@@ -44,7 +44,7 @@ fn test_known_menu_items_contains_standard_actions() {
 fn test_scm_params_action_required() {
     let p: ScmParams = serde_json::from_str(r#"{"action": "status"}"#).unwrap();
     assert_eq!(p.action, "status");
-    assert_eq!(p.namespace, "USER"); // default_namespace
+    assert_eq!(p.namespace, None); // omitted -> resolved to the connection namespace at call time
     assert!(p.document.is_none());
     assert!(p.action_id.is_none());
     assert!(p.answer.is_none());
@@ -65,7 +65,7 @@ fn test_scm_params_full() {
     assert_eq!(p.action, "execute");
     assert_eq!(p.document.as_deref(), Some("MyClass.cls"));
     assert_eq!(p.action_id.as_deref(), Some("CheckOut"));
-    assert_eq!(p.namespace, "MYNAMESPACE");
+    assert_eq!(p.namespace.as_deref(), Some("MYNAMESPACE"));
 }
 
 #[test]
@@ -81,7 +81,7 @@ fn test_scm_params_with_elicitation_fields() {
     assert_eq!(p.action, "execute");
     assert_eq!(p.answer.as_deref(), Some("yes"));
     assert_eq!(p.elicitation_id.as_deref(), Some("eid-abc123"));
-    assert_eq!(p.namespace, "USER");
+    assert_eq!(p.namespace, None);
 }
 
 #[test]

--- a/crates/iris-agentic-dev-core/tests/unit/test_search_unit.rs
+++ b/crates/iris-agentic-dev-core/tests/unit/test_search_unit.rs
@@ -7,8 +7,8 @@ fn test_search_params_minimal() {
     let p: SearchParams = serde_json::from_str(r#"{"query": "test"}"#).unwrap();
     assert_eq!(p.query, "test");
     // namespace defaults to "USER"
-    assert_eq!(p.namespace, "USER");
-    // bool fields default to false
+    assert_eq!(p.namespace, None); // omitted -> resolved to the connection namespace at call time
+                                   // bool fields default to false
     assert!(!p.regex);
     assert!(!p.case_sensitive);
     // optional fields default to empty/None
@@ -30,7 +30,7 @@ fn test_search_params_full() {
     )
     .unwrap();
     assert_eq!(p.query, "Director");
-    assert_eq!(p.namespace, "USER");
+    assert_eq!(p.namespace, None); // omitted -> resolved to the connection namespace at call time
     assert!(p.regex);
     assert!(!p.case_sensitive);
     assert_eq!(p.category.as_deref(), Some("CLS"));
@@ -49,7 +49,7 @@ fn test_search_params_case_sensitive_flag() {
 fn test_search_params_custom_namespace() {
     let p: SearchParams =
         serde_json::from_str(r#"{"query": "foo", "namespace": "IRISAPP"}"#).unwrap();
-    assert_eq!(p.namespace, "IRISAPP");
+    assert_eq!(p.namespace.as_deref(), Some("IRISAPP"));
 }
 
 #[test]


### PR DESCRIPTION
## What

Fixes #15 — `iris_execute` (and every other general tool) with no per-call `namespace`
ran in a hardcoded **USER**, silently returning plausible results from the wrong
database. Root cause: a serde default `default_namespace() -> "USER"` on **24 param
structs** across `mod.rs`, `info.rs`, `doc.rs`, `scm.rs`, `dict.rs`, `search.rs`.
The #5 fix (PR #8) had brought only the *interop* tools to the right semantic; this PR
routes the general tools through the same `resolve_namespace()`:

> explicit param → wins; omitted/empty → the connection namespace
> (`IRIS_NAMESPACE` / discovery); `USER` only when there is no connection at all.

As the issue notes, the same root cause plausibly underlay #5 — this removes it everywhere.

## How

- `namespace` fields become `Option<String>` (the type change let the compiler find all
  ~60 use sites), resolved once at each handler top.
- `iris_execute` / `iris_query` responses keep echoing `namespace` — which now truthfully
  names where the code ran (the issue's second ask).
- `iris_select_container` resolves against the current connection before switching;
  generate/debug/search/dict handlers resolve inside their connection scope.
- Tool descriptions for `iris_execute`/`iris_query` now state the default.
- Unit tests that pinned the old behaviour (`omitted => "USER"`) now pin
  `omitted => None` + `explicit => Some(...)`.
- Bump 0.7.0 → 0.7.1.

## Verification

New e2e repro `test_execute_and_query_namespace_defaults_to_connection` (run with
`IRIS_NAMESPACE=APP` against live IRIS):
- `iris_execute` `WRITE $NAMESPACE`, no namespace arg → output `APP`, `response.namespace: "APP"`
  (was: `USER`, the exact 3/3 failure from the graded sessions);
- `iris_query` counting `Ens.Director` in `%Dictionary.CompiledClass` → 1 (0 in USER).

Full interop e2e suite green (8/8) against dev IRIS, CI suites green locally,
`clippy --all-targets -D warnings` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)