### PR TITLE
fix(search): send files= scope and explicit case=; refuse unscoped searches; parse v8 result shapes (fixes #17)

### DIFF
--- a/crates/iris-agentic-dev-core/src/tools/mod.rs
+++ b/crates/iris-agentic-dev-core/src/tools/mod.rs
@@ -4021,7 +4021,7 @@ Methods:
     }
 
     #[tool(
-        description = "Full-text search across IRIS documents via Atelier REST v2. Auto-upgrades to async polling for large namespaces. Supports regex, case sensitivity, category filter (CLS/MAC/INT/INC/ALL), and wildcard document scopes."
+        description = "Full-text search across IRIS documents via Atelier REST v2. documents: REQUIRED wildcard scope (e.g. [\"MyPkg.*.cls\"]) — Atelier greps sequentially, so an unscoped search is refused (SCOPE_REQUIRED) rather than timing out server-side. Case-INsensitive by default (case_sensitive: true for exact case). Supports regex and category filter (CLS/MAC/INT/INC/ALL). Auto-upgrades to async polling when the server defers via workId. namespace: optional — defaults to the connection namespace (IRIS_NAMESPACE)."
     )]
     async fn iris_search(
         &self,

--- a/crates/iris-agentic-dev-core/src/tools/search.rs
+++ b/crates/iris-agentic-dev-core/src/tools/search.rs
@@ -15,7 +15,9 @@ pub struct SearchParams {
     pub case_sensitive: bool,
     /// Filter to document category: CLS, MAC, INT, INC, or ALL (default)
     pub category: Option<String>,
-    /// Wildcard document scopes e.g. ["HS.FHIR.*.cls"]
+    /// REQUIRED wildcard document scope, e.g. ["MyPkg.*.cls"] or ["HS.FHIR.**.cls"].
+    /// Atelier search is a sequential grep — an empty scope greps the whole namespace
+    /// and times out server-side, so at least one scope must be provided.
     #[serde(default)]
     pub documents: Vec<String>,
     #[serde(default)]
@@ -31,6 +33,64 @@ fn ok_json(v: serde_json::Value) -> Result<rmcp::model::CallToolResult, rmcp::Er
     ]))
 }
 
+/// Resolve the Atelier `files` scope for a search.
+///
+/// Atelier `/action/search` is a sequential grep, not an index: it searches only
+/// the documents matched by the `files` wildcard list. A caller who supplies
+/// `documents` gets exactly that scope (comma-joined). A caller who supplies none
+/// is asking to grep the *entire* namespace — which times out server-side on any
+/// real namespace, so we refuse with SCOPE_REQUIRED rather than return a
+/// misleading empty result.
+fn resolve_files(documents: &[String]) -> Option<String> {
+    if documents.is_empty() {
+        return None;
+    }
+    Some(documents.join(","))
+}
+
+/// Flatten Atelier search response content into one result per MATCH.
+///
+/// Response shape varies by API version:
+///   • v8 (IRIS 2024+): `result` is itself the array of document entries.
+///   • older/async:      `result.content` holds the array.
+/// Entries either nest matches (`{doc, matches:[{text, line, member}]}`) or put a
+/// single match flat on the entry (`{doc, atLine, text, member}`). Flatten both so
+/// `total_found` counts matches, not documents.
+fn flatten_results(body: &serde_json::Value) -> Vec<serde_json::Value> {
+    let content = body["result"]
+        .as_array()
+        .or_else(|| body["result"]["content"].as_array())
+        .cloned()
+        .unwrap_or_default();
+
+    let mut results: Vec<serde_json::Value> = Vec::new();
+    for item in content {
+        let doc = item["doc"].clone();
+        match item["matches"].as_array() {
+            Some(matches) if !matches.is_empty() => {
+                for m in matches {
+                    results.push(serde_json::json!({
+                        "document": doc,
+                        // v2 nested matches use `line`; tolerate `atLine` too.
+                        "line": if m["line"].is_null() { m["atLine"].clone() } else { m["line"].clone() },
+                        "member": m["member"],
+                        "content": m["text"],
+                    }));
+                }
+            }
+            _ => {
+                results.push(serde_json::json!({
+                    "document": doc,
+                    "line": if item["line"].is_null() { item["atLine"].clone() } else { item["line"].clone() },
+                    "member": item["member"],
+                    "content": item["text"],
+                }));
+            }
+        }
+    }
+    results
+}
+
 pub async fn handle_iris_search(
     iris: &IrisConnection,
     client: &reqwest::Client,
@@ -39,21 +99,51 @@ pub async fn handle_iris_search(
 ) -> Result<rmcp::model::CallToolResult, rmcp::ErrorData> {
     let namespace = crate::tools::interop::resolve_namespace(p.namespace.as_deref(), Some(iris));
     let category = p.category.as_deref().unwrap_or("ALL");
-    let mut query_string = format!(
-        "query={}&regex={}&sys=false&category={}",
+    // A scope is mandatory. Without one Atelier would grep the whole namespace and
+    // time out server-side, returning nothing — an empty result that reads as
+    // "term not found" when the term is simply out of a (nonexistent) scope.
+    let files = match resolve_files(&p.documents) {
+        Some(f) => f,
+        None => {
+            return crate::tools::envelope::fail_with(
+                "SCOPE_REQUIRED",
+                "iris_search requires a document scope. Namespace-wide search greps \
+                 every document sequentially and times out server-side. Pass \
+                 `documents` with a wildcard scope, e.g. [\"MyPkg.*.cls\"].",
+                serde_json::json!({"query": p.query}),
+            );
+        }
+    };
+    // Atelier `/action/search` treats a *missing* `case` param as case-SENSITIVE,
+    // so omitting it (the old behaviour when `case_sensitive=false`) silently made
+    // every default search exact-case. Always send `case` explicitly:
+    // `case=0` = insensitive (the tool default), `case=1` = sensitive.
+    let case_flag = if p.case_sensitive { 1 } else { 0 };
+    let query_string = format!(
+        "query={}&regex={}&sys=false&category={}&files={}&case={}",
         urlencoding::encode(&p.query),
         p.regex,
         category,
+        urlencoding::encode(&files),
+        case_flag,
     );
-    if p.case_sensitive {
-        query_string.push_str("&case=1");
-    }
 
     let sync_url = iris.versioned_ns_url(&namespace, &format!("/action/search?{}", query_string));
 
-    // Try sync search with 2s timeout
+    // Try the synchronous search first. Many IRIS servers answer `/action/search`
+    // synchronously — even for wildcard scopes that take several seconds — and
+    // never hand back a `workId` to poll. A tight timeout trips on those, falls
+    // through to the async POST, which on those servers returns an empty `{}`
+    // (no workId) and parses as zero hits. Give the sync path a generous,
+    // env-overridable budget; async polling remains the fallback for servers
+    // that genuinely defer via workId.
+    let sync_timeout_secs = std::env::var("IRIS_SEARCH_SYNC_TIMEOUT")
+        .ok()
+        .and_then(|v| v.parse::<u64>().ok())
+        .filter(|&v| v > 0)
+        .unwrap_or(30);
     let sync_client = reqwest::Client::builder()
-        .timeout(std::time::Duration::from_secs(2))
+        .timeout(std::time::Duration::from_secs(sync_timeout_secs))
         .danger_accept_invalid_certs(true)
         .build()
         .unwrap_or_else(|_| client.clone());
@@ -85,6 +175,9 @@ pub async fn handle_iris_search(
                 "regex": p.regex,
                 "sys": false,
                 "category": category,
+                "files": files,
+                // Always explicit — a missing `case` defaults to case-sensitive server-side.
+                "case": case_flag,
             });
             let resp = client
                 .post(&post_url)
@@ -160,22 +253,8 @@ fn parse_search_results(
     inline: bool,
     log_store: &Arc<Mutex<log_store::LogStore>>,
 ) -> Result<rmcp::model::CallToolResult, rmcp::ErrorData> {
-    let content = body["result"]["content"]
-        .as_array()
-        .cloned()
-        .unwrap_or_default();
-    let total = content.len();
-    let results: Vec<serde_json::Value> = content
-        .into_iter()
-        .map(|item| {
-            serde_json::json!({
-                "document": item["doc"],
-                "line": item["atLine"],
-                "member": item["member"],
-                "content": item["text"],
-            })
-        })
-        .collect();
+    let results = flatten_results(&body);
+    let total = results.len();
 
     let mut resp = serde_json::json!({
         "success": true,
@@ -210,8 +289,6 @@ mod tests {
         assert_eq!(p.query, "test");
     }
 
-    // ── parse_search_results ──────────────────────────────────────────────────
-    // parse_search_results is private — test indirectly via known behaviour
     #[test]
     fn test_search_params_namespace_optional_field() {
         // Explicit namespace is kept; omitted resolves to the connection
@@ -222,5 +299,63 @@ mod tests {
         assert_eq!(result.unwrap().namespace.as_deref(), Some("MYNS"));
         let omitted: SearchParams = serde_json::from_str(r#"{"query":"x"}"#).unwrap();
         assert_eq!(omitted.namespace, None);
+    }
+
+    // ── resolve_files (issue #17: scope must reach the query) ─────────────────
+    #[test]
+    fn resolve_files_joins_scopes() {
+        assert_eq!(
+            resolve_files(&["A.*.cls".into(), "B.*.mac".into()]).as_deref(),
+            Some("A.*.cls,B.*.mac")
+        );
+        assert_eq!(
+            resolve_files(&["Pkg.**.cls".into()]).as_deref(),
+            Some("Pkg.**.cls")
+        );
+    }
+
+    #[test]
+    fn resolve_files_empty_means_no_scope() {
+        assert_eq!(resolve_files(&[]), None);
+    }
+
+    // ── flatten_results (issue #17: v8 array + matches[] shapes) ──────────────
+    #[test]
+    fn flatten_handles_legacy_content_shape() {
+        let body = serde_json::json!({"result": {"content": [
+            {"doc": "A.cls", "atLine": 3, "member": "M", "text": "hit"}
+        ]}});
+        let r = flatten_results(&body);
+        assert_eq!(r.len(), 1);
+        assert_eq!(r[0]["document"], "A.cls");
+        assert_eq!(r[0]["line"], 3);
+        assert_eq!(r[0]["content"], "hit");
+    }
+
+    #[test]
+    fn flatten_handles_v8_result_array_with_nested_matches() {
+        let body = serde_json::json!({"result": [
+            {"doc": "A.cls", "matches": [
+                {"text": "one", "line": 1, "member": "X"},
+                {"text": "two", "line": 9, "member": "Y"}
+            ]},
+            {"doc": "B.cls", "matches": [{"text": "three", "atLine": 5}]}
+        ]});
+        let r = flatten_results(&body);
+        // one result per MATCH (3), not per document (2)
+        assert_eq!(r.len(), 3);
+        assert_eq!(r[0]["document"], "A.cls");
+        assert_eq!(r[1]["line"], 9);
+        assert_eq!(r[2]["document"], "B.cls");
+        assert_eq!(
+            r[2]["line"], 5,
+            "atLine must be tolerated in nested matches"
+        );
+    }
+
+    #[test]
+    fn flatten_empty_body_is_empty() {
+        assert!(flatten_results(&serde_json::json!({})).is_empty());
+        assert!(flatten_results(&serde_json::json!({"result": {}})).is_empty());
     }
 }

--- a/crates/iris-agentic-dev-core/tests/interop_e2e_tests.rs
+++ b/crates/iris-agentic-dev-core/tests/interop_e2e_tests.rs
@@ -580,6 +580,90 @@ fn test_execute_and_query_namespace_defaults_to_connection() {
 }
 
 #[test]
+#[ignore = "requires live IRIS"]
+fn test_search_scope_and_case_insensitive_default() {
+    // Issue #17: iris_search never sent a `files=` scope (Atelier greps nothing
+    // without one) and omitted `case=`, which Atelier treats as case-SENSITIVE —
+    // so the natural lowercase search missed mixed-case code.
+    let iris_host = std::env::var("IRIS_HOST").unwrap_or_default();
+    assert!(!iris_host.is_empty(), "IRIS_HOST must be set");
+
+    let exchange = |args: serde_json::Value, tool: &str| {
+        let responses = mcp_exchange(&[
+            serde_json::json!({"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2024-11-05","capabilities":{},"clientInfo":{"name":"e2e","version":"0.1"}}}),
+            serde_json::json!({"jsonrpc":"2.0","method":"notifications/initialized","params":{}}),
+            serde_json::json!({"jsonrpc":"2.0","id":2,"method":"tools/call","params":{"name":tool,"arguments":args}}),
+        ]);
+        find_response(&responses, 2).expect("no response")
+    };
+
+    // Marker class with a MiXeD-case token; searched lowercase below.
+    let marker =
+        "Class IrisDevE2E.SearchMarker\n{\n/// carries the SeArChMaRkEr17 token\nClassMethod Noop()\n{\n    Quit\n}\n}\n";
+    let frame = exchange(
+        serde_json::json!({"mode":"put","name":"IrisDevE2E.SearchMarker.cls","content":marker,"compile":false}),
+        "iris_doc",
+    );
+    assert_ne!(
+        frame["result"]["isError"], true,
+        "marker PUT failed: {frame}"
+    );
+
+    // 1. No `documents` scope → explicit SCOPE_REQUIRED error, not empty results.
+    let frame = exchange(serde_json::json!({"query":"searchmarker17"}), "iris_search");
+    assert_eq!(
+        frame["result"]["isError"], true,
+        "scopeless search must be refused: {frame}"
+    );
+    let v = parse_tool_text(&frame);
+    assert_eq!(v["error_code"], "SCOPE_REQUIRED", "{v}");
+
+    // 2. Lowercase query + scope → finds the MiXeD-case token (case-insensitive
+    //    default). The pre-fix code returned 0 results here (no files= param).
+    let frame = exchange(
+        serde_json::json!({"query":"searchmarker17","documents":["IrisDevE2E.*.cls"]}),
+        "iris_search",
+    );
+    assert_ne!(frame["result"]["isError"], true, "{frame}");
+    let v = parse_tool_text(&frame);
+    assert_eq!(v["success"], true, "{v}");
+    let total = v["total_found"].as_i64().unwrap_or(0);
+    assert!(
+        total >= 1,
+        "case-insensitive scoped search found nothing: {v}"
+    );
+    let hits = v["results"].as_array().cloned().unwrap_or_default();
+    assert!(
+        hits.iter().any(|r| r["document"]
+            .as_str()
+            .unwrap_or("")
+            .contains("SearchMarker")),
+        "marker class not in results: {v}"
+    );
+
+    // 3. case_sensitive:true with the wrong case → no hits for the marker.
+    let frame = exchange(
+        serde_json::json!({"query":"searchmarker17","documents":["IrisDevE2E.*.cls"],"case_sensitive":true}),
+        "iris_search",
+    );
+    let v = parse_tool_text(&frame);
+    let hits = v["results"].as_array().cloned().unwrap_or_default();
+    assert!(
+        !hits.iter().any(|r| r["document"]
+            .as_str()
+            .unwrap_or("")
+            .contains("SearchMarker")),
+        "case-sensitive search must miss the mixed-case token: {v}"
+    );
+
+    // Cleanup (best-effort).
+    let _ = exchange(
+        serde_json::json!({"mode":"delete","name":"IrisDevE2E.SearchMarker.cls"}),
+        "iris_doc",
+    );
+}
+
+#[test]
 #[ignore = "requires live IRIS with Interoperability"]
 fn test_error_envelope_and_is_error_flag() {
     // Issue #2: genuine tool failures must set isError on the CallToolResult


### PR DESCRIPTION
## What

Fixes #17 — `iris_search` searched **nothing**: the Atelier query never included the `files=` scope (`/action/search` greps only the scoped files; our `documents` param was declared but never read), and a missing `case=` param means case-SENSITIVE to Atelier, so even a correctly-scoped default search required byte-exact casing. Two further defects: only the legacy `result.content` response shape was parsed (v8's result-as-array and nested `matches[]` were dropped; `total_found` counted documents, not matches), and the 2s sync timeout tripped on slow-but-synchronous servers, falling through to an async POST that parses an empty reply as 0 hits.

## How

Port of upstream `07f64e5` + `66b486f` **end state**, adapted to this fork's conventions:

- `documents` is now REQUIRED — an unscoped search returns `SCOPE_REQUIRED` through the #2 error envelope (`isError` on the wire) instead of upstream's `success:false`-in-`ok_json`, because a namespace-wide grep times out server-side and reads as "term not found".
- `case` always sent explicitly: `case=0` default (insensitive), `case=1` for `case_sensitive: true`.
- New pure `flatten_results()` handles v8 result-as-array, legacy `result.content`, nested `matches[]`, and flat single-match entries — one result per **match**. Unit-tested on all four shapes.
- Sync budget 30s, overridable via `IRIS_SEARCH_SYNC_TIMEOUT`.
- Namespace keeps the #15 `resolve_namespace` path; tool description updated (scope required, case default, namespace default).

## Verification

New e2e `test_search_scope_and_case_insensitive_default` against live IRIS (APP): puts a marker class carrying a `SeArChMaRkEr17` token, then asserts (1) unscoped search → `SCOPE_REQUIRED` + `isError`, (2) lowercase query with `documents: ["IrisDevE2E.*.cls"]` finds it — the pre-fix code returned 0 results on this exact call, (3) `case_sensitive: true` with lowercase correctly misses it. Full e2e suite 9/9 green, CI suites 9/9, clippy `-D warnings` clean.

**Stacked on #16** (both touch `search.rs`); base will be retargeted to `master` when #16 merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)