### PR TITLE
fix(debug,execute): iris_debug over plain HTTP + 2026.2 banner strip + %occInclude + 120s test timeout (fixes #20, fixes #22)

### DIFF
--- a/crates/iris-agentic-dev-core/src/iris/connection.rs
+++ b/crates/iris-agentic-dev-core/src/iris/connection.rs
@@ -380,6 +380,11 @@ impl IrisConnection {
     /// for the existing Rust-side transport decode in `execute_via_generator_once`).
     fn build_exec_class(class_name: &str, code: &str) -> Vec<String> {
         let mut lines: Vec<String> = vec![
+            // $$$macros in USER code ($$$OK, $$$ISERR, $$$ThrowOnError...) must resolve
+            // regardless of whether this IRIS version implicitly includes %occInclude
+            // for class compiles (issue #22, upstream 713c23c).
+            "Include %occInclude".into(),
+            "".into(),
             format!("Class {} [ Final ]", class_name),
             "{".into(),
             "".into(),
@@ -423,7 +428,7 @@ impl IrisConnection {
             "  Set sc = stream.LinkToFile(tmpfile)".into(),
             // $SYSTEM.Status.IsOK avoids needing %occStatus.inc in a non-objectgenerator method.
             "  If $SYSTEM.Status.IsOK(sc) {".into(),
-            "    While 'stream.AtEnd { Set out = out_stream.ReadLine()_$Char(10) }".into(),
+            "    While 'stream.AtEnd { Set out = out _ stream.ReadLine() _ $Char(10) }".into(),
             "  }".into(),
             "  Do ##class(%Library.File).Delete(tmpfile)".into(),
             // Encode newlines as $C(1) for the Rust-side transport (decoded \x01 -> \n).
@@ -688,16 +693,26 @@ fn is_production_namespace(ns: &str) -> bool {
 pub fn strip_iris_banner(output: &str) -> String {
     let mut result_lines: Vec<&str> = Vec::new();
 
+    // Banner-text rules only apply before the first prompt is seen — after that, a line
+    // like "IRIS for UNIX ..." is legitimate `Write $ZVersion` output, not the
+    // connect-time banner, and must not be stripped (issue #20, upstream 37fdc95).
+    let mut seen_prompt = false;
+
     for line in output.lines() {
         let trimmed = line.trim();
 
-        // Unconditionally strip well-known banner lines.
-        if trimmed.starts_with("Copyright")
-            || trimmed.contains("InterSystems Corporation")
-            || trimmed.starts_with("All rights reserved")
-            || trimmed.starts_with("IRIS for ")
-            || trimmed.starts_with("Cache for ")
-            || trimmed.starts_with("Ensemble for ")
+        if !seen_prompt
+            && (trimmed.starts_with("Copyright")
+                || trimmed.contains("InterSystems Corporation")
+                || trimmed.starts_with("All rights reserved")
+                || trimmed.starts_with("IRIS for ")
+                || trimmed.starts_with("Cache for ")
+                || trimmed.starts_with("Ensemble for ")
+                // IRIS 2026.2+ prints "Node: <hostname>, Instance: IRIS" on session
+                // connect. Without this, its embedded ':' gets misparsed as a name:code
+                // pair by callers like parse_status_response ("Node" became the
+                // production name).
+                || (trimmed.starts_with("Node: ") && trimmed.contains(", Instance:")))
         {
             continue;
         }
@@ -705,6 +720,7 @@ pub fn strip_iris_banner(output: &str) -> String {
         // Strip bare prompt-only lines: lines that are just "USER>", "IRIS>", "%SYS>", etc.
         // A bare prompt line has no content beyond the prompt token.
         if is_bare_prompt_line(trimmed) {
+            seen_prompt = true;
             continue;
         }
 
@@ -752,6 +768,43 @@ fn is_bare_prompt_line(s: &str) -> bool {
 #[cfg(test)]
 mod system_mode_tests {
     use super::*;
+
+    // ── strip_iris_banner (issue #20, upstream 37fdc95) ──────────────────────
+    #[test]
+    fn strip_iris_banner_removes_node_instance_line() {
+        // IRIS 2026.2+ prints this on every `iris session` connect. Its embedded ':'
+        // previously got misparsed as a name:code pair by callers like
+        // interop::parse_status_response (production name came back as "Node").
+        let raw = "\nNode: de17f22ad88c, Instance: IRIS\n\nUSER>\nIrisDevTest.CoverageProduction:1\n\nUSER>\n";
+        let stripped = strip_iris_banner(raw);
+        assert!(!stripped.contains("Node:"), "{stripped:?}");
+        assert_eq!(stripped.trim(), "IrisDevTest.CoverageProduction:1");
+    }
+
+    #[test]
+    fn strip_iris_banner_keeps_iris_for_line_after_first_prompt() {
+        // `Write $ZVersion` legitimately outputs a string starting with "IRIS for
+        // UNIX ..." — that must NOT be treated as the connect-time banner just
+        // because it shares the prefix. Banner rules apply only before the first
+        // prompt is seen.
+        let raw = "\nNode: de17f22ad88c, Instance: IRIS\n\nUSER>\nIRIS for UNIX (Ubuntu Server LTS for ARM64 Containers) 2026.2.0L\n\nUSER>\n";
+        let stripped = strip_iris_banner(raw);
+        assert!(
+            stripped.trim().starts_with("IRIS for UNIX"),
+            "$ZVersion output must survive: {stripped:?}"
+        );
+    }
+
+    // ── build_exec_class: $$$macros must resolve (issue #22, upstream 713c23c) ─
+    #[test]
+    fn build_exec_class_includes_occinclude() {
+        let cls = IrisConnection::build_exec_class("User.T", "write $$$OK,!").join("\n");
+        let inc = cls
+            .find("Include %occInclude")
+            .expect("Include line missing");
+        let class_kw = cls.find("Class User.T").expect("Class line missing");
+        assert!(inc < class_kw, "Include must precede the Class line");
+    }
 
     // ── iris_execute generated-class shape (A2 silent-loss fix) ──────────────
     // The old class used `CodeMode = objectgenerator`, which ran user code at COMPILE

--- a/crates/iris-agentic-dev-core/src/tools/info.rs
+++ b/crates/iris-agentic-dev-core/src/tools/info.rs
@@ -202,11 +202,10 @@ pub struct DebugParams {
 
 pub async fn handle_iris_debug(
     iris: &IrisConnection,
-    _client: &reqwest::Client,
+    client: &reqwest::Client,
     p: DebugParams,
 ) -> Result<rmcp::model::CallToolResult, rmcp::ErrorData> {
     let namespace = crate::tools::interop::resolve_namespace(p.namespace.as_deref(), Some(iris));
-    let _query_url = iris.versioned_ns_url(&namespace, "/action/query");
 
     match p.action.as_str() {
         "map_int" => {
@@ -215,13 +214,12 @@ pub async fn handle_iris_debug(
                 "set err=\"{}\" set routine=$piece($piece(err,\"^\",2),\".\",1) set offset=$piece(err,\"+\",2) set offset=$piece(offset,\"^\",1) write ##class(%Studio.Debugger).SourceLine(routine,+offset)",
                 err.replace('"', "\\\"")
             );
-            match iris.execute(&code, &namespace).await {
+            // execute_via_generator works over plain Atelier HTTP — no docker exec
+            // needed (issue #20; the DOCKER_REQUIRED bail-out made iris_debug fail on
+            // every HTTP-only connection).
+            match iris.execute_via_generator(&code, &namespace, client).await {
                 Ok(output) => ok_json(
                     serde_json::json!({"success": true, "error_string": err, "source_location": output.trim()}),
-                ),
-                Err(e) if e.to_string() == "DOCKER_REQUIRED" => crate::tools::envelope::fail(
-                    "DOCKER_REQUIRED",
-                    "iris_debug map_int requires docker exec. Set IRIS_CONTAINER=<container_name>.",
                 ),
                 Err(e) => err_json("EXECUTION_FAILED", &e.to_string()),
             }
@@ -238,14 +236,10 @@ pub async fn handle_iris_debug(
         }
         "capture" => {
             let code = "set err=$ZERROR write \"error:\"_err,! set loc=$ZPOSITION write \"position:\"_loc,!";
-            match iris.execute(code, &namespace).await {
+            match iris.execute_via_generator(code, &namespace, client).await {
                 Ok(output) => {
                     ok_json(serde_json::json!({"success": true, "capture": output.trim()}))
                 }
-                Err(e) if e.to_string() == "DOCKER_REQUIRED" => crate::tools::envelope::fail(
-                    "DOCKER_REQUIRED",
-                    "iris_debug capture requires docker exec. Set IRIS_CONTAINER=<container_name>.",
-                ),
                 Err(e) => err_json("EXECUTION_FAILED", &e.to_string()),
             }
         }
@@ -255,13 +249,9 @@ pub async fn handle_iris_debug(
                 "set map=\"\" set line=1 do {{set int=##class(%Studio.Debugger).MapToINT({cls},line,.intline) if int=\"\" quit set map=map_line_\"->\"_intline_\",\" set line=line+1 }} while 1 write map",
                 cls = crate::objectscript::os_str_expr(cls)
             );
-            match iris.execute(&code, &namespace).await {
+            match iris.execute_via_generator(&code, &namespace, client).await {
                 Ok(output) => ok_json(
                     serde_json::json!({"success": true, "class": cls, "mapping": output.trim()}),
-                ),
-                Err(e) if e.to_string() == "DOCKER_REQUIRED" => crate::tools::envelope::fail(
-                    "DOCKER_REQUIRED",
-                    "iris_debug source_map requires docker exec. Set IRIS_CONTAINER=<container_name>.",
                 ),
                 Err(e) => err_json("EXECUTION_FAILED", &e.to_string()),
             }

--- a/crates/iris-agentic-dev-core/src/tools/mod.rs
+++ b/crates/iris-agentic-dev-core/src/tools/mod.rs
@@ -707,7 +707,13 @@ pub struct TestParams {
 }
 
 fn default_test_timeout() -> u64 {
-    60
+    // %UnitTest.TestProduction suites (the TDD workshop pattern) routinely exceed 60s.
+    // OBJECTSCRIPT_TEST_TIMEOUT overrides for slower instances (issue #22, upstream #59).
+    std::env::var("OBJECTSCRIPT_TEST_TIMEOUT")
+        .ok()
+        .and_then(|v| v.parse::<u64>().ok())
+        .filter(|&v| v > 0)
+        .unwrap_or(120)
 }
 #[derive(Debug, Deserialize, JsonSchema)]
 pub struct SymbolsParams {


### PR DESCRIPTION
Fixes #20 and #22 (batched — both small, adjacent layers).

**#20**: `iris_debug`'s three actions used docker-exec with a `DOCKER_REQUIRED` bail-out — the tool failed on every HTTP-only connection (workshop VM config). Now routed through `execute_via_generator`, completing the conversion the fork already did for the production tools. Plus the `strip_iris_banner` fixes from upstream `37fdc95`: the IRIS 2026.2+ `Node: …, Instance: IRIS` connect line is stripped, and banner rules stop at the first prompt so `Write $ZVersion` output survives.

**#22**: `Include %occInclude` in the generated executor class ($$$macros in user code resolve on any IRIS version), test timeout 60→120s with `OBJECTSCRIPT_TEST_TIMEOUT` override, and the cosmetic spacing fix on the exec-class read loop.

Verified live (HTTP-only, no `IRIS_CONTAINER`): `iris_debug capture` returns real `$ZERROR`/`$ZPOSITION` output — previously `DOCKER_REQUIRED`; `iris_execute` running `If $$$ISOK($$$OK)` prints the marker. 3 new unit tests. CI suites 9/9, e2e 10/10, clippy clean.

**Stacked on #28** (→ #27 → #26 → #25 → #16 → master).

🤖 Generated with [Claude Code](https://claude.com/claude-code)