### PR TITLE
fix(scm): port upstream source-control session rework as one unit (fixes #19)

### DIFF
--- a/crates/iris-agentic-dev-core/src/elicitation.rs
+++ b/crates/iris-agentic-dev-core/src/elicitation.rs
@@ -1,6 +1,7 @@
 //! Elicitation state management for MCP source control dialogs.
 //! Stores pending elicitations keyed by UUID, expires after 5 minutes.
 
+use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 use std::sync::{Arc, Mutex};
 use std::time::{Duration, Instant};
@@ -8,12 +9,24 @@ use uuid::Uuid;
 
 const EXPIRY: Duration = Duration::from_secs(300); // 5 minutes
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 pub enum ElicitationAction {
     /// Resume a iris_doc(mode=put) write
     Put,
     /// Resume an iris_source_control execute action
     ScmExecute,
+}
+
+/// Serde-friendly mirror of [`PendingElicitation`] without the non-serializable [`Instant`].
+/// Used for serialization, deserialization, and persistence of elicitation state.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct PendingElicitationRecord {
+    pub id: String,
+    pub document: String,
+    pub action: ElicitationAction,
+    pub content: Option<String>,
+    pub scm_action_id: Option<String>,
+    pub namespace: String,
 }
 
 #[derive(Debug, Clone)]
@@ -27,6 +40,68 @@ pub struct PendingElicitation {
     pub scm_action_id: Option<String>,
     pub namespace: String,
     pub expires_at: Instant,
+}
+
+/// TTL for a cached "this document is checked out by me" entry. Kept short so a
+/// stale entry (e.g. someone reverted the checkout out-of-band) self-heals quickly;
+/// the IRIS-side write rejection is the ultimate backstop, and any SCM action we run
+/// on the doc invalidates the entry immediately (see [`CheckoutCache::invalidate`]).
+const CHECKOUT_CACHE_TTL: Duration = Duration::from_secs(60);
+
+/// Session-scoped cache of documents we have already checked out under this connection.
+///
+/// The pre-write SCM probe (query MenuItems / UserAction) is one IRIS round-trip per write.
+/// On repeated writes to the same doc that probe returns the same "already checked out by
+/// me → proceed" answer every time, so we cache it.
+///
+/// Keyed by `(namespace, document)`. Entries expire after [`CHECKOUT_CACHE_TTL`] and are
+/// cleared explicitly whenever an SCM action (undo checkout, check-in, disconnect) runs on
+/// the doc. A cached write that IRIS still rejects must clear its own entry so the retry
+/// re-probes rather than looping on a bad cache.
+#[derive(Clone, Default)]
+pub struct CheckoutCache(Arc<Mutex<HashMap<(String, String), Instant>>>);
+
+impl CheckoutCache {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    fn key(namespace: &str, document: &str) -> (String, String) {
+        (namespace.to_string(), document.to_string())
+    }
+
+    /// Record that `document` in `namespace` is checked out by us (or freely writable),
+    /// so subsequent writes can skip the pre-write SCM probe until the entry expires.
+    pub fn mark(&self, namespace: &str, document: &str) {
+        self.0.lock().unwrap().insert(
+            Self::key(namespace, document),
+            Instant::now() + CHECKOUT_CACHE_TTL,
+        );
+    }
+
+    /// Returns true if we have a live (non-expired) checkout entry for this document.
+    /// Expired entries are removed on access so a cache miss always re-probes IRIS.
+    pub fn is_checked_out(&self, namespace: &str, document: &str) -> bool {
+        let mut store = self.0.lock().unwrap();
+        let key = Self::key(namespace, document);
+        match store.get(&key) {
+            Some(expires) if Instant::now() <= *expires => true,
+            Some(_) => {
+                store.remove(&key);
+                false
+            }
+            None => false,
+        }
+    }
+
+    /// Drop the cached checkout entry for this document — call after any SCM action that
+    /// changes checkout state (undo/checkin/disconnect) or after a write IRIS rejected.
+    pub fn invalidate(&self, namespace: &str, document: &str) {
+        self.0
+            .lock()
+            .unwrap()
+            .remove(&Self::key(namespace, document));
+    }
 }
 
 #[derive(Clone, Default)]
@@ -90,5 +165,308 @@ impl ElicitationStore {
             store.remove(&key);
         }
         count
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_insert_returns_uuid() {
+        let store = ElicitationStore::new();
+        let id = store.insert("Foo.cls", ElicitationAction::Put, None, None, "USER");
+        assert!(!id.is_empty());
+    }
+
+    #[test]
+    fn test_lookup_finds_inserted() {
+        let store = ElicitationStore::new();
+        let id = store.insert(
+            "Foo.cls",
+            ElicitationAction::Put,
+            Some("content".into()),
+            None,
+            "USER",
+        );
+        let pending = store.lookup(&id).expect("should find it");
+        assert_eq!(pending.document, "Foo.cls");
+        assert_eq!(pending.namespace, "USER");
+        assert_eq!(pending.content.as_deref(), Some("content"));
+    }
+
+    #[test]
+    fn test_lookup_missing_returns_none() {
+        let store = ElicitationStore::new();
+        assert!(store.lookup("nonexistent-id").is_none());
+    }
+
+    #[test]
+    fn test_clear_removes_entry() {
+        let store = ElicitationStore::new();
+        let id = store.insert(
+            "Bar.cls",
+            ElicitationAction::ScmExecute,
+            None,
+            Some("CheckOut".into()),
+            "USER",
+        );
+        store.clear(&id);
+        assert!(store.lookup(&id).is_none());
+    }
+
+    #[test]
+    fn test_sweep_empty_store() {
+        let store = ElicitationStore::new();
+        assert_eq!(store.sweep(), 0);
+    }
+
+    #[test]
+    fn test_sweep_removes_nothing_fresh() {
+        let store = ElicitationStore::new();
+        store.insert("A.cls", ElicitationAction::Put, None, None, "USER");
+        store.insert("B.cls", ElicitationAction::Put, None, None, "USER");
+        assert_eq!(store.sweep(), 0, "fresh entries should not be swept");
+    }
+
+    #[test]
+    fn test_scm_execute_action_fields() {
+        let store = ElicitationStore::new();
+        let id = store.insert(
+            "App.cls",
+            ElicitationAction::ScmExecute,
+            None,
+            Some("CheckIn".into()),
+            "MYNS",
+        );
+        let p = store.lookup(&id).unwrap();
+        assert!(matches!(p.action, ElicitationAction::ScmExecute));
+        assert_eq!(p.scm_action_id.as_deref(), Some("CheckIn"));
+        assert_eq!(p.namespace, "MYNS");
+    }
+
+    // ── Serde tests ──────────────────────────────────────────────────────────
+
+    #[test]
+    fn serde_action_put_roundtrip() {
+        let action = ElicitationAction::Put;
+        let json = serde_json::to_string(&action).expect("serialize Put");
+        let back: ElicitationAction = serde_json::from_str(&json).expect("deserialize Put");
+        assert_eq!(back, ElicitationAction::Put);
+    }
+
+    #[test]
+    fn serde_action_scm_execute_roundtrip() {
+        let action = ElicitationAction::ScmExecute;
+        let json = serde_json::to_string(&action).expect("serialize ScmExecute");
+        let back: ElicitationAction = serde_json::from_str(&json).expect("deserialize ScmExecute");
+        assert_eq!(back, ElicitationAction::ScmExecute);
+    }
+
+    #[test]
+    fn serde_action_put_json_value() {
+        let action = ElicitationAction::Put;
+        let v: serde_json::Value = serde_json::to_value(&action).unwrap();
+        assert_eq!(v, serde_json::Value::String("Put".to_string()));
+    }
+
+    #[test]
+    fn serde_action_scm_execute_json_value() {
+        let action = ElicitationAction::ScmExecute;
+        let v: serde_json::Value = serde_json::to_value(&action).unwrap();
+        assert_eq!(v, serde_json::Value::String("ScmExecute".to_string()));
+    }
+
+    #[test]
+    fn serde_action_unknown_variant_fails() {
+        let result: Result<ElicitationAction, _> = serde_json::from_str("\"UnknownVariant\"");
+        assert!(
+            result.is_err(),
+            "deserializing an unknown variant must fail"
+        );
+    }
+
+    #[test]
+    fn serde_record_put_roundtrip() {
+        let record = PendingElicitationRecord {
+            id: "test-id-1".into(),
+            document: "Pkg.Foo.cls".into(),
+            action: ElicitationAction::Put,
+            content: Some("Class Pkg.Foo {}".into()),
+            scm_action_id: None,
+            namespace: "USER".into(),
+        };
+        let json = serde_json::to_string(&record).expect("serialize record");
+        let back: PendingElicitationRecord =
+            serde_json::from_str(&json).expect("deserialize record");
+        assert_eq!(back, record);
+    }
+
+    #[test]
+    fn serde_record_scm_execute_roundtrip() {
+        let record = PendingElicitationRecord {
+            id: "test-id-2".into(),
+            document: "App.Router.cls".into(),
+            action: ElicitationAction::ScmExecute,
+            content: None,
+            scm_action_id: Some("CheckIn".into()),
+            namespace: "PRODUCTION".into(),
+        };
+        let json = serde_json::to_string(&record).expect("serialize scm record");
+        let back: PendingElicitationRecord =
+            serde_json::from_str(&json).expect("deserialize scm record");
+        assert_eq!(back, record);
+        assert_eq!(back.scm_action_id.as_deref(), Some("CheckIn"));
+        assert!(back.content.is_none());
+    }
+
+    #[test]
+    fn serde_record_optional_fields_none() {
+        let record = PendingElicitationRecord {
+            id: "test-id-3".into(),
+            document: "X.cls".into(),
+            action: ElicitationAction::Put,
+            content: None,
+            scm_action_id: None,
+            namespace: "NS".into(),
+        };
+        let json = serde_json::to_string(&record).unwrap();
+        let back: PendingElicitationRecord = serde_json::from_str(&json).unwrap();
+        assert!(back.content.is_none());
+        assert!(back.scm_action_id.is_none());
+    }
+
+    #[test]
+    fn serde_record_missing_required_field_fails() {
+        // "namespace" field is intentionally omitted — deserialization must fail.
+        let json =
+            r#"{"id":"x","document":"X.cls","action":"Put","content":null,"scm_action_id":null}"#;
+        let result: Result<PendingElicitationRecord, _> = serde_json::from_str(json);
+        assert!(
+            result.is_err(),
+            "missing required field 'namespace' must fail"
+        );
+    }
+
+    #[test]
+    fn serde_record_from_raw_json() {
+        let json = r#"{
+            "id": "abc-123",
+            "document": "My.Doc.cls",
+            "action": "ScmExecute",
+            "content": null,
+            "scm_action_id": "GetLatest",
+            "namespace": "LIVE"
+        }"#;
+        let record: PendingElicitationRecord = serde_json::from_str(json).expect("parse raw JSON");
+        assert_eq!(record.id, "abc-123");
+        assert_eq!(record.document, "My.Doc.cls");
+        assert_eq!(record.action, ElicitationAction::ScmExecute);
+        assert_eq!(record.scm_action_id.as_deref(), Some("GetLatest"));
+        assert_eq!(record.namespace, "LIVE");
+        assert!(record.content.is_none());
+    }
+
+    #[test]
+    fn test_lookup_expired_returns_none() {
+        let store = ElicitationStore::new();
+        let id = "expired-id-123".to_string();
+        // Insert directly with an already-expired timestamp
+        let entry = PendingElicitation {
+            id: id.clone(),
+            document: "Exp.cls".into(),
+            action: ElicitationAction::Put,
+            content: None,
+            scm_action_id: None,
+            namespace: "USER".into(),
+            expires_at: Instant::now() - Duration::from_secs(1),
+        };
+        store.0.lock().unwrap().insert(id.clone(), entry);
+        // Lookup should return None and remove the entry
+        assert!(store.lookup(&id).is_none());
+        // Entry should be removed from the store
+        assert!(store.0.lock().unwrap().get(&id).is_none());
+    }
+
+    #[test]
+    fn test_sweep_removes_expired_entries() {
+        let store = ElicitationStore::new();
+        // Insert one expired and one fresh entry
+        let expired_id = "expired-sweep-id".to_string();
+        let fresh_id = store.insert("Fresh.cls", ElicitationAction::Put, None, None, "USER");
+        let expired_entry = PendingElicitation {
+            id: expired_id.clone(),
+            document: "Old.cls".into(),
+            action: ElicitationAction::ScmExecute,
+            content: None,
+            scm_action_id: None,
+            namespace: "USER".into(),
+            expires_at: Instant::now() - Duration::from_secs(1),
+        };
+        store
+            .0
+            .lock()
+            .unwrap()
+            .insert(expired_id.clone(), expired_entry);
+        let removed = store.sweep();
+        assert_eq!(removed, 1, "should have removed exactly 1 expired entry");
+        // Expired entry gone, fresh entry still there
+        assert!(store.lookup(&expired_id).is_none());
+        assert!(store.lookup(&fresh_id).is_some());
+    }
+
+    // ── CheckoutCache ─────────────────────────────────────────────────────────
+    #[test]
+    fn test_checkout_cache_miss_by_default() {
+        let cache = CheckoutCache::new();
+        assert!(!cache.is_checked_out("USER", "Foo.cls"));
+    }
+
+    #[test]
+    fn test_checkout_cache_hit_after_mark() {
+        let cache = CheckoutCache::new();
+        cache.mark("USER", "Foo.cls");
+        assert!(cache.is_checked_out("USER", "Foo.cls"));
+    }
+
+    #[test]
+    fn test_checkout_cache_is_keyed_by_namespace_and_doc() {
+        let cache = CheckoutCache::new();
+        cache.mark("USER", "Foo.cls");
+        // Same doc, different namespace → miss.
+        assert!(!cache.is_checked_out("DVP", "Foo.cls"));
+        // Same namespace, different doc → miss.
+        assert!(!cache.is_checked_out("USER", "Bar.cls"));
+    }
+
+    #[test]
+    fn test_checkout_cache_invalidate_clears_entry() {
+        let cache = CheckoutCache::new();
+        cache.mark("USER", "Foo.cls");
+        cache.invalidate("USER", "Foo.cls");
+        assert!(!cache.is_checked_out("USER", "Foo.cls"));
+    }
+
+    #[test]
+    fn test_checkout_cache_invalidate_missing_is_noop() {
+        let cache = CheckoutCache::new();
+        cache.invalidate("USER", "Nonexistent.cls"); // must not panic
+        assert!(!cache.is_checked_out("USER", "Nonexistent.cls"));
+    }
+
+    #[test]
+    fn test_checkout_cache_expired_entry_is_a_miss() {
+        let cache = CheckoutCache::new();
+        // Insert an already-expired entry directly (expires 1s in the past).
+        cache.0.lock().unwrap().insert(
+            ("USER".to_string(), "Old.cls".to_string()),
+            Instant::now() - Duration::from_secs(1),
+        );
+        assert!(
+            !cache.is_checked_out("USER", "Old.cls"),
+            "expired entry must read as a miss"
+        );
+        // And the expired entry is evicted on access.
+        assert!(cache.0.lock().unwrap().is_empty());
     }
 }

--- a/crates/iris-agentic-dev-core/src/iris/connection.rs
+++ b/crates/iris-agentic-dev-core/src/iris/connection.rs
@@ -416,9 +416,11 @@ impl IrisConnection {
             "    Write \"ERROR: \",ex.DisplayString(),!".into(),
             "  }".into(),
             "  Write !".into(), // IDEV-3: sentinel ensures temp file always ends with \n
-            // Surface non-exception errors (e.g. OPEN failure sets $ZERROR but doesn't throw).
-            "  If ($ZError'=\"\") && ($ZError'=\",\") { Write \"ERROR($ZERROR): \",$ZError,! }"
-                .into(),
+            // Snapshot $ZERROR now, before Close/Use/stream operations below can clobber
+            // it. This captures non-exception errors (e.g. an OPEN failure that sets
+            // $ZERROR without throwing) so we can surface them if the body produced no
+            // output — but WITHOUT writing to tmpfile yet (see the out="" test below).
+            "  Set ze = $ZError".into(),
             "  Close tmpfile".into(),
             "  Use savedIO".into(),
             // Read the temp file contents using %Stream for reliability.
@@ -431,6 +433,12 @@ impl IrisConnection {
             "    While 'stream.AtEnd { Set out = out _ stream.ReadLine() _ $Char(10) }".into(),
             "  }".into(),
             "  Do ##class(%Library.File).Delete(tmpfile)".into(),
+            // Only surface a non-exception $ZERROR when the body produced NO output.
+            // A residual like <ENDOFFILE> is often left as a benign side effect of an
+            // SCM provider's internal Read even when the operation fully succeeded;
+            // appending it to a non-empty result corrupted otherwise-valid output.
+            "  If (out=\"\") && (ze'=\"\") && (ze'=\",\") { Set out = \"ERROR($ZERROR): \"_ze_$Char(10) }"
+                .into(),
             // Encode newlines as $C(1) for the Rust-side transport (decoded \x01 -> \n).
             "  Quit $Replace(out,$Char(10),$Char(1))".into(),
             "}".into(),

--- a/crates/iris-agentic-dev-core/src/tools/doc.rs
+++ b/crates/iris-agentic-dev-core/src/tools/doc.rs
@@ -170,10 +170,11 @@ pub async fn handle_iris_doc(
     client: &reqwest::Client,
     p: IrisDocParams,
     elicitation_store: &crate::elicitation::ElicitationStore,
+    checkout_cache: &crate::elicitation::CheckoutCache,
 ) -> Result<rmcp::model::CallToolResult, rmcp::ErrorData> {
     match DocMode::parse(&p.mode) {
         Some(DocMode::Get) => handle_get(iris, client, p).await,
-        Some(DocMode::Put) => handle_put(iris, client, p, elicitation_store).await,
+        Some(DocMode::Put) => handle_put(iris, client, p, elicitation_store, checkout_cache).await,
         Some(DocMode::Delete) => handle_delete(iris, client, p).await,
         Some(DocMode::Head) => handle_head(iris, client, p).await,
         None => crate::tools::envelope::fail_with(
@@ -303,6 +304,7 @@ async fn handle_put(
     client: &reqwest::Client,
     p: IrisDocParams,
     elicitation_store: &crate::elicitation::ElicitationStore,
+    checkout_cache: &crate::elicitation::CheckoutCache,
 ) -> Result<rmcp::model::CallToolResult, rmcp::ErrorData> {
     let namespace = crate::tools::interop::resolve_namespace(p.namespace.as_deref(), Some(iris));
     let ns = &namespace;
@@ -314,6 +316,33 @@ async fn handle_put(
             if answer.to_lowercase() != "yes" {
                 return crate::tools::envelope::fail("WRITE_ABORTED", "User declined checkout");
             }
+            // Finalize the checkout the user just approved. The pre-write check only
+            // ran UserAction (which *offers* the dialog); the checkout is not actually
+            // committed until AfterUserAction is called. Because do_write is a separate
+            // HTTP job, the in-memory %SourceControl session from the pre-write check is
+            // already gone — so without this the write hits ERROR #5865 "not checked out
+            // of source control". AfterUserAction persists the checkout server-side.
+            let after_code = crate::tools::scm::after_user_action_code(
+                "%CheckOut",
+                &pending.document,
+                "yes",
+                &iris.username,
+                &iris.password,
+            );
+            if let Ok(out) = iris
+                .execute_via_generator(&after_code, &pending.namespace, client)
+                .await
+            {
+                let out = out.lines().next().unwrap_or("").trim().to_string();
+                // Non-empty output from after_user_action_code is an SCM error string.
+                if !out.is_empty() && out != "SCM_UNAVAILABLE" {
+                    return err_json("SCM_CHECKOUT_FAILED", &out);
+                }
+            }
+            // Checkout is now committed server-side — cache it so writes that follow
+            // in quick succession skip the redundant pre-write probe.
+            checkout_cache.mark(&pending.namespace, &pending.document);
+
             // User said yes — proceed with the stored content directly
             let resume_content = pending.content.as_deref().unwrap_or("");
             return do_write(
@@ -360,14 +389,82 @@ async fn handle_put(
         _ => raw_content,
     };
 
-    // SCM OnBeforeSave — check if write is allowed (requires docker exec; skipped if unavailable)
+    write_with_scm(
+        iris,
+        client,
+        name,
+        content,
+        ns,
+        p.compile,
+        p.allow_storage_regeneration,
+        elicitation_store,
+        checkout_cache,
+    )
+    .await
+}
+
+/// Run the SCM pre-write check, then write. `content` is the full document body to write.
+// Args are all distinct scalars/handles threaded straight through from the tool entry point;
+// bundling them into a struct would add indirection without clarifying anything.
+#[allow(clippy::too_many_arguments)]
+async fn write_with_scm(
+    iris: &IrisConnection,
+    client: &reqwest::Client,
+    name: &str,
+    content: &str,
+    ns: &str,
+    compile: bool,
+    allow_storage_regeneration: bool,
+    elicitation_store: &crate::elicitation::ElicitationStore,
+    checkout_cache: &crate::elicitation::CheckoutCache,
+) -> Result<rmcp::model::CallToolResult, rmcp::ErrorData> {
+    // Fast path: if we already checked this doc out earlier this session (cache hit), skip the
+    // pre-write SCM probe entirely — it is one IRIS round-trip that returns the same "proceed"
+    // answer every time on a chained write. A stale entry self-heals: the write below still
+    // goes through IRIS, and if it is rejected we invalidate so the retry re-probes.
+    if checkout_cache.is_checked_out(ns, name) {
+        let result = do_write(
+            iris,
+            client,
+            name,
+            content,
+            ns,
+            compile,
+            allow_storage_regeneration,
+        )
+        .await?;
+        if !write_result_succeeded(&result) {
+            // Cache was stale (checkout lost out-of-band) — drop it so the next call re-probes.
+            checkout_cache.invalidate(ns, name);
+        }
+        return Ok(result);
+    }
+
+    // SCM pre-write check — uses SourceControlCreate for a proper session (HTTP-compatible).
+    // %GetImplementationObject does not exist on any IRIS version; use Interface API instead.
+    //
+    // First inspect the MenuItems: if %UndoCheckout is offered, WE already hold the checkout,
+    // so we must NOT re-run the %CheckOut probe. Re-invoking %CheckOut on a doc we already hold
+    // returns action=1 ("needs confirmation dialog"), which made every chained edit on an
+    // already-checked-out doc re-elicit "requires checkout" forever.
+    // In that case emit a PROCEED sentinel and write directly.
+    let n = name.replace('"', "\"\""); // ObjectScript double-quote escaping
     let scm_check = format!(
-        "set scmObj=##class(%Studio.SourceControl.Base).%GetImplementationObject(\"{n}\") if '$IsObject(scmObj) {{ write \"NO_SCM\" }} else {{ set action=0 set msg=\"\" set target=\"\" set reload=0 set sc=scmObj.UserAction(0,\"%SourceMenu,CheckOut\",\"{n}\",\"\",.action,.target,.msg,.reload) write action_\"|\"_msg }}",
-        n = name.replace('"', "\\\"")
+        "set scmClass=##class(%Studio.SourceControl.Interface).SourceControlClassGet() if scmClass=\"\" {{ write \"NO_SCM\" }} else {{ set sc=##class(%Studio.SourceControl.Interface).SourceControlCreate(\"{u}\",\"{p}\",.c,.f,.o) set obj=$get(%SourceControl) if '$IsObject(obj) {{ write \"NO_SCM\" }} else {{ set hasUndoCheckout=0 try {{ set rset=##class(%ResultSet).%New(\"%Studio.SourceControl.Interface:MenuItems\") set sc=rset.Execute(\"%SourceMenu\",\"{n}\",\"\") while rset.Next() {{ if rset.GetData(2)&&(rset.GetData(1)=\"%UndoCheckout\") {{ set hasUndoCheckout=1 }} }} }} catch {{}} if hasUndoCheckout {{ write \"PROCEED|\" }} else {{ set action=0 set msg=\"\" set target=\"\" set reload=0 set sc=obj.UserAction(0,\"%SourceMenu,%CheckOut\",\"{n}\",\"\",.action,.target,.msg,.reload) write action_\"|\"_msg }} }} }}",
+        u = iris.username.replace('"', "\"\""),
+        p = iris.password.replace('"', "\"\""),
     );
-    if let Ok(out) = iris.execute(&scm_check, ns).await {
+    // Whether the probe told us the doc is already writable by us (PROCEED / already checked out).
+    // Only such a "we hold it" outcome is safe to cache — NOT NO_SCM (no source control at all),
+    // where there is no checkout to remember.
+    let mut we_hold_checkout = false;
+    if let Ok(out) = iris.execute_via_generator(&scm_check, ns, client).await {
         let out = out.trim().to_string();
-        if out != "NO_SCM" && !out.is_empty() {
+        // "NO_SCM"/empty → no source control; "PROCEED" → we already hold the checkout.
+        // Both skip the checkout dialog and fall through to do_write below.
+        if out.starts_with("PROCEED") {
+            we_hold_checkout = true;
+        } else if out != "NO_SCM" && !out.is_empty() {
             let parts: Vec<&str> = out.splitn(2, '|').collect();
             let action_code = parts
                 .first()
@@ -381,7 +478,7 @@ async fn handle_put(
                     crate::elicitation::ElicitationAction::Put,
                     Some(content.to_string()),
                     None,
-                    ns.clone(),
+                    ns.to_string(),
                 );
                 return ok_json(serde_json::json!({
                     "success": false,
@@ -397,16 +494,33 @@ async fn handle_put(
         }
     }
 
-    do_write(
+    let result = do_write(
         iris,
         client,
         name,
         content,
         ns,
-        p.compile,
-        p.allow_storage_regeneration,
+        compile,
+        allow_storage_regeneration,
     )
-    .await
+    .await?;
+    // Remember the checkout only when the probe confirmed we hold it AND the write landed, so
+    // the next chained edit skips the probe. Never cache when there is no SCM (nothing to hold).
+    if we_hold_checkout && write_result_succeeded(&result) {
+        checkout_cache.mark(ns, name);
+    }
+    Ok(result)
+}
+
+/// Inspect a `do_write` result and report whether the write succeeded (JSON `success:true`).
+fn write_result_succeeded(result: &rmcp::model::CallToolResult) -> bool {
+    result
+        .content
+        .first()
+        .and_then(|c| c.raw.as_text())
+        .and_then(|t| serde_json::from_str::<serde_json::Value>(&t.text).ok())
+        .map(|v| v["success"] == serde_json::Value::Bool(true))
+        .unwrap_or(false)
 }
 
 async fn do_write(

--- a/crates/iris-agentic-dev-core/src/tools/mod.rs
+++ b/crates/iris-agentic-dev-core/src/tools/mod.rs
@@ -1411,6 +1411,9 @@ pub struct IrisTools {
     pub history: Arc<std::sync::Mutex<VecDeque<ToolCallEntry>>>,
     /// Pending elicitation state for SCM dialogs.
     pub elicitation_store: Arc<ElicitationStore>,
+    /// Session-scoped cache of documents already checked out by us — lets chained
+    /// iris_doc writes skip the pre-write SCM probe (invalidated by SCM actions).
+    pub checkout_cache: Arc<crate::elicitation::CheckoutCache>,
     /// UUID-keyed in-memory log store for progressive disclosure (027).
     pub log_store: Arc<std::sync::Mutex<log_store::LogStore>>,
     /// Session-scoped TTL cache for %Dictionary introspection results (037).
@@ -1444,6 +1447,7 @@ impl IrisTools {
             client,
             history: Arc::new(std::sync::Mutex::new(VecDeque::with_capacity(50))),
             elicitation_store: Arc::new(ElicitationStore::new()),
+            checkout_cache: Arc::new(crate::elicitation::CheckoutCache::new()),
             log_store: Arc::new(std::sync::Mutex::new(log_store::LogStore::new(
                 log_max, log_ttl,
             ))),
@@ -1725,6 +1729,7 @@ impl IrisTools {
             client,
             history: Arc::new(std::sync::Mutex::new(VecDeque::with_capacity(50))),
             elicitation_store: Arc::new(ElicitationStore::new()),
+            checkout_cache: Arc::new(crate::elicitation::CheckoutCache::new()),
             log_store: Arc::new(std::sync::Mutex::new(log_store::LogStore::new(
                 log_max, log_ttl,
             ))),
@@ -2845,7 +2850,14 @@ do ##class(%UnitTest.Manager).RunTest("{pattern}","{flags}","{token}")"#,
         let namespace = interop::resolve_namespace(p.namespace.as_deref(), Some(&iris));
         tracing::info!(namespace = %namespace, "iris_doc");
         let client = self.http_client();
-        let result = doc::handle_iris_doc(&iris, client, p, &self.elicitation_store).await;
+        let result = doc::handle_iris_doc(
+            &iris,
+            client,
+            p,
+            &self.elicitation_store,
+            &self.checkout_cache,
+        )
+        .await;
         self.record_call("iris_doc", Self::call_ok(&result));
         result
     }
@@ -4260,9 +4272,14 @@ Methods:
         Parameters(p): Parameters<ScmParams>,
     ) -> Result<CallToolResult, McpError> {
         let iris = self.get_iris_reloaded().await?;
-        let result =
-            scm::handle_iris_source_control(&iris, self.http_client(), p, &self.elicitation_store)
-                .await;
+        let result = scm::handle_iris_source_control(
+            &iris,
+            self.http_client(),
+            p,
+            &self.elicitation_store,
+            &self.checkout_cache,
+        )
+        .await;
         self.record_call("iris_source_control", Self::call_ok(&result));
         result
     }

--- a/crates/iris-agentic-dev-core/src/tools/scm.rs
+++ b/crates/iris-agentic-dev-core/src/tools/scm.rs
@@ -10,20 +10,45 @@ fn ok_json(v: serde_json::Value) -> Result<rmcp::model::CallToolResult, rmcp::Er
         rmcp::model::Content::text(v.to_string()),
     ]))
 }
+/// Genuine failures go through the fork's single failure envelope (issue #2):
+/// {success:false, error_code, error} + isError on the wire. Elicitation dialogs
+/// are NOT failures and stay ok_json (success:false + elicitation_required:true).
 fn err_json(code: &str, msg: &str) -> Result<rmcp::model::CallToolResult, rmcp::ErrorData> {
     crate::tools::envelope::fail(code, msg)
 }
 
-/// Known menu item names to probe via OnMenuItem.
-pub const KNOWN_MENU_ITEMS: &[&str] = &[
-    "CheckOut",
-    "UndoCheckOut",
-    "CheckIn",
-    "GetLatest",
-    "Status",
-    "History",
-    "AddToSourceControl",
-];
+/// Menu prefix used for source control actions.
+pub const SCM_MENU: &str = "%SourceMenu";
+
+/// SCM menu actions as reported by %Studio.SourceControl.Interface:MenuItems.
+#[derive(Debug, PartialEq, Eq)]
+pub enum ScmAction {
+    CheckOut,
+    UndoCheckout,
+    CheckIn,
+    GetLatest,
+    AddToSourceControl,
+    Diff,
+    Disconnect,
+    Reconnect,
+    Unknown(String),
+}
+
+impl ScmAction {
+    pub fn from_id(id: &str) -> Self {
+        match id.trim_start_matches('%') {
+            "CheckOut" => Self::CheckOut,
+            "UndoCheckout" => Self::UndoCheckout,
+            "CheckIn" => Self::CheckIn,
+            "GetLatest" => Self::GetLatest,
+            "AddToSourceControl" => Self::AddToSourceControl,
+            "Diff" => Self::Diff,
+            "Disconnect" => Self::Disconnect,
+            "Reconnect" => Self::Reconnect,
+            other => Self::Unknown(other.to_string()),
+        }
+    }
+}
 
 #[derive(Debug, Deserialize, JsonSchema)]
 pub struct ScmParams {
@@ -41,11 +66,11 @@ pub struct ScmParams {
 
 async fn xecute(
     iris: &IrisConnection,
-    _client: &reqwest::Client,
+    client: &reqwest::Client,
     code: &str,
     namespace: &str,
 ) -> anyhow::Result<String> {
-    iris.execute(code, namespace).await
+    iris.execute_via_generator(code, namespace, client).await
 }
 
 /// Escape a string for safe interpolation into an ObjectScript double-quoted literal.
@@ -72,9 +97,23 @@ pub async fn handle_iris_source_control(
     client: &reqwest::Client,
     p: ScmParams,
     elicitation_store: &ElicitationStore,
+    checkout_cache: &crate::elicitation::CheckoutCache,
 ) -> Result<rmcp::model::CallToolResult, rmcp::ErrorData> {
+    let raw_doc = p.document.as_deref().unwrap_or("");
+    let doc_owned;
+    let raw_lower = raw_doc.to_ascii_lowercase();
+    let doc = if !raw_doc.is_empty()
+        && !raw_lower.ends_with(".cls")
+        && !raw_lower.ends_with(".mac")
+        && !raw_lower.ends_with(".inc")
+        && !raw_lower.ends_with(".int")
+    {
+        doc_owned = format!("{}.cls", raw_doc);
+        doc_owned.as_str()
+    } else {
+        raw_doc
+    };
     let namespace = crate::tools::interop::resolve_namespace(p.namespace.as_deref(), Some(iris));
-    let doc = p.document.as_deref().unwrap_or("");
     let ns = &namespace;
 
     // Handle elicitation resume
@@ -87,12 +126,12 @@ pub async fn handle_iris_source_control(
         };
         elicitation_store.clear(eid);
         let action_id = pending.scm_action_id.as_deref().unwrap_or("");
-        let after_code = format!(
-            "set sc=##class(%Studio.SourceControl.Base).AfterUserAction(0,\"{}\",\"{}\",{},\"{}\") write $system.Status.GetErrorText(sc)",
-            os_quote(action_id),
-            os_quote(&pending.document),
-            if answer == "yes" { "1" } else { "0" },
-            os_quote(answer),
+        let after_code = after_user_action_code(
+            action_id,
+            &pending.document,
+            answer,
+            &iris.username,
+            &iris.password,
         );
         let out = match xecute(iris, client, &after_code, &pending.namespace).await {
             Ok(o) => o,
@@ -107,10 +146,14 @@ pub async fn handle_iris_source_control(
                 } else {
                     ("SCM_UNAVAILABLE", msg)
                 };
-                return crate::tools::envelope::fail(ec, &emsg);
+                return err_json(ec, &emsg);
             }
         };
-        if out.is_empty() || out.starts_with('$') {
+        let out = out.lines().next().unwrap_or("").trim().to_string();
+        if out.is_empty() {
+            // Any resumed SCM action (checkout/undo/checkin/disconnect) changes checkout state,
+            // so drop the cached entry — the next write re-probes and re-caches if still ours.
+            checkout_cache.invalidate(&pending.namespace, &pending.document);
             return ok_json(
                 serde_json::json!({"success": true, "document": pending.document, "action_id": action_id}),
             );
@@ -120,69 +163,130 @@ pub async fn handle_iris_source_control(
 
     match p.action.as_str() {
         "status" => {
-            // Check if SCM is installed
-            let doc_q = os_quote(doc);
-            let check_code = format!(
-                "set obj=##class(%Studio.SourceControl.Base).%GetImplementationObject(\"{doc_q}\") if '$IsObject(obj) {{ write \"UNCONTROLLED\" }} else {{ set editable=obj.IsEditable(\"{doc_q}\") write editable_\"|\"_$get(obj.Owner) }}"
-            );
-            let out = xecute(iris, client, &check_code, ns)
-                .await
-                .unwrap_or_else(|_| "UNCONTROLLED".to_string());
-            if out.trim() == "UNCONTROLLED" || out.is_empty() {
-                return ok_json(
-                    serde_json::json!({"success":true,"controlled":false,"editable":true,"locked":false,"owner":null}),
+            let check_code = status_check_code(doc, &iris.username, &iris.password);
+            let raw = match xecute(iris, client, &check_code, ns).await {
+                Ok(o) => o,
+                Err(e) => {
+                    // A transport/exec failure must NOT be reported as "editable" — that is the
+                    // very inconsistency this path used to have. Surface it honestly.
+                    return err_json("SCM_UNAVAILABLE", &e.to_string());
+                }
+            };
+            // The executor may append "ERROR($ZERROR): …" on later lines — find the SCMSTATUS
+            // sentinel line rather than assuming it is the first one.
+            let parsed = raw.lines().find_map(parse_scm_status_line);
+            let Some((is_in_sc, has_co, has_undo, has_add, owner)) = parsed else {
+                // No SCMSTATUS sentinel. Before giving up, try the provider's native
+                // "checked out by user '<name>'" notice, which short-circuits the probe (often
+                // with a <PROTECT>) before the sentinel is written. That notice still tells us the
+                // document is controlled and locked by another user — report that instead of an
+                // opaque SCM_UNAVAILABLE.
+                if let Some((other_owner, ts)) = parse_checked_out_by(&raw) {
+                    let checked_out_by_me = other_owner.eq_ignore_ascii_case(&iris.username);
+                    let mut resp = serde_json::json!({
+                        "success": true,
+                        "controlled": true,
+                        "editable": checked_out_by_me,
+                        "locked": !checked_out_by_me,
+                        "checked_out_by_me": checked_out_by_me,
+                        "owner": other_owner,
+                    });
+                    if let Some(ts) = ts {
+                        resp["checked_out_at"] = serde_json::Value::String(ts);
+                    }
+                    return ok_json(resp);
+                }
+                // Echo the raw IRIS output (truncated) so the actual failure — a <PROTECT>, an
+                // authentication banner, an empty body — is diagnosable instead of being flattened
+                // into an opaque "no status signal".
+                let raw_trunc: String = raw.trim().chars().take(600).collect();
+                return crate::tools::envelope::fail_with(
+                    "SCM_UNAVAILABLE",
+                    "Could not determine source control status (no SCMSTATUS sentinel in IRIS output)",
+                    serde_json::json!({ "raw_output": raw_trunc }),
                 );
-            }
-            let (editable_flag, owner) = parse_action_msg(&out);
-            let editable = editable_flag == 1;
-            let owner = Some(owner).filter(|s| !s.is_empty());
+            };
+            let status =
+                derive_scm_status(is_in_sc, has_co, has_undo, has_add, &owner, &iris.username);
+            let Some(status) = status else {
+                return err_json(
+                    "SCM_UNAVAILABLE",
+                    "Source control status is indeterminate for this document",
+                );
+            };
             ok_json(serde_json::json!({
                 "success": true,
-                "controlled": true,
-                "editable": editable,
-                "locked": !editable,
-                "owner": owner,
+                "controlled": status.controlled,
+                "editable": status.editable,
+                "locked": status.locked,
+                "checked_out_by_me": status.checked_out_by_me,
+                "owner": status.owner,
             }))
         }
 
         "menu" => {
-            let doc_q = os_quote(doc);
+            let code = menu_all_items_code(doc, &iris.username, &iris.password);
+            let raw = xecute(iris, client, &code, ns).await.unwrap_or_default();
             let mut actions = vec![];
-            for &item in KNOWN_MENU_ITEMS {
-                let code = format!(
-                    "set enabled=0 set displayName=\"{item}\" set sc=##class(%Studio.SourceControl.Base).OnMenuItem(\"%SourceMenu,{item}\",\"{doc_q}\",\"\",.enabled,.displayName) write enabled_\"|\"_displayName"
-                );
-                let out = xecute(iris, client, &code, ns).await.unwrap_or_default();
-                let (enabled_flag, label) = parse_action_msg(&out);
-                if enabled_flag == 1 {
-                    let label = if label.is_empty() {
-                        item.to_string()
-                    } else {
-                        label.to_string()
-                    };
-                    actions.push(serde_json::json!({"id": item, "label": label, "enabled": true}));
+            for line in raw.lines() {
+                let line = line.trim();
+                if line == "SCM_UNAVAILABLE" || line.is_empty() || line.starts_with("ERROR") {
+                    continue;
+                }
+                // format: "name|enabled"
+                let mut parts = line.splitn(2, '|');
+                let name = parts.next().unwrap_or("").trim();
+                let enabled: u8 = parts
+                    .next()
+                    .and_then(|s| s.trim().parse().ok())
+                    .unwrap_or(0);
+                let checkin_allowed = std::env::var("IRIS_SCM_ALLOW_CHECKIN")
+                    .map(|v| matches!(v.to_ascii_lowercase().as_str(), "1" | "true" | "yes"))
+                    .unwrap_or(false);
+                if enabled == 1
+                    && !name.is_empty()
+                    && (ScmAction::from_id(name) != ScmAction::CheckIn || checkin_allowed)
+                {
+                    actions.push(serde_json::json!({"id": name, "label": name, "enabled": true}));
                 }
             }
             ok_json(serde_json::json!({"success": true, "document": doc, "actions": actions}))
         }
 
         "checkout" => {
-            let code = user_action_code("CheckOut", doc);
-            let out = match xecute(iris, client, &code, ns).await {
+            let code = user_action_code("%CheckOut", doc, &iris.username, &iris.password);
+            let raw = match xecute(iris, client, &code, ns).await {
                 Ok(o) => o,
-                Err(e) => {
-                    let msg = e.to_string();
-                    let (ec, emsg) = if msg == "DOCKER_REQUIRED" {
-                        ("DOCKER_REQUIRED", "SCM checkout requires docker exec. Set IRIS_CONTAINER=<container_name>.".to_string())
-                    } else {
-                        ("SCM_UNAVAILABLE", msg)
-                    };
-                    return crate::tools::envelope::fail(ec, &emsg);
-                }
+                Err(e) => return err_json("SCM_UNAVAILABLE", &e.to_string()),
             };
-            let (action_code, msg) = parse_action_msg(&out);
+            let out = raw.lines().next().unwrap_or("").trim();
+            if out == "SCM_UNAVAILABLE" {
+                return err_json(
+                    "SCM_UNAVAILABLE",
+                    "Source control session could not be initialized",
+                );
+            }
+            let (action_code, msg) = parse_action_msg(out);
 
             if action_code == 0 {
+                // action=0 means UserAction wants no confirmation dialog — but the checkout
+                // is NOT actually committed until AfterUserAction runs. Reporting success
+                // here on UserAction alone was a false positive: the item looked checked out
+                // but a later write failed with ERROR #5865. Finalize with AfterUserAction so
+                // the checkout genuinely persists server-side before we claim success.
+                let after_code =
+                    after_user_action_code("%CheckOut", doc, "yes", &iris.username, &iris.password);
+                match xecute(iris, client, &after_code, ns).await {
+                    Ok(o) => {
+                        let aout = o.lines().next().unwrap_or("").trim().to_string();
+                        if !aout.is_empty() && aout != "SCM_UNAVAILABLE" {
+                            return err_json("SCM_CHECKOUT_FAILED", &aout);
+                        }
+                    }
+                    Err(e) => return err_json("SCM_UNAVAILABLE", &e.to_string()),
+                }
+                // Checkout committed — cache it so a following iris_doc write skips the probe.
+                checkout_cache.mark(ns, doc);
                 return ok_json(
                     serde_json::json!({"success": true, "document": doc, "editable": true}),
                 );
@@ -192,7 +296,7 @@ pub async fn handle_iris_source_control(
                 doc,
                 ElicitationAction::ScmExecute,
                 None,
-                Some("CheckOut".to_string()),
+                Some("%CheckOut".to_string()),
                 ns.clone(),
             );
             ok_json(serde_json::json!({
@@ -206,25 +310,40 @@ pub async fn handle_iris_source_control(
 
         "execute" => {
             let action_id = p.action_id.as_deref().unwrap_or("");
-            let code = user_action_code(action_id, doc);
-            let out = match xecute(iris, client, &code, ns).await {
-                Ok(o) => o,
-                Err(e) => {
-                    let msg = e.to_string();
-                    let (ec, emsg) = if msg == "DOCKER_REQUIRED" {
-                        ("DOCKER_REQUIRED", "SCM execute requires docker exec. Set IRIS_CONTAINER=<container_name>.".to_string())
-                    } else {
-                        ("SCM_UNAVAILABLE", msg)
-                    };
-                    return crate::tools::envelope::fail(ec, &emsg);
+            if ScmAction::from_id(action_id) == ScmAction::CheckIn {
+                let allowed = std::env::var("IRIS_SCM_ALLOW_CHECKIN")
+                    .map(|v| matches!(v.to_ascii_lowercase().as_str(), "1" | "true" | "yes"))
+                    .unwrap_or(false);
+                if !allowed {
+                    return err_json(
+                        "CHECKIN_BLOCKED",
+                        "CheckIn is disabled by default. Set IRIS_SCM_ALLOW_CHECKIN=1 to enable.",
+                    );
                 }
+            }
+            let code = user_action_code(action_id, doc, &iris.username, &iris.password);
+            let raw = match xecute(iris, client, &code, ns).await {
+                Ok(o) => o,
+                Err(e) => return err_json("SCM_UNAVAILABLE", &e.to_string()),
             };
-            let (action_code, msg) = parse_action_msg(&out);
+            let out = raw.lines().next().unwrap_or("").trim();
+            if out == "SCM_UNAVAILABLE" {
+                return err_json(
+                    "SCM_UNAVAILABLE",
+                    "Source control session could not be initialized",
+                );
+            }
+            let (action_code, msg) = parse_action_msg(out);
 
             match action_code {
-                0 => ok_json(
-                    serde_json::json!({"success": true, "document": doc, "action_id": action_id}),
-                ),
+                0 => {
+                    // A completed execute (undo checkout / checkin / disconnect / …) changes
+                    // checkout state — drop any cached entry so the next write re-probes.
+                    checkout_cache.invalidate(ns, doc);
+                    ok_json(
+                        serde_json::json!({"success": true, "document": doc, "action_id": action_id}),
+                    )
+                }
                 1 => {
                     // Yes/No confirmation
                     let eid = elicitation_store.insert(
@@ -272,13 +391,255 @@ pub async fn handle_iris_source_control(
     }
 }
 
-/// Build the ObjectScript snippet that invokes `%Studio.SourceControl.Base:UserAction`
-/// for a given menu item id and document, writing "action|msg" to the output stream.
-fn user_action_code(action_id: &str, doc: &str) -> String {
+/// Build the ObjectScript snippet that determines SCM status for a document.
+/// Uses GetStatus for controlled/uncontrolled, then MenuItems to deduce editable/owner
+/// since many SCM implementations don't populate GetStatus's editable/owner fields.
+///
+/// Emits one structured, pipe-delimited line so the caller (`derive_scm_status`) can combine
+/// every available signal instead of relying on a single heuristic:
+///   `SCMSTATUS|<isErr>|<isInSC>|<editable>|<hasCheckOut>|<hasUndoCheckout>|<hasAddToSC>|<owner>`
+/// where the six middle fields are 0/1 and `owner` is the GetStatus owner (may be empty).
+/// The `SCMSTATUS` sentinel lets the caller distinguish a real result from a transport/error
+/// line (the executor may append `ERROR($ZERROR): …` on subsequent lines).
+fn status_check_code(doc: &str, username: &str, password: &str) -> String {
+    let doc_q = os_quote(doc);
+    let user_q = os_quote(username);
+    let pass_q = os_quote(password);
+    // Each risky step is wrapped in TRY/CATCH so a runtime error (SourceControlCreate failing,
+    // GetStatus <PROTECT>, an SCM provider that has no MenuItems query, …) can never abort the
+    // job before the SCMSTATUS sentinel is written. Without this, any partial failure produced
+    // "no status signal returned" instead of a usable (possibly indeterminate) status.
     format!(
-        "set action=0 set target=\"\" set msg=\"\" set reload=0 set sc=##class(%Studio.SourceControl.Base).UserAction(0,\"%SourceMenu,{}\",\"{}\",\"\",.action,.target,.msg,.reload) write action_\"|\"_msg",
+        "set isErr=0,isInSC=0,editable=0,isCheckedOut=0,owner=\"\" \
+         set hasCheckOut=0,hasUndoCheckout=0,hasAddToSC=0 \
+         try {{ set sc=##class(%Studio.SourceControl.Interface).SourceControlCreate(\"{user_q}\",\"{pass_q}\",.created,.flags,.outuser) }} catch {{ set isErr=1 }} \
+         try {{ set sc=##class(%Studio.SourceControl.Interface).GetStatus(\"{doc_q}\",.isInSC,.editable,.isCheckedOut,.owner) if $system.Status.IsError(sc) {{ set isErr=1 }} }} catch {{ set isErr=1 }} \
+         try {{ \
+           set rset=##class(%ResultSet).%New(\"%Studio.SourceControl.Interface:MenuItems\") \
+           set sc=rset.Execute(\"%SourceMenu\",\"{doc_q}\",\"\") \
+           while rset.Next() {{ \
+             set itemName=rset.GetData(1),itemEnabled=rset.GetData(2) \
+             if itemEnabled&&(itemName=\"%CheckOut\") {{ set hasCheckOut=1 }} \
+             if itemEnabled&&(itemName=\"%UndoCheckout\") {{ set hasUndoCheckout=1 }} \
+             if itemEnabled&&(itemName=\"%AddToSourceControl\") {{ set hasAddToSC=1 }} \
+           }} \
+         }} catch {{ set isErr=1 }} \
+         write \"SCMSTATUS|\"_isErr_\"|\"_isInSC_\"|\"_editable_\"|\"_hasCheckOut_\"|\"_hasUndoCheckout_\"|\"_hasAddToSC_\"|\"_owner"
+    )
+}
+
+/// Resolved SCM status for a document, derived from the combined `status_check_code` signals.
+#[derive(Debug, PartialEq, Eq)]
+pub struct ScmStatus {
+    /// The document is under source control.
+    pub controlled: bool,
+    /// The document can be written right now (uncontrolled, or checked out by the current user).
+    pub editable: bool,
+    /// The document is locked by someone else (controlled, checked out, not by us).
+    pub locked: bool,
+    /// The current user holds the checkout.
+    pub checked_out_by_me: bool,
+    /// The checkout owner, when known (the current user if we hold it, else GetStatus owner).
+    pub owner: Option<String>,
+}
+
+/// Combine every SCM signal into a coherent status.
+///
+/// Decision logic:
+/// - With zero signal (no in-SC flag, no menu items, no owner) there is no SCM configured for
+///   this namespace/document → uncontrolled, freely editable. (This fork deliberately keeps
+///   the pre-aa937dd behavior: dev instances without any source control are the common case,
+///   and reporting SCM_UNAVAILABLE for every one of them was the real regression.)
+/// - `uncontrolled` ⇔ the menu offers `%AddToSourceControl` (you can only add a document that
+///   is not yet under source control). Keyed on this positive signal rather than on GetStatus's
+///   `isInSC`, which some providers leave unpopulated.
+/// - checked-out-by-me ⇔ `%UndoCheckout` is enabled (only the holder can undo their checkout).
+/// - available-to-checkout ⇔ controlled and `%CheckOut` is enabled (free to take, not locked).
+/// - locked-by-other ⇔ controlled and neither CheckOut nor UndoCheckout is available
+///   (someone else holds it).
+fn derive_scm_status(
+    is_in_sc: bool,
+    has_checkout: bool,
+    has_undo_checkout: bool,
+    has_add_to_sc: bool,
+    owner: &str,
+    current_user: &str,
+) -> Option<ScmStatus> {
+    let owner_opt = Some(owner.trim().to_string()).filter(|s| !s.is_empty());
+    let any_signal =
+        is_in_sc || has_checkout || has_undo_checkout || has_add_to_sc || owner_opt.is_some();
+    // No signal at all → no SCM configured, document is freely editable.
+    // (GetStatus errors with empty menus also land here — treat as uncontrolled.)
+    if !any_signal {
+        return Some(ScmStatus {
+            controlled: false,
+            editable: true,
+            locked: false,
+            checked_out_by_me: false,
+            owner: None,
+        });
+    }
+
+    // A document is uncontrolled iff we are offered the action to add it to source control.
+    if has_add_to_sc {
+        return Some(ScmStatus {
+            controlled: false,
+            editable: true,
+            locked: false,
+            checked_out_by_me: false,
+            owner: None,
+        });
+    }
+
+    if has_undo_checkout {
+        // We hold the checkout → writable by us.
+        return Some(ScmStatus {
+            controlled: true,
+            editable: true,
+            locked: false,
+            checked_out_by_me: true,
+            owner: owner_opt.or_else(|| Some(current_user.to_string())),
+        });
+    }
+
+    if has_checkout {
+        // Controlled and free to check out — not currently editable, but not locked by anyone.
+        return Some(ScmStatus {
+            controlled: true,
+            editable: false,
+            locked: false,
+            checked_out_by_me: false,
+            owner: owner_opt,
+        });
+    }
+
+    // Controlled, can neither check out nor undo → locked by another user.
+    Some(ScmStatus {
+        controlled: true,
+        editable: false,
+        locked: true,
+        checked_out_by_me: false,
+        owner: owner_opt,
+    })
+}
+
+/// Parse the `SCMSTATUS|…` line emitted by `status_check_code` into
+/// `(isInSC, hasCheckOut, hasUndoCheckout, hasAddToSC, owner)`. Returns `None` if the line is
+/// missing the sentinel or has the wrong arity (e.g. a transport error was returned instead).
+///
+/// The leading `isErr` and the `editable` fields are consumed but not returned: `isErr` only
+/// gates nothing now (absence of signal is the real "unknown" test), and GetStatus's `editable`
+/// is advisory — the menu action signals are authoritative.
+fn parse_scm_status_line(line: &str) -> Option<(bool, bool, bool, bool, String)> {
+    // SCMSTATUS|isErr|isInSC|editable|hasCheckOut|hasUndoCheckout|hasAddToSC|owner
+    let mut parts = line.trim().splitn(8, '|');
+    if parts.next()? != "SCMSTATUS" {
+        return None;
+    }
+    let flag = |p: Option<&str>| p.map(|s| s.trim() != "0" && !s.trim().is_empty());
+    let _is_err = flag(parts.next())?;
+    let is_in_sc = flag(parts.next())?;
+    let _editable = flag(parts.next())?;
+    let has_checkout = flag(parts.next())?;
+    let has_undo_checkout = flag(parts.next())?;
+    let has_add_to_sc = flag(parts.next())?;
+    let owner = parts.next().unwrap_or("").trim().to_string();
+    Some((
+        is_in_sc,
+        has_checkout,
+        has_undo_checkout,
+        has_add_to_sc,
+        owner,
+    ))
+}
+
+/// Fallback owner detection from the SCM provider's native `checked out by user '<name>'` notice.
+///
+/// Some source-control providers emit a native `NOTICE: … is currently checked out by user
+/// 'xxx', and was last updated at 2026-07-07 12:34:56` message (often followed by a `<PROTECT>`)
+/// that short-circuits `status_check_code` before the `SCMSTATUS|` sentinel is ever written. In
+/// that case `parse_scm_status_line` finds nothing, yet the raw output already tells us the
+/// document is controlled and locked by another user — so we scrape it here instead of reporting
+/// an opaque `SCM_UNAVAILABLE`.
+///
+/// The regex is tolerant: the message may be repeated (the probe loops) and truncated mid-line
+/// (before `updated at …`). We take the first match, ignore repetitions, and treat the timestamp
+/// as optional. Returns `(owner, Option<timestamp>)`.
+fn parse_checked_out_by(raw: &str) -> Option<(String, Option<String>)> {
+    use std::sync::OnceLock;
+    static RE: OnceLock<regex::Regex> = OnceLock::new();
+    let re = RE.get_or_init(|| {
+        // "checked out by user 'xxx'" — timestamp captured only if the line isn't truncated.
+
+        regex::Regex::new(r"checked out by user '([^']+)'(?:.*?updated at ([0-9-]+ [0-9:]+))?")
+            .expect("static SCM checked-out regex is valid")
+    });
+    let caps = re.captures(raw)?;
+    let owner = caps.get(1)?.as_str().trim().to_string();
+    if owner.is_empty() {
+        return None;
+    }
+    let ts = caps.get(2).map(|m| m.as_str().trim().to_string());
+    Some((owner, ts))
+}
+
+/// Prefix that initializes a SCM session via SourceControlCreate and binds obj=%SourceControl.
+/// All SCM methods are instance methods — they require an active %SourceControl object.
+fn scm_init_prefix(username: &str, password: &str) -> String {
+    let user_q = os_quote(username);
+    let pass_q = os_quote(password);
+    format!(
+        "set sc=##class(%Studio.SourceControl.Interface).SourceControlCreate(\"{user_q}\",\"{pass_q}\",.created,.flags,.outuser) \
+         set obj=$get(%SourceControl) \
+         if '$IsObject(obj) {{ write \"SCM_UNAVAILABLE\" quit }} "
+    )
+}
+
+/// Build the ObjectScript snippet that invokes `UserAction` on the SCM instance,
+/// writing "action|msg" to the output stream.
+fn user_action_code(action_id: &str, doc: &str, username: &str, password: &str) -> String {
+    let prefix = scm_init_prefix(username, password);
+    format!(
+        "{prefix}set action=0 set target=\"\" set msg=\"\" set reload=0 \
+         set sc=obj.UserAction(0,\"%SourceMenu,{}\",\"{}\",\"\",.action,.target,.msg,.reload) \
+         write action_\"|\"_$select(msg'=\"\":msg,target'=\"\":target,1:\"\")",
         os_quote(action_id),
         os_quote(doc),
+    )
+}
+
+/// Build the ObjectScript snippet that re-runs `UserAction` then immediately calls
+/// `AfterUserAction` in the same job, so %SourceControl state is preserved.
+pub(crate) fn after_user_action_code(
+    action_id: &str,
+    doc: &str,
+    answer: &str,
+    username: &str,
+    password: &str,
+) -> String {
+    let prefix = scm_init_prefix(username, password);
+    let answer_int = if answer == "yes" { "1" } else { "0" };
+    let action_id_q = os_quote(action_id);
+    let doc_q = os_quote(doc);
+    format!(
+        "{prefix}\
+         set action=0 set target=\"\" set msg=\"\" set reload=0 \
+         set sc=obj.UserAction(0,\"%SourceMenu,{action_id_q}\",\"{doc_q}\",\"\",.action,.target,.msg,.reload) \
+         set sc=obj.AfterUserAction(0,\"%SourceMenu,{action_id_q}\",\"{doc_q}\",{answer_int},\"\") \
+         write $system.Status.GetErrorText(sc)"
+    )
+}
+
+/// Build a single ObjectScript snippet that queries all enabled SCM menu items via
+/// the MenuItems ResultSet, writing one "name|enabled|displayName" line per item.
+fn menu_all_items_code(doc: &str, username: &str, password: &str) -> String {
+    let prefix = scm_init_prefix(username, password);
+    let doc_q = os_quote(doc);
+    format!(
+        "{prefix}\
+         set rset=##class(%ResultSet).%New(\"%Studio.SourceControl.Interface:MenuItems\") \
+         set sc=rset.Execute(\"%SourceMenu\",\"{doc_q}\",\"\") \
+         while rset.Next() {{ write rset.GetData(1)_\"|\"_rset.GetData(2),! }}"
     )
 }
 
@@ -306,6 +667,16 @@ mod tests {
     #[test]
     fn test_os_quote_empty() {
         assert_eq!(os_quote(""), "");
+    }
+    #[test]
+    fn test_os_quote_mixed_quote_and_newline() {
+        // String with both double-quote and newline
+        assert_eq!(os_quote("say \"hi\"\nbye"), "say \"\"hi\"\"$Char(10)bye");
+    }
+    #[test]
+    fn test_os_quote_cr_and_newline() {
+        // String with carriage return AND newline
+        assert_eq!(os_quote("line\r\nend"), "line$Char(13)$Char(10)end");
     }
 
     // ── parse_action_msg ─────────────────────────────────────────────────────
@@ -344,7 +715,7 @@ mod tests {
     // ── user_action_code ──────────────────────────────────────────────────────
     #[test]
     fn test_user_action_code_no_backslash_quote() {
-        let code = user_action_code("CheckOut", "MyApp.Patient.cls");
+        let code = user_action_code("CheckOut", "MyApp.Patient.cls", "user", "pass");
         assert!(
             !code.contains("\\\""),
             "must use ObjectScript quoting, not backslash: {}",
@@ -363,7 +734,7 @@ mod tests {
     }
     #[test]
     fn test_user_action_code_escapes_quotes_in_action() {
-        let code = user_action_code("Check\"Out", "Doc.cls");
+        let code = user_action_code("Check\"Out", "Doc.cls", "user", "pass");
         assert!(
             code.contains("\"\""),
             "double-quote must become \"\": {}",
@@ -373,7 +744,7 @@ mod tests {
     }
     #[test]
     fn test_user_action_code_escapes_newline_in_doc() {
-        let code = user_action_code("CheckOut", "Doc\nwith\nnewlines.cls");
+        let code = user_action_code("CheckOut", "Doc\nwith\nnewlines.cls", "user", "pass");
         assert!(
             code.contains("$Char(10)"),
             "newline must become $Char(10): {}",
@@ -381,11 +752,565 @@ mod tests {
         );
     }
 
-    // ── KNOWN_MENU_ITEMS ──────────────────────────────────────────────────────
+    // ── status_check_code ─────────────────────────────────────────────────────
     #[test]
-    fn test_known_menu_items_has_checkout() {
-        assert!(KNOWN_MENU_ITEMS.contains(&"CheckOut"));
-        assert!(KNOWN_MENU_ITEMS.contains(&"CheckIn"));
-        assert!(KNOWN_MENU_ITEMS.contains(&"GetLatest"));
+    fn test_status_check_code_uses_get_status() {
+        let code = status_check_code("MyApp.Patient.cls", "user", "pass");
+        assert!(
+            code.contains("%Studio.SourceControl.Interface"),
+            "must use Interface class: {code}"
+        );
+        assert!(code.contains("GetStatus"), "must call GetStatus: {code}");
+        assert!(
+            code.contains("SourceControlCreate"),
+            "must init session: {code}"
+        );
+        assert!(
+            !code.contains("%GetImplementationObject"),
+            "must not use removed method: {code}"
+        );
+    }
+
+    #[test]
+    fn test_status_check_code_contains_doc() {
+        let code = status_check_code("MyApp.Patient.cls", "user", "pass");
+        assert!(
+            code.contains("MyApp.Patient.cls"),
+            "must embed document name: {code}"
+        );
+    }
+
+    #[test]
+    fn test_status_check_code_escapes_quotes_in_doc() {
+        let code = status_check_code("My\"App.cls", "user", "pass");
+        assert!(
+            code.contains("\"\""),
+            "double-quote must become \"\": {code}"
+        );
+        assert!(!code.contains("\\\""), "no backslash-quote: {code}");
+    }
+
+    #[test]
+    fn test_status_check_code_escapes_quotes_in_credentials() {
+        let code = status_check_code("Any.cls", "us\"er", "p\"ass");
+        assert!(
+            code.contains("\"\""),
+            "double-quote in credentials must be escaped: {code}"
+        );
+    }
+
+    #[test]
+    fn test_status_check_code_emits_structured_sentinel() {
+        let code = status_check_code("Any.cls", "user", "pass");
+        assert!(
+            code.contains("SCMSTATUS|"),
+            "must emit the SCMSTATUS sentinel line: {code}"
+        );
+    }
+
+    #[test]
+    fn test_status_check_code_uses_menu_items_for_checkout_state() {
+        let code = status_check_code("Any.cls", "user", "pass");
+        assert!(
+            code.contains("MenuItems"),
+            "must use MenuItems to deduce checkout state: {code}"
+        );
+        assert!(
+            code.contains("%UndoCheckout"),
+            "must check for UndoCheckout to detect checked-out: {code}"
+        );
+        assert!(
+            code.contains("%CheckOut"),
+            "must check for CheckOut availability: {code}"
+        );
+        assert!(
+            code.contains("%AddToSourceControl"),
+            "must check AddToSourceControl to distinguish uncontrolled docs: {code}"
+        );
+    }
+
+    #[test]
+    fn test_status_check_code_contains_username() {
+        let code = status_check_code("Doc.cls", "myuser", "pass");
+        assert!(code.contains("myuser"), "must contain the username: {code}");
+    }
+
+    #[test]
+    fn test_status_check_code_contains_document_name() {
+        let code = status_check_code("MyClass.cls", "user", "pass");
+        assert!(
+            code.contains("MyClass.cls"),
+            "must contain the document name: {code}"
+        );
+    }
+
+    #[test]
+    fn test_status_check_code_contains_scmstatus_sentinel() {
+        let code = status_check_code("Doc.cls", "user", "pass");
+        assert!(
+            code.contains("SCMSTATUS"),
+            "must contain SCMSTATUS sentinel: {code}"
+        );
+    }
+
+    // ── parse_scm_status_line ─────────────────────────────────────────────────
+    #[test]
+    fn test_parse_scm_status_line_full() {
+        let (in_sc, co, undo, add, owner) =
+            parse_scm_status_line("SCMSTATUS|0|1|0|0|0|0|test").unwrap();
+        assert!(in_sc);
+        assert!(!co);
+        assert!(!undo);
+        assert!(!add);
+        assert_eq!(owner, "test");
+    }
+
+    #[test]
+    fn test_parse_scm_status_line_finds_sentinel_amid_noise() {
+        // Executor may prepend/append error lines; find_map over lines must still parse it.
+        let raw = "SCMSTATUS|0|0|0|1|0|1|\nERROR($ZERROR): <ENDOFFILE>";
+        let parsed = raw.lines().find_map(parse_scm_status_line);
+        assert!(parsed.is_some());
+    }
+
+    #[test]
+    fn test_parse_scm_status_line_rejects_non_sentinel() {
+        assert!(parse_scm_status_line("ERROR: something broke").is_none());
+        assert!(parse_scm_status_line("").is_none());
+    }
+
+    #[test]
+    fn test_parse_scm_status_line_with_owner() {
+        // Line with owner field populated
+        let (in_sc, co, undo, add, owner) =
+            parse_scm_status_line("SCMSTATUS|0|1|0|1|1|0|alice").unwrap();
+        assert!(in_sc);
+        assert!(co);
+        assert!(undo);
+        assert!(!add);
+        assert_eq!(owner, "alice");
+    }
+
+    #[test]
+    fn test_parse_scm_status_line_malformed_missing_pipe() {
+        // Malformed line (missing pipe) should return None
+        assert!(parse_scm_status_line("SCMSTATUS0101010").is_none());
+    }
+
+    #[test]
+    fn test_parse_scm_status_line_all_fields_zero() {
+        // Valid line with all boolean fields as 0
+        let (in_sc, co, undo, add, owner) =
+            parse_scm_status_line("SCMSTATUS|0|0|0|0|0|0|").unwrap();
+        assert!(!in_sc);
+        assert!(!co);
+        assert!(!undo);
+        assert!(!add);
+        assert_eq!(owner, "");
+    }
+
+    // ── parse_checked_out_by (native NOTICE fallback, bug #3) ─────────────────
+    #[test]
+    fn test_parse_checked_out_by_with_timestamp() {
+        let raw = "NOTICE: 'My.Class.cls' is currently checked out by user 'todor', and was last updated at 2026-07-07 12:34:56";
+        let (owner, ts) = parse_checked_out_by(raw).unwrap();
+        assert_eq!(owner, "todor");
+        assert_eq!(ts.as_deref(), Some("2026-07-07 12:34:56"));
+    }
+
+    #[test]
+    fn test_parse_checked_out_by_truncated_no_timestamp() {
+        // Real-world case: the message is truncated mid-line before "updated at …".
+        let raw = "...is currently checked out by user 'todor', and was last";
+        let (owner, ts) = parse_checked_out_by(raw).unwrap();
+        assert_eq!(owner, "todor");
+        assert_eq!(ts, None);
+    }
+
+    #[test]
+    fn test_parse_checked_out_by_takes_first_of_repeated() {
+        // The probe loops, so the notice repeats. First occurrence wins.
+        let raw =
+            "checked out by user 'todor', and was last\nchecked out by user 'alice', and was last";
+        let (owner, _) = parse_checked_out_by(raw).unwrap();
+        assert_eq!(owner, "todor");
+    }
+
+    #[test]
+    fn test_parse_checked_out_by_none_when_absent() {
+        assert!(parse_checked_out_by("ERROR: <PROTECT>").is_none());
+        assert!(parse_checked_out_by("").is_none());
+    }
+
+    #[test]
+    fn test_parse_checked_out_by_standard_format_no_timestamp() {
+        // Standard format without timestamp
+        let raw = "checked out by user 'james'";
+        let (owner, ts) = parse_checked_out_by(raw).unwrap();
+        assert_eq!(owner, "james");
+        assert_eq!(ts, None);
+    }
+
+    #[test]
+    fn test_parse_checked_out_by_empty_string() {
+        // Empty string should return None
+        assert!(parse_checked_out_by("").is_none());
+    }
+
+    #[test]
+    fn test_parse_checked_out_by_unrelated_text() {
+        // Unrelated text without the pattern should return None
+        assert!(parse_checked_out_by("This document has some other information").is_none());
+        assert!(
+            parse_checked_out_by("checked out by admin but not in the expected format").is_none()
+        );
+    }
+
+    // ── derive_scm_status ─────────────────────────────────────────────────────
+    #[test]
+    fn test_derive_uncontrolled_is_editable() {
+        // Menu offers AddToSourceControl → uncontrolled, editable.
+        let s = derive_scm_status(false, false, false, true, "", "me").unwrap();
+        assert!(!s.controlled);
+        assert!(s.editable);
+        assert!(!s.locked);
+        assert_eq!(s.owner, None);
+    }
+
+    #[test]
+    fn test_derive_checked_out_by_me() {
+        // In SC, UndoCheckout enabled → I hold it, editable.
+        let s = derive_scm_status(true, false, true, false, "", "me").unwrap();
+        assert!(s.controlled);
+        assert!(s.editable);
+        assert!(!s.locked);
+        assert!(s.checked_out_by_me);
+        assert_eq!(s.owner.as_deref(), Some("me"));
+    }
+
+    #[test]
+    fn test_derive_locked_by_other() {
+        // controlled, no CheckOut and no UndoCheckout available, GetStatus
+        // owner reported → locked by someone else, NOT editable.
+        let s = derive_scm_status(true, false, false, false, "test", "me").unwrap();
+        assert!(s.controlled);
+        assert!(
+            !s.editable,
+            "must NOT claim editable when locked by another user"
+        );
+        assert!(s.locked);
+        assert!(!s.checked_out_by_me);
+        assert_eq!(s.owner.as_deref(), Some("test"));
+    }
+
+    #[test]
+    fn test_derive_controlled_available_to_checkout() {
+        // Controlled, CheckOut offered (free to take) → not editable yet, but not locked.
+        let s = derive_scm_status(true, true, false, false, "", "me").unwrap();
+        assert!(s.controlled);
+        assert!(!s.editable);
+        assert!(!s.locked);
+        assert!(!s.checked_out_by_me);
+    }
+
+    #[test]
+    fn test_derive_locked_by_other_detected_via_owner_only() {
+        // GetStatus didn't report isInSC and the menu offered nothing, but an owner came back →
+        // controlled and locked by that other user (not a false "editable").
+        let s = derive_scm_status(false, false, false, false, "test", "me").unwrap();
+        assert!(s.controlled);
+        assert!(s.locked);
+        assert!(!s.editable);
+        assert_eq!(s.owner.as_deref(), Some("test"));
+    }
+
+    #[test]
+    fn test_derive_no_signal_is_uncontrolled() {
+        // No in-SC flag, no menu items, no owner → no SCM configured in this namespace.
+        // Must return controlled:false, editable:true — NOT None/SCM_UNAVAILABLE, which
+        // was a false-positive error for namespaces that simply have no SCM.
+        let s = derive_scm_status(false, false, false, false, "", "me").unwrap();
+        assert!(!s.controlled);
+        assert!(s.editable);
+        assert!(!s.locked);
+        assert!(!s.checked_out_by_me);
+        assert!(s.owner.is_none());
+    }
+
+    #[test]
+    fn test_derive_resolves_from_menu_signal_alone() {
+        // GetStatus gave nothing, but the menu offered CheckOut → controlled, available.
+        let s = derive_scm_status(false, true, false, false, "", "me").unwrap();
+        assert!(s.controlled);
+        assert!(!s.editable);
+        assert!(!s.locked);
+    }
+
+    // ── SCM_MENU ──────────────────────────────────────────────────────────────
+    #[test]
+    fn test_scm_menu_prefix() {
+        assert_eq!(SCM_MENU, "%SourceMenu");
+    }
+
+    // ── scm_init_prefix ──────────────────────────────────────────────────────
+    #[test]
+    fn test_scm_init_prefix_contains_source_control_create() {
+        let code = scm_init_prefix("user", "pass");
+        assert!(code.contains("SourceControlCreate"), "{code}");
+        assert!(code.contains("%Studio.SourceControl.Interface"), "{code}");
+    }
+
+    #[test]
+    fn test_scm_init_prefix_escapes_quotes_in_user() {
+        let code = scm_init_prefix("us\"er", "pass");
+        assert!(
+            code.contains("\"\""),
+            "double-quote must be doubled: {code}"
+        );
+        assert!(!code.contains("\\\""), "no backslash-quote: {code}");
+    }
+
+    // ── menu_all_items_code ──────────────────────────────────────────────────
+    #[test]
+    fn test_menu_all_items_code_contains_menu_items() {
+        let code = menu_all_items_code("MyApp.cls", "user", "pass");
+        assert!(code.contains("MenuItems"), "{code}");
+    }
+
+    #[test]
+    fn test_menu_all_items_code_contains_doc() {
+        let code = menu_all_items_code("MyApp.Patient.cls", "user", "pass");
+        assert!(code.contains("MyApp.Patient.cls"), "{code}");
+    }
+
+    // ── after_user_action_code ───────────────────────────────────────────────
+    #[test]
+    fn test_after_user_action_code_contains_after_user_action() {
+        let code = after_user_action_code("CheckOut", "MyApp.cls", "yes", "user", "pass");
+        assert!(code.contains("AfterUserAction"), "{code}");
+    }
+
+    #[test]
+    fn test_after_user_action_code_contains_doc() {
+        let code = after_user_action_code("CheckOut", "MyApp.Patient.cls", "no", "user", "pass");
+        assert!(code.contains("MyApp.Patient.cls"), "{code}");
+    }
+
+    #[test]
+    fn test_after_user_action_code_yes_becomes_1() {
+        let code = after_user_action_code("CheckOut", "Doc.cls", "yes", "user", "pass");
+        assert!(code.contains(",1,"), "yes should become 1: {code}");
+    }
+
+    #[test]
+    fn test_after_user_action_code_no_becomes_0() {
+        let code = after_user_action_code("CheckOut", "Doc.cls", "no", "user", "pass");
+        assert!(code.contains(",0,"), "no should become 0: {code}");
+    }
+
+    // ── Document name normalization ──────────────────────────────────────────
+    #[test]
+    fn test_normalize_cls_extension_appended_for_bare_class() {
+        let doc = "MyApp.Patient";
+        let normalized = if !doc.contains('.')
+            || doc.ends_with(".cls")
+            || doc.ends_with(".mac")
+            || doc.ends_with(".inc")
+            || doc.ends_with(".int")
+        {
+            doc.to_string()
+        } else {
+            format!("{}.cls", doc)
+        };
+        // "MyApp.Patient" has a dot but no extension suffix → should get .cls
+        assert_eq!(normalized, "MyApp.Patient.cls");
+    }
+
+    // ── scm_init_prefix additional ───────────────────────────────────────────
+    #[test]
+    fn test_scm_init_prefix_contains_get_source_control() {
+        let code = scm_init_prefix("user", "pass");
+        // Must bind obj to %SourceControl for instance method calls
+        assert!(
+            code.contains("%SourceControl"),
+            "must bind %SourceControl: {code}"
+        );
+    }
+
+    #[test]
+    fn test_scm_init_prefix_writes_scm_unavailable_on_no_obj() {
+        let code = scm_init_prefix("user", "pass");
+        assert!(
+            code.contains("SCM_UNAVAILABLE"),
+            "must write SCM_UNAVAILABLE when obj unavailable: {code}"
+        );
+    }
+
+    #[test]
+    fn test_scm_init_prefix_escapes_quotes_in_password() {
+        let code = scm_init_prefix("user", "p\"ass");
+        assert!(
+            code.contains("\"\""),
+            "double-quote in password must be doubled: {code}"
+        );
+        assert!(
+            !code.contains("\\\""),
+            "no backslash-quote in password: {code}"
+        );
+    }
+
+    // ── user_action_code additional ───────────────────────────────────────────
+    #[test]
+    fn test_user_action_code_contains_user_action() {
+        let code = user_action_code("CheckOut", "MyApp.cls", "user", "pass");
+        assert!(
+            code.contains("UserAction"),
+            "must invoke UserAction: {code}"
+        );
+    }
+
+    #[test]
+    fn test_user_action_code_contains_source_menu() {
+        let code = user_action_code("CheckOut", "MyApp.cls", "user", "pass");
+        assert!(
+            code.contains("%SourceMenu"),
+            "must pass %SourceMenu prefix: {code}"
+        );
+    }
+
+    #[test]
+    fn test_user_action_code_escapes_quotes_in_credentials() {
+        let code = user_action_code("CheckOut", "Doc.cls", "us\"er", "p\"ass");
+        assert!(
+            code.contains("\"\""),
+            "double-quote in credentials must be doubled: {code}"
+        );
+        assert!(!code.contains("\\\""), "no backslash-quote: {code}");
+    }
+
+    // ── menu_all_items_code additional ────────────────────────────────────────
+    #[test]
+    fn test_menu_all_items_code_contains_source_menu() {
+        let code = menu_all_items_code("MyApp.cls", "user", "pass");
+        assert!(
+            code.contains("%SourceMenu"),
+            "must pass %SourceMenu to Execute: {code}"
+        );
+    }
+
+    #[test]
+    fn test_menu_all_items_code_escapes_quotes_in_doc() {
+        let code = menu_all_items_code("My\"App.cls", "user", "pass");
+        assert!(
+            code.contains("\"\""),
+            "double-quote in doc must be doubled: {code}"
+        );
+        assert!(!code.contains("\\\""), "no backslash-quote: {code}");
+    }
+
+    #[test]
+    fn test_menu_all_items_code_contains_source_control_create() {
+        let code = menu_all_items_code("MyApp.cls", "user", "pass");
+        assert!(
+            code.contains("SourceControlCreate"),
+            "must init session: {code}"
+        );
+    }
+
+    // ── after_user_action_code additional ────────────────────────────────────
+    #[test]
+    fn test_after_user_action_code_contains_source_menu() {
+        let code = after_user_action_code("CheckOut", "MyApp.cls", "yes", "user", "pass");
+        assert!(
+            code.contains("%SourceMenu"),
+            "must pass %SourceMenu: {code}"
+        );
+    }
+
+    #[test]
+    fn test_after_user_action_code_contains_user_action() {
+        let code = after_user_action_code("CheckOut", "MyApp.cls", "yes", "user", "pass");
+        assert!(
+            code.contains("UserAction"),
+            "must call UserAction first: {code}"
+        );
+    }
+
+    #[test]
+    fn test_after_user_action_code_writes_error_text() {
+        let code = after_user_action_code("CheckOut", "MyApp.cls", "yes", "user", "pass");
+        assert!(
+            code.contains("GetErrorText"),
+            "must write error text from AfterUserAction: {code}"
+        );
+    }
+
+    // ── parse_action_msg edge cases ───────────────────────────────────────────
+    #[test]
+    fn test_parse_action_msg_empty_string() {
+        let (code, msg) = parse_action_msg("");
+        assert_eq!(code, 0);
+        assert_eq!(msg, "");
+    }
+
+    #[test]
+    fn test_parse_action_msg_whitespace_trimmed() {
+        let (code, msg) = parse_action_msg("  1  |  some msg  ");
+        assert_eq!(code, 1);
+        assert_eq!(msg, "some msg");
+    }
+
+    // ── ScmAction ─────────────────────────────────────────────────────────────
+    #[test]
+    fn test_scm_action_from_id() {
+        assert_eq!(ScmAction::from_id("CheckOut"), ScmAction::CheckOut);
+        assert_eq!(ScmAction::from_id("%CheckIn"), ScmAction::CheckIn);
+        assert_eq!(ScmAction::from_id("%GetLatest"), ScmAction::GetLatest);
+        assert_eq!(
+            ScmAction::from_id("Unknown"),
+            ScmAction::Unknown("Unknown".to_string())
+        );
+    }
+
+    #[test]
+    fn test_checkin_action_recognized() {
+        assert_eq!(ScmAction::from_id("%CheckIn"), ScmAction::CheckIn);
+        assert_eq!(ScmAction::from_id("CheckIn"), ScmAction::CheckIn);
+    }
+
+    #[test]
+    fn test_iris_scm_allow_checkin_gate() {
+        // Default: blocked
+        std::env::remove_var("IRIS_SCM_ALLOW_CHECKIN");
+        let allowed = std::env::var("IRIS_SCM_ALLOW_CHECKIN")
+            .map(|v| matches!(v.to_ascii_lowercase().as_str(), "1" | "true" | "yes"))
+            .unwrap_or(false);
+        assert!(!allowed, "CheckIn should be blocked by default");
+
+        // Opt-in variants
+        for val in &["1", "true", "yes", "TRUE", "YES"] {
+            std::env::set_var("IRIS_SCM_ALLOW_CHECKIN", val);
+            let allowed = std::env::var("IRIS_SCM_ALLOW_CHECKIN")
+                .map(|v| matches!(v.to_ascii_lowercase().as_str(), "1" | "true" | "yes"))
+                .unwrap_or(false);
+            assert!(
+                allowed,
+                "IRIS_SCM_ALLOW_CHECKIN={val} should enable CheckIn"
+            );
+        }
+
+        // Explicitly disabled
+        for val in &["0", "false", "no"] {
+            std::env::set_var("IRIS_SCM_ALLOW_CHECKIN", val);
+            let allowed = std::env::var("IRIS_SCM_ALLOW_CHECKIN")
+                .map(|v| matches!(v.to_ascii_lowercase().as_str(), "1" | "true" | "yes"))
+                .unwrap_or(false);
+            assert!(
+                !allowed,
+                "IRIS_SCM_ALLOW_CHECKIN={val} should keep CheckIn blocked"
+            );
+        }
+
+        std::env::remove_var("IRIS_SCM_ALLOW_CHECKIN");
     }
 }

--- a/crates/iris-agentic-dev-core/tests/unit/test_scm_unit.rs
+++ b/crates/iris-agentic-dev-core/tests/unit/test_scm_unit.rs
@@ -1,43 +1,37 @@
-// Unit tests for scm.rs internal logic (no IRIS needed).
-// Tests KNOWN_MENU_ITEMS and ScmParams deserialization.
+// Unit tests for scm.rs public surface (no IRIS needed).
+// Tests ScmAction/SCM_MENU and ScmParams deserialization.
 
-use iris_agentic_dev_core::tools::scm::{ScmParams, KNOWN_MENU_ITEMS};
+use iris_agentic_dev_core::tools::scm::{ScmAction, ScmParams, SCM_MENU};
 
 #[test]
-fn test_known_menu_items_not_empty() {
-    assert!(
-        !KNOWN_MENU_ITEMS.is_empty(),
-        "KNOWN_MENU_ITEMS must have entries"
-    );
-    assert!(
-        KNOWN_MENU_ITEMS.contains(&"CheckOut"),
-        "must contain CheckOut"
-    );
-    assert!(
-        KNOWN_MENU_ITEMS.contains(&"CheckIn"),
-        "must contain CheckIn"
+fn test_scm_menu_is_source_menu() {
+    assert_eq!(SCM_MENU, "%SourceMenu");
+}
+
+#[test]
+fn test_scm_action_from_id_standard_actions() {
+    assert_eq!(ScmAction::from_id("CheckOut"), ScmAction::CheckOut);
+    assert_eq!(ScmAction::from_id("UndoCheckout"), ScmAction::UndoCheckout);
+    assert_eq!(ScmAction::from_id("CheckIn"), ScmAction::CheckIn);
+    assert_eq!(ScmAction::from_id("GetLatest"), ScmAction::GetLatest);
+    assert_eq!(
+        ScmAction::from_id("AddToSourceControl"),
+        ScmAction::AddToSourceControl
     );
 }
 
 #[test]
-fn test_known_menu_items_count() {
-    assert!(
-        KNOWN_MENU_ITEMS.len() >= 5,
-        "expect at least 5 known menu items, got {}",
-        KNOWN_MENU_ITEMS.len()
-    );
+fn test_scm_action_from_id_strips_percent_prefix() {
+    assert_eq!(ScmAction::from_id("%CheckOut"), ScmAction::CheckOut);
+    assert_eq!(ScmAction::from_id("%CheckIn"), ScmAction::CheckIn);
 }
 
 #[test]
-fn test_known_menu_items_contains_standard_actions() {
-    let expected = ["CheckOut", "UndoCheckOut", "CheckIn", "GetLatest", "Status"];
-    for item in &expected {
-        assert!(
-            KNOWN_MENU_ITEMS.contains(item),
-            "KNOWN_MENU_ITEMS missing: {}",
-            item
-        );
-    }
+fn test_scm_action_from_id_unknown_preserved() {
+    assert_eq!(
+        ScmAction::from_id("SomethingElse"),
+        ScmAction::Unknown("SomethingElse".to_string())
+    );
 }
 
 #[test]


### PR DESCRIPTION
Fixes #19 — the last and largest port from the upstream audit. Upstream rebuilt source-control across eleven commits; this lands their **final state** in one unit (replaying the steps would re-import two changes upstream itself reverted). Full breakdown in the commit message.

The two acute bugs this kills:
1. **Approved checkouts were never committed** — `UserAction` only offers the dialog; without `AfterUserAction` the checkout evaporated with the HTTP-scoped session and the follow-up write failed `ERROR #5865`.
2. **`IsEditable()` unguarded** — on providerless instances the generated `<METHOD DOES NOT EXIST>` fell through parsing as `editable:false` for perfectly editable docs.

Plus: SCM probe now runs over `execute_via_generator` (no docker), `CheckoutCache` stops the re-elicit-on-every-edit loop, `IRIS_SCM_ALLOW_CHECKIN` gates check-ins, and the executor's `$ZERROR` residue no longer corrupts valid output.

Fork adaptations: no policy subsystem, `Option` namespace via `resolve_namespace` (#15), failures through the #2 envelope. Implementation by a delegated port agent against a written adaptation contract; independently re-verified: 260 lib tests, suites 9/9, live e2e 10/10, manual no-SCM probes (status/put/compile/delete) all clean.

**Stacked on #29** (→ #28 → #27 → #26 → #25 → #16 → master). Closes out the fix-PR series from the divergence audit — every issue #17–#23 now has a verified PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)