### PR TITLE
fix(ci): make e2e-tests actually run — pin the IRIS image off the broken 2026.1 tag, dump container logs, fix one stale test (fixes #44)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,6 +4,8 @@ on:
   push:
     branches: [master, main]
   pull_request:
+  # Lets the master-only e2e-tests job be validated on a branch before merging.
+  workflow_dispatch:
 
 env:
   CARGO_TERM_COLOR: always
@@ -81,7 +83,7 @@ jobs:
 
   e2e-tests:
     runs-on: ubuntu-latest
-    if: github.ref == 'refs/heads/master'
+    if: github.ref == 'refs/heads/master' || github.event_name == 'workflow_dispatch'
     steps:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@stable
@@ -89,14 +91,27 @@ jobs:
       - run: cargo build -p iris-agentic-dev
       - name: Start IRIS container
         run: |
+          # --shm-size/--ulimit: the community image fails to start reliably on
+          # GitHub runners with Docker's 64m default shm (upstream 0308344, afea706).
           docker run -d --name iris-e2e \
             -p 52773:52773 \
+            --shm-size 1g \
+            --ulimit nofile=65536:65536 \
             -e IRIS_PASSWORD=SYS \
             -e IRIS_USERNAME=_SYSTEM \
             intersystemsdc/iris-community:2026.1
-          # Wait for container to be running
-          sleep 10
-          docker ps | grep iris-e2e
+          # Wait for container to be running, then show why if it is not
+          sleep 15
+          docker ps -a | grep iris-e2e
+          echo "=== Early container logs ==="
+          docker logs iris-e2e 2>&1 | head -40 || true
+          state=$(docker inspect -f '{{.State.Status}}' iris-e2e)
+          if [ "$state" != "running" ]; then
+            echo "::error::IRIS container is '$state' 15s after start (exit code $(docker inspect -f '{{.State.ExitCode}}' iris-e2e))"
+            echo "=== Full container logs ==="
+            docker logs iris-e2e 2>&1 | tail -80
+            exit 1
+          fi
       - name: Wait for IRIS Atelier API to be ready (up to 7 minutes)
         run: |
           IRIS_IP=$(docker inspect -f '{{range .NetworkSettings.Networks}}{{.IPAddress}}{{end}}' iris-e2e)
@@ -120,7 +135,8 @@ jobs:
             sleep 5
           done
           echo "IRIS did not become ready in 7 minutes"
-          docker logs iris-e2e 2>&1 | tail -20
+          echo "=== Full container logs ==="
+          docker logs iris-e2e 2>&1 | tail -80
           exit 1
       - name: Detect and set IRIS credentials
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -91,15 +91,22 @@ jobs:
       - run: cargo build -p iris-agentic-dev
       - name: Start IRIS container
         run: |
-          # --shm-size/--ulimit: the community image fails to start reliably on
-          # GitHub runners with Docker's 64m default shm (upstream 0308344, afea706).
+          # Image tag: intersystemsdc 2026.1 and latest-cd fail post-startup on GHA
+          # runners — the image's own `iris-after-start` hook dies with "Cannot call
+          # an iris.package wrapper ... dbapi.connect" and the entrypoint then shuts
+          # IRIS down (see #44). 2025.3 is the last known-good stable tag; upstream
+          # made the same switch. Community licenses expire ~150 days after image
+          # publish, so if this starts failing with "Community License expired",
+          # move to a newer known-good tag.
+          # --shm-size/--ulimit: the community image also needs these to start
+          # reliably on GitHub runners (upstream 0308344, afea706).
           docker run -d --name iris-e2e \
             -p 52773:52773 \
             --shm-size 1g \
             --ulimit nofile=65536:65536 \
             -e IRIS_PASSWORD=SYS \
             -e IRIS_USERNAME=_SYSTEM \
-            intersystemsdc/iris-community:2026.1
+            intersystemsdc/iris-community:2025.3
           # Wait for container to be running, then show why if it is not
           sleep 15
           docker ps -a | grep iris-e2e

--- a/.github/workflows/interop-fork.yml
+++ b/.github/workflows/interop-fork.yml
@@ -25,12 +25,19 @@ jobs:
       - uses: dtolnay/rust-toolchain@stable
       - name: Boot IRIS Community (with password env — else Atelier 401)
         run: |
-          # --shm-size/--ulimit: the community image fails to start reliably on
-          # GitHub runners with Docker's 64m default shm (upstream 0308344, afea706).
+          # Image tag: intersystemsdc 2026.1 and latest-cd fail post-startup on GHA
+          # runners — the image's own `iris-after-start` hook dies with "Cannot call
+          # an iris.package wrapper ... dbapi.connect" and the entrypoint then shuts
+          # IRIS down (see #44). 2025.3 is the last known-good stable tag; upstream
+          # made the same switch. Community licenses expire ~150 days after image
+          # publish, so if this starts failing with "Community License expired",
+          # move to a newer known-good tag.
+          # --shm-size/--ulimit: the community image also needs these to start
+          # reliably on GitHub runners (upstream 0308344, afea706).
           docker run -d --name iris-e2e -p 1972:1972 -p 52773:52773 \
             --shm-size 1g --ulimit nofile=65536:65536 \
             -e IRIS_PASSWORD=SYS -e IRIS_USERNAME=_SYSTEM \
-            intersystemsdc/iris-community:2026.1
+            intersystemsdc/iris-community:2025.3
           sleep 15
           docker ps -a | grep iris-e2e
           echo "=== Early container logs ==="

--- a/.github/workflows/interop-fork.yml
+++ b/.github/workflows/interop-fork.yml
@@ -25,16 +25,30 @@ jobs:
       - uses: dtolnay/rust-toolchain@stable
       - name: Boot IRIS Community (with password env — else Atelier 401)
         run: |
+          # --shm-size/--ulimit: the community image fails to start reliably on
+          # GitHub runners with Docker's 64m default shm (upstream 0308344, afea706).
           docker run -d --name iris-e2e -p 1972:1972 -p 52773:52773 \
+            --shm-size 1g --ulimit nofile=65536:65536 \
             -e IRIS_PASSWORD=SYS -e IRIS_USERNAME=_SYSTEM \
             intersystemsdc/iris-community:2026.1
+          sleep 15
+          docker ps -a | grep iris-e2e
+          echo "=== Early container logs ==="
+          docker logs iris-e2e 2>&1 | head -40 || true
           echo "waiting for Atelier API ..."
+          ready=""
           for i in $(seq 1 80); do
             code=$(curl -s -o /dev/null -w '%{http_code}' -u _SYSTEM:SYS \
               http://localhost:52773/api/atelier/ || echo 000)
-            [ "$code" = "200" ] && { echo "ready after ~$((i*3))s"; break; }
+            [ "$code" = "200" ] && { echo "ready after ~$((i*3))s"; ready=1; break; }
             sleep 3
           done
+          if [ -z "$ready" ]; then
+            echo "::error::Atelier API never returned 200 — IRIS did not come up"
+            echo "=== Full container logs ==="
+            docker logs iris-e2e 2>&1 | tail -80
+            exit 1
+          fi
           echo "enabling Interoperability on USER (Community edition includes the interop engine) ..."
           printf 'do ##class(%%Library.EnsembleMgr).EnableNamespace("USER")\nhalt\n' \
             | docker exec -i iris-e2e iris session IRIS -U %%SYS || true

--- a/crates/iris-agentic-dev-core/tests/integration/test_e2e.rs
+++ b/crates/iris-agentic-dev-core/tests/integration/test_e2e.rs
@@ -363,9 +363,10 @@ fn e2e_symbols_plain_substring_no_regression() {
 // ── iris_doc ──────────────────────────────────────────────────────────────────
 
 #[test]
-fn e2e_doc_put_with_storage_block_strips_and_succeeds() {
+fn e2e_doc_put_with_storage_block_requires_opt_in() {
     require_iris!();
-    // I-3: Storage blocks must be stripped automatically
+    // I-3: the UDL write path strips Storage blocks, so a put that would silently
+    // discard one is refused unless the caller opts in (issue #18, upstream #88).
     let cls_with_storage = r#"Class Test022.StorageTest Extends %Persistent {
 Property Name As %String;
 Storage Default
@@ -382,14 +383,32 @@ Storage Default
 }
 }"#;
 
-    let result = call_tool(
+    let blocked = call_tool(
         "iris_doc",
         serde_json::json!({"mode":"put","name":"Test022.StorageTest.cls",
             "content": cls_with_storage, "namespace":"USER"}),
     );
     assert_eq!(
+        blocked["success"], false,
+        "put that would strip a Storage block must be refused: {}",
+        blocked
+    );
+    assert_eq!(
+        blocked["error_code"], "STORAGE_STRIP_BLOCKED",
+        "refusal must carry STORAGE_STRIP_BLOCKED: {}",
+        blocked
+    );
+
+    // Opting in strips the Storage block and writes the class.
+    let result = call_tool(
+        "iris_doc",
+        serde_json::json!({"mode":"put","name":"Test022.StorageTest.cls",
+            "content": cls_with_storage, "namespace":"USER",
+            "allow_storage_regeneration": true}),
+    );
+    assert_eq!(
         result["success"], true,
-        "put with Storage block should succeed: {}",
+        "put with allow_storage_regeneration should succeed: {}",
         result
     );
     assert_eq!(


### PR DESCRIPTION
Closes #44. **Verified: all five jobs green on this branch, `e2e-tests` 126 passed / 0 failed** — run [32704158186](https://github.com/intersystems-ib/iris-interop-dev/actions/runs/32704158186). This job has never completed successfully on the fork before.

## Root cause — not shm, and not anything we merged

`e2e-tests` failed at **Start IRIS container** on every master run. Nothing dumped the container logs, so the reason had never been visible. Adding an unconditional log dump showed IRIS starting *completely* — shared memory allocated, databases mounted, `Interoperability System Startup Complete`, 52773 listening — and then:

```
[INFO]  Executing command /docker-entrypoint.sh iris-after-start ...
[INFO]  Create namespace: USER
[ERROR] Cannot call an iris.package wrapper ... Given name was: dbapi.connect
[ERROR] Command "/docker-entrypoint.sh iris-after-start " exited with status 256
[FATAL] Error executing post-startup command
[INFO]  Shutting down InterSystems IRIS instance IRIS...
```

The image's own post-startup hook fails on `dbapi.connect`; the entrypoint treats that as fatal and shuts the instance down. It is a defect in `intersystemsdc/iris-community:2026.1`, which is why it reproduced on every run regardless of what we merged. Upstream hit the same thing and recorded it in their `ci.yml`: *"2026.1 + latest-cd both fail post-startup on GHA runners with 'Cannot call an iris.package wrapper / dbapi.connect' — upstream image regression. Replaced both with 2025.3, last known-good stable on GHA."*

## Changes

1. **Pin both workflows to `intersystemsdc/iris-community:2025.3`**, with an in-file note that community licenses expire ~150 days after image publish, so the tag needs revisiting if it starts reporting "Community License expired".
2. **`--shm-size 1g` + `--ulimit nofile=65536:65536`** — upstream parity (`0308344`, `afea706`); not the cause here, but the community image wants them on GHA runners.
3. **Diagnostics that made this findable:** wait 15s, `docker ps -a` so an exited container still shows, dump the first 40 log lines unconditionally, and fail with `::error::` plus the last 80 lines when the container is not `running`. Readiness step dumps 80 lines instead of 20. `interop-fork.yml` gets the same treatment — its wait loop also fell through silently into a doomed test run when IRIS never answered.
4. **`workflow_dispatch`** so this master-only job can be validated on a branch instead of only after merging. That is how every iteration here was verified.
5. **One stale test fixed.** With the suite finally running, `e2e_doc_put_with_storage_block_strips_and_succeeds` failed (125/126): it still expected a put carrying an explicit Storage block to succeed silently, which PR #26 deliberately made a `STORAGE_STRIP_BLOCKED` refusal (issue #18 — a stripped Storage on an existing `%Persistent` extent loses the global mapping with no visible error). Renamed to `e2e_doc_put_with_storage_block_requires_opt_in` and it now asserts both halves: refused without the flag, strips and succeeds with `allow_storage_regeneration: true`. Verified green against a live IRIS as well as in CI.

The stale expectation is itself evidence of the cost of #44 — it sat undetected because the job it belonged to never ran.

🤖 Generated with [Claude Code](https://claude.com/claude-code)