### PR TITLE
fix(compile): a compile IRIS rejected sets is_error instead of looking successful (fixes #46)

### DIFF
--- a/crates/iris-agentic-dev-core/src/tools/mod.rs
+++ b/crates/iris-agentic-dev-core/src/tools/mod.rs
@@ -1099,6 +1099,36 @@ fn ok_json(v: serde_json::Value) -> Result<CallToolResult, McpError> {
 fn err_json(code: &str, msg: &str) -> Result<CallToolResult, McpError> {
     crate::tools::envelope::fail(code, msg)
 }
+/// Issue #46: a compile that IRIS rejected is a genuine tool failure, so it gets
+/// `isError` on the wire and the standard envelope — same contract iris_doc's
+/// compile path already follows (issue #2). Diagnostics ride along unchanged in
+/// `errors`/`warnings`/`console`; `payload` carries `success:false`, which the
+/// envelope owns and re-asserts.
+fn compile_failure(target: &str, payload: serde_json::Value) -> Result<CallToolResult, McpError> {
+    let first = payload["errors"][0]["text"]
+        .as_str()
+        .map(str::to_string)
+        .or_else(|| payload["errors"][0].as_str().map(str::to_string))
+        .unwrap_or_else(|| format!("compile of {target} failed — see console"));
+    crate::tools::envelope::fail_with(
+        "COMPILE_ERROR",
+        &first,
+        // The built-in COMPILE_ERROR hint names iris_doc's `compile_console`;
+        // this payload calls that field `console`.
+        merge_hint(
+            payload,
+            "Fix the first reported error and recompile — later errors are often cascades \
+             of the first. Full compiler output is in console.",
+        ),
+    )
+}
+fn merge_hint(mut payload: serde_json::Value, hint: &str) -> serde_json::Value {
+    if let Some(obj) = payload.as_object_mut() {
+        obj.entry("hint")
+            .or_insert_with(|| serde_json::Value::String(hint.to_string()));
+    }
+    payload
+}
 pub fn write_open_hint(namespace: &str, document: &str) {
     if let Some(home) = dirs::home_dir() {
         let dir = home.join(".iris-agentic-dev");
@@ -1976,7 +2006,7 @@ impl IrisTools {
                     .collect();
                 let success = cr.success();
                 self.record_call("iris_compile", success);
-                return ok_json(serde_json::json!({
+                let payload = serde_json::json!({
                     "success": success,
                     "target": doc_name,
                     "uploaded_from": local_src,
@@ -1985,7 +2015,11 @@ impl IrisTools {
                     "errors": errors,
                     "warnings": [],
                     "console": console,
-                }));
+                });
+                if !success {
+                    return compile_failure(&doc_name, payload);
+                }
+                return ok_json(payload);
             }
         }
 
@@ -2198,6 +2232,9 @@ impl IrisTools {
             resp["truncated"] = serde_json::Value::Bool(false);
         }
 
+        if !success {
+            return compile_failure(&p.target, resp);
+        }
         ok_json(resp)
     }
 
@@ -5567,6 +5604,68 @@ mod schema_normalization_tests {
         assert!(
             !DOCKER_REQUIRED_HINT.to_lowercase().contains("docker run"),
             "DOCKER_REQUIRED hint must not suggest 'docker run' (guides non-Docker users)"
+        );
+    }
+}
+
+#[cfg(test)]
+mod compile_envelope_tests {
+    use super::compile_failure;
+    use rmcp::model::RawContent;
+
+    fn payload(r: &rmcp::model::CallToolResult) -> serde_json::Value {
+        let text = match &r.content[0].raw {
+            RawContent::Text(t) => &t.text,
+            _ => panic!("expected text content"),
+        };
+        serde_json::from_str(text).unwrap()
+    }
+
+    /// Issue #46: a compile IRIS rejected came back as a success-shaped result —
+    /// `success:false` with no `isError` — so clients read it as a working call.
+    #[test]
+    fn failed_compile_is_flagged_and_keeps_diagnostics() {
+        let r = compile_failure(
+            "MyApp.Broken.cls",
+            serde_json::json!({
+                "success": false,
+                "target": "MyApp.Broken.cls",
+                "targets_compiled": 1,
+                "namespace": "USER",
+                "errors": [{"severity":"error","text":"ERROR #1026: Invalid command"}],
+                "warnings": [],
+                "console": ["Detected 1 errors during compilation"],
+            }),
+        )
+        .unwrap();
+        assert_eq!(r.is_error, Some(true), "failed compile must set isError");
+        let v = payload(&r);
+        assert_eq!(v["success"], false);
+        assert_eq!(v["error_code"], "COMPILE_ERROR");
+        assert_eq!(v["error"], "ERROR #1026: Invalid command");
+        assert!(
+            v["console"].is_array(),
+            "console must survive as detail: {v}"
+        );
+        assert_eq!(v["targets_compiled"], 1, "extras must survive: {v}");
+        assert!(
+            v["hint"].as_str().unwrap().contains("console"),
+            "hint must name this payload's console field, not iris_doc's: {v}"
+        );
+    }
+
+    #[test]
+    fn failed_compile_without_parsed_errors_still_carries_a_message() {
+        let r = compile_failure(
+            "MyApp.Silent.cls",
+            serde_json::json!({"success": false, "errors": [], "console": []}),
+        )
+        .unwrap();
+        let v = payload(&r);
+        assert_eq!(r.is_error, Some(true));
+        assert!(
+            v["error"].as_str().unwrap().contains("MyApp.Silent.cls"),
+            "fallback message must name the target: {v}"
         );
     }
 }

--- a/crates/iris-agentic-dev-core/tests/interop_e2e_tests.rs
+++ b/crates/iris-agentic-dev-core/tests/interop_e2e_tests.rs
@@ -812,6 +812,62 @@ fn test_error_envelope_and_is_error_flag() {
         serde_json::json!({"mode":"delete","name":"IrisDevE2E.Broken.cls","namespace":ns}),
         "iris_doc",
     );
+
+    // 5. iris_compile on a class that does not compile → isError + COMPILE_ERROR.
+    //    Issue #46: this branch returned ok_json with success:false and no isError,
+    //    so a spec-compliant client read a failed compile as a successful call and
+    //    the agent kept iterating against a class it believed it had compiled.
+    let broken_src = "Class IrisDevE2E.BrokenCompile\n{\nClassMethod X()\n{\n    this is not objectscript\n}\n}\n";
+    let _ = exchange(
+        serde_json::json!({"mode":"put","name":"IrisDevE2E.BrokenCompile.cls","content":broken_src,"namespace":ns}),
+        "iris_doc",
+    );
+    let frame = exchange(
+        serde_json::json!({"target":"IrisDevE2E.BrokenCompile.cls","namespace":ns}),
+        "iris_compile",
+    );
+    assert_eq!(
+        frame["result"]["isError"], true,
+        "failed compile unflagged: {frame}"
+    );
+    let v = parse_tool_text(&frame);
+    assert_eq!(v["success"], false, "{v}");
+    assert_eq!(v["error_code"], "COMPILE_ERROR", "{v}");
+    assert!(
+        !v["error"].as_str().unwrap_or("").is_empty(),
+        "message must live in `error`: {v}"
+    );
+    assert!(
+        v["errors"]
+            .as_array()
+            .map(|a| !a.is_empty())
+            .unwrap_or(false),
+        "diagnostics must stay as detail: {v}"
+    );
+
+    // 6. a compile that succeeds must NOT be flagged
+    let good_src =
+        "Class IrisDevE2E.GoodCompile\n{\nClassMethod X() As %String\n{\n    Return \"ok\"\n}\n}\n";
+    let _ = exchange(
+        serde_json::json!({"mode":"put","name":"IrisDevE2E.GoodCompile.cls","content":good_src,"namespace":ns}),
+        "iris_doc",
+    );
+    let frame = exchange(
+        serde_json::json!({"target":"IrisDevE2E.GoodCompile.cls","namespace":ns}),
+        "iris_compile",
+    );
+    assert_ne!(
+        frame["result"]["isError"], true,
+        "successful compile wrongly flagged: {frame}"
+    );
+    assert_eq!(parse_tool_text(&frame)["success"], true, "{frame}");
+
+    for name in ["IrisDevE2E.BrokenCompile.cls", "IrisDevE2E.GoodCompile.cls"] {
+        let _ = exchange(
+            serde_json::json!({"mode":"delete","name":name,"namespace":ns}),
+            "iris_doc",
+        );
+    }
 }
 
 #[test]


### PR DESCRIPTION
Closes #46.

## The bug

Both `iris_compile` return paths built their result with `ok_json`, so a compile IRIS rejected came back **success-shaped**: `success:false`, no `error_code`, no `error`, and `isError` absent on the wire. From the reporter's harness, the practical effect: *"a compile attempt against a document that isn't there returns 'success' to the model. In the run above the agent kept iterating against a class it believed it had compiled."*

Reproduced against a live IRIS before touching anything:

```json
{"success":false,"target":"IrisDevE2E.BrokenCompile.cls","errors":[{"text":"ERROR #5475: ..."}], ...}
```
with `"isError": false` on the frame.

## The fix

`iris_doc`'s compile path already follows the issue #2 contract; `iris_compile` now matches it. A rejected compile returns `fail_with("COMPILE_ERROR", first_error, payload)` — `isError` set, the first compiler error in `error`, and every diagnostic field (`errors`, `warnings`, `console`, the progressive-disclosure `truncated`/`log_id`) riding along unchanged, so nothing a caller reads today disappears. A successful compile is untouched.

The hint is passed explicitly rather than taken from `builtin_hint`: that one names `compile_console`, which is `iris_doc`'s field name — this payload calls it `console`, and a hint pointing at a field that isn't in the payload is worse than no hint.

Both return paths are covered: the main compile path and the upload-then-compile branch.

## Verification

- **Unit tests in the `--lib` set** (`compile_envelope_tests`) — so CI catches a regression with no live IRIS, since the e2e job doesn't run this suite.
- **Cases 5 and 6 added to `test_error_envelope_and_is_error_flag`** in `interop_e2e_tests`: a failing compile is flagged, a passing one is not. Written first, watched fail, then fixed.
- Full local gate green: `cargo fmt --check`, `clippy --all-targets -D warnings`, the CI test list (262 lib + the eight suites), and `interop_e2e_tests --ignored` 10/10 against a live IRIS.

## On the reporter's `NO_CODE`

Still zero occurrences of the string `NO_CODE` anywhere in the crate tree, so this fixes the genuinely success-shaped `iris_compile` branch their classifier is most likely bucketing. The request for one raw frame stands — if `NO_CODE` is real it arrives from outside this server and we should see where.

🤖 Generated with [Claude Code](https://claude.com/claude-code)