### PR TITLE
chore(release): 0.7.3

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -960,7 +960,7 @@ dependencies = [
 
 [[package]]
 name = "iris-agentic-dev"
-version = "0.7.2"
+version = "0.7.3"
 dependencies = [
  "anyhow",
  "clap",
@@ -977,7 +977,7 @@ dependencies = [
 
 [[package]]
 name = "iris-agentic-dev-core"
-version = "0.7.2"
+version = "0.7.3"
 dependencies = [
  "anyhow",
  "bollard",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "0.7.2"
+version = "0.7.3"
 edition = "2021"
 authors = ["Thomas Dyar <thomas.dyar@intersystems.com>"]
 license = "MIT"


### PR DESCRIPTION
Version bump for the 0.7.3 release. The release workflow's provenance guard (#3) refuses to publish unless the tag, `Cargo.toml` and the built binary's `--version` all agree, so this lands before `v0.7.3-interop` is tagged.

Three fixes since 0.7.2, each merged green and verified on master:

| Issue | PR | What changed for the user |
|---|---|---|
| #44 | #49 | `e2e-tests` runs at all. The `intersystemsdc/iris-community:2026.1` tag boots IRIS then kills it from its own `iris-after-start` hook — pinned to 2025.3. Container logs are now dumped unconditionally, and `workflow_dispatch` lets the master-only job be validated on a branch. |
| #46 | #50 | A compile IRIS rejected no longer looks successful: `isError` is set and the standard envelope carries the first compiler error, with all diagnostics preserved. |
| #47 | #51 | `NO_TESTS_FOUND` names the pattern and the namespace it searched, offers `did_you_mean` for near-miss candidates, admits `%UnitTest.TestProduction`, and reports `25+` instead of silently capping. |

Local binary confirms `iris-interop-dev 0.7.3`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)