### PR TITLE
chore(deps): bump GitHub Actions to their Node 24 majors

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,7 @@ jobs:
   test:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
       - uses: dtolnay/rust-toolchain@stable
         with:
           components: clippy, rustfmt
@@ -42,8 +42,8 @@ jobs:
   benchmark-lint:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-python@v5
+      - uses: actions/checkout@v7
+      - uses: actions/setup-python@v7
         with:
           python-version: '3.11'
       - run: pip install pyyaml
@@ -60,7 +60,7 @@ jobs:
   windows-handshake:
     runs-on: windows-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
       - uses: dtolnay/rust-toolchain@stable
       - uses: Swatinem/rust-cache@v2
       - run: cargo build -p iris-agentic-dev
@@ -85,7 +85,7 @@ jobs:
     runs-on: ubuntu-latest
     if: github.ref == 'refs/heads/master' || github.event_name == 'workflow_dispatch'
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
       - uses: dtolnay/rust-toolchain@stable
       - uses: Swatinem/rust-cache@v2
       - run: cargo build -p iris-agentic-dev
@@ -185,7 +185,7 @@ jobs:
   cross-compile-check:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
       - uses: dtolnay/rust-toolchain@stable
         with:
           targets: x86_64-unknown-linux-musl,aarch64-unknown-linux-musl

--- a/.github/workflows/interop-fork.yml
+++ b/.github/workflows/interop-fork.yml
@@ -12,7 +12,7 @@ jobs:
   unit:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
       - uses: dtolnay/rust-toolchain@stable
       - name: Unit tests + per-tool validation gate
         run: ./scripts/test-all.sh unit
@@ -21,7 +21,7 @@ jobs:
     runs-on: ubuntu-latest
     if: github.ref == 'refs/heads/fork/interop-lean'
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
       - uses: dtolnay/rust-toolchain@stable
       - name: Boot IRIS Community (with password env — else Atelier 401)
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -32,7 +32,7 @@ jobs:
             bin: iris-interop-dev
     runs-on: ${{ matrix.os }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
       # Provenance guard (issue #3): a release where the tag name, Cargo.toml and the
       # binary's --version disagree must never publish. Check tag vs Cargo.toml before
       # spending a build; the built binary is checked in "guard: binary --version" below.
@@ -72,7 +72,7 @@ jobs:
             echo "::error::built binary reports $bin_version but Cargo.toml says $cargo_version — refusing to release"
             exit 1
           fi
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@v7
         with:
           name: ${{ matrix.asset }}
           path: ${{ matrix.asset }}
@@ -84,11 +84,11 @@ jobs:
     permissions:
       contents: write
     steps:
-      - uses: actions/download-artifact@v4
+      - uses: actions/download-artifact@v8
         with:
           path: dist
           merge-multiple: true
-      - uses: softprops/action-gh-release@v2
+      - uses: softprops/action-gh-release@v3
         with:
           files: dist/*
           generate_release_notes: true


### PR DESCRIPTION
Takes the five open Actions dependabot PRs — #34, #35, #37, #38, #48 — as one batch, so the matched pair lands atomically.

| Dependabot PR | Bump | Note |
|---|---|---|
| #48 | actions/checkout v4 → **v7** | 8 call sites |
| #35 | actions/setup-python v5 → **v7** | |
| #34 | actions/upload-artifact v4 → **v7** | pairs with ↓ |
| #37 | actions/download-artifact v4 → **v8** | pairs with ↑ |
| #38 | softprops/action-gh-release v2 → **v3** | |

## Why edits, not cherry-picks

#48 touches `ci.yml` and `interop-fork.yml` — the same files the #44 fix rewrote. Cherry-picking dependabot's stale-based commit and resolving in its favour would have silently reverted the `intersystemsdc/iris-community:2025.3` image pin, re-breaking `e2e-tests` while looking like a routine version bump. The bumps are applied directly instead, and the pin plus the container-log diagnostics are verified intact in the diff. The dependabot PRs close on their own once these versions are on master.

## Breaking-change review

All five are Node 20 → Node 24 runtime moves, which also clears the `Node.js 20 is deprecated` warning every job currently prints.

- **checkout v7** — the documented breaking change is `allow-unsafe-pr-checkout` / safer `pull_request_target` defaults. No workflow here uses `pull_request_target`, so it does not apply.
- **download-artifact v8** — no longer blanket-unzips; it checks `Content-Type` and skips non-zipped files. Our release job downloads exactly what `upload-artifact` produced, which stays on the zip path, and `merge-multiple: true` is unchanged in v8.
- **upload-artifact v7 / gh-release v3** — runtime only; inputs unchanged.

## Verification, and one honest gap

CI is dispatched on this branch so `e2e-tests` actually runs (it is skipped on PR events). `release.yml` is also dispatched here, which exercises checkout v7, the build, both provenance guards and **upload-artifact v7** on all three platforms.

**What that cannot reach:** the release job is `if: startsWith(github.ref, 'refs/tags/')`, so **download-artifact v8 and gh-release v3 are first exercised at the next tag.** If either misbehaves there, nothing partial gets published — the provenance guards run before upload, and the publish step is the last thing in the workflow — and the fix is a one-line revert of those two lines.

🤖 Generated with [Claude Code](https://claude.com/claude-code)