### PR TITLE
feat(interop): port 056 interop-depth — message bodies, business rules, production diff (#24)

### DIFF
--- a/crates/iris-agentic-dev-core/src/tools/doc.rs
+++ b/crates/iris-agentic-dev-core/src/tools/doc.rs
@@ -879,7 +879,7 @@ pub fn strip_storage_blocks(content: &str) -> (String, bool) {
     }
 }
 
-fn doc_content_to_string(body: &serde_json::Value) -> String {
+pub(crate) fn doc_content_to_string(body: &serde_json::Value) -> String {
     // Atelier GET /doc/<name> returns result.content as a flat array of line strings.
     body["result"]["content"]
         .as_array()

--- a/crates/iris-agentic-dev-core/src/tools/interop.rs
+++ b/crates/iris-agentic-dev-core/src/tools/interop.rs
@@ -2211,6 +2211,680 @@ If $$$ISERR(tSC) {{ Write "ERROR:INTEROP_ERROR:"_$System.Status.GetErrorText(tSC
     }
 }
 
+// ── 056 interop-depth ────────────────────────────────────────────────────────
+// Ported from upstream's 056-interop-depth (f92da6d), adapted to this fork:
+// every user string reaching ObjectScript goes through `os_str_expr` (issue #6),
+// SQL uses bound parameters instead of interpolation, and the namespace arrives
+// already resolved by the caller (issue #15).
+
+#[derive(Debug, Deserialize, JsonSchema)]
+pub struct MessageBodyParams {
+    pub message_id: String,
+    #[serde(default = "default_ns")]
+    pub namespace: String,
+    #[serde(default = "default_max_bytes")]
+    pub max_bytes: u32,
+    #[serde(default)]
+    pub acknowledge_phi: bool,
+}
+fn default_max_bytes() -> u32 {
+    65536
+}
+
+#[derive(Debug, Deserialize, JsonSchema)]
+pub struct BusinessRuleInfoParams {
+    pub action: String,
+    pub rule_name: Option<String>,
+    #[serde(default = "default_ns")]
+    pub namespace: String,
+}
+
+#[derive(Debug, Deserialize, JsonSchema)]
+pub struct ProductionDiffParams {
+    pub production: Option<String>,
+    #[serde(default = "default_ns")]
+    pub namespace: String,
+}
+
+/// Detect a body's content type from its leading characters.
+/// `"HL7v2"` for MSH|-prefixed content, `"JSON"`/`"XML"` for {/[ and < prefixes,
+/// `"text"` for everything else.
+pub fn detect_content_type(body: &str) -> &'static str {
+    let trimmed = body.trim_start();
+    if trimmed.starts_with("MSH|") {
+        "HL7v2"
+    } else if trimmed.starts_with('{') || trimmed.starts_with('[') {
+        "JSON"
+    } else if trimmed.starts_with('<') {
+        "XML"
+    } else {
+        "text"
+    }
+}
+
+/// Truncate `body` to at most `max_bytes`, breaking at a UTF-8 char boundary at or
+/// before the limit. Returns `(content, was_truncated, original_byte_len)` — the
+/// length is the whole body's, so callers can report what they did not return.
+pub fn truncate_body(body: &str, max_bytes: usize) -> (String, bool, usize) {
+    let original_len = body.len();
+    if original_len <= max_bytes {
+        return (body.to_string(), false, original_len);
+    }
+    let mut end = max_bytes;
+    while end > 0 && !body.is_char_boundary(end) {
+        end -= 1;
+    }
+    (body[..end].to_string(), true, original_len)
+}
+
+/// Replace the standard HL7 v2 PHI field positions (PID-3, PID-5, PID-7, PID-8,
+/// PID-11, PID-18, MSH-3) with `[REDACTED]`. Content without an `MSH|` segment is
+/// returned unchanged — only HL7 v2 has known PHI positions to blank.
+pub fn redact_hl7v2(body: &str) -> String {
+    if detect_content_type(body) != "HL7v2" {
+        return body.to_string();
+    }
+    let line_ending = if body.contains("\r\n") {
+        "\r\n"
+    } else if body.contains('\r') {
+        "\r"
+    } else {
+        "\n"
+    };
+    let redact_fields = |line: &str, segment: &str, field_indices: &[usize]| -> String {
+        let mut fields: Vec<&str> = line.split('|').collect();
+        if fields.first().copied() != Some(segment) {
+            return line.to_string();
+        }
+        for &idx in field_indices {
+            if idx < fields.len() {
+                fields[idx] = "[REDACTED]";
+            }
+        }
+        fields.join("|")
+    };
+    body.split(line_ending)
+        .map(|line| {
+            // MSH-1 is the implicit field-separator char (not a split element), so
+            // fields[1] = MSH-2 (encoding chars) and fields[2] = MSH-3 (sending app).
+            let redacted = redact_fields(line, "MSH", &[2]);
+            redact_fields(&redacted, "PID", &[3, 5, 7, 8, 11, 18])
+        })
+        .collect::<Vec<_>>()
+        .join(line_ending)
+}
+
+/// Parse `<Item Name="..." ClassName="..." Enabled="..."/>` entries out of a
+/// production class's UDL/XData source. Returns `(name, class_name, enabled)`.
+pub fn parse_production_items_from_source(source: &str) -> Vec<(String, String, bool)> {
+    let mut items = Vec::new();
+    for line in source.lines() {
+        let trimmed = line.trim();
+        if !trimmed.starts_with("<Item ") {
+            continue;
+        }
+        let name = extract_xml_attr(trimmed, "Name");
+        let class_name = extract_xml_attr(trimmed, "ClassName");
+        // IRIS treats a missing Enabled as enabled.
+        let enabled = extract_xml_attr(trimmed, "Enabled")
+            .map(|v| v == "true" || v == "1")
+            .unwrap_or(true);
+        if let (Some(name), Some(class_name)) = (name, class_name) {
+            items.push((name, class_name, enabled));
+        }
+    }
+    items
+}
+
+fn extract_xml_attr(line: &str, attr: &str) -> Option<String> {
+    // Require whitespace before the attribute name so `Name="` does not match
+    // inside `ClassName="`. Attributes are always preceded by a space.
+    let needle = format!(" {attr}=\"");
+    let start = line.find(&needle)? + needle.len();
+    let rest = &line[start..];
+    let end = rest.find('"')?;
+    Some(rest[..end].to_string())
+}
+
+/// Read an Ensemble message body (`Ens.StringContainer`, `Ens.StreamContainer`,
+/// `%Stream.Object`). `data_policy` gates PHI: `block` refuses outright, `allow`
+/// requires an explicit acknowledgement, `redact` blanks known HL7 v2 PHI fields.
+pub async fn handle_iris_message_body(
+    iris: Option<&IrisConnection>,
+    params: &MessageBodyParams,
+    data_policy: &str,
+) -> Result<CallToolResult, McpError> {
+    if data_policy == "block" {
+        return err_json(
+            "PHI_POLICY_BLOCKED",
+            "iris_message_body is blocked while dataPolicy=block — message bodies may contain PHI. \
+             Pass dataPolicy=redact to blank known HL7 v2 PHI fields, or dataPolicy=allow with \
+             acknowledgePhi=true to read the body as-is.",
+        );
+    }
+    if data_policy == "allow" && !params.acknowledge_phi {
+        return err_json(
+            "PHI_ACK_REQUIRED",
+            "dataPolicy=allow requires acknowledgePhi=true — the body is returned unredacted.",
+        );
+    }
+    let message_id: i64 = match params.message_id.trim().parse() {
+        Ok(n) => n,
+        Err(_) => {
+            return err_json(
+                "INVALID_MESSAGE_ID",
+                &format!(
+                    "message_id '{}' is not a valid integer — pass the Ens.MessageHeader ID",
+                    params.message_id
+                ),
+            )
+        }
+    };
+    let mut max_bytes = params.max_bytes.max(1);
+    let mut max_bytes_clamped = false;
+    if max_bytes > 1_048_576 {
+        max_bytes = 1_048_576;
+        max_bytes_clamped = true;
+    }
+
+    let iris = match iris {
+        Some(i) => i,
+        None => return err_json("IRIS_UNREACHABLE", "No IRIS connection"),
+    };
+    let client = IrisConnection::http_client().map_err(|_| iris_unreachable())?;
+
+    // message_id is an i64 and max_bytes a u32 — both are numeric, so nothing
+    // user-controlled reaches the generated source as a string here.
+    let code = format!(
+        r#"Set hdr=##class(Ens.MessageHeader).%OpenId({message_id})
+If '$IsObject(hdr) {{ Write "ERROR:MESSAGE_NOT_FOUND" Quit }}
+Set bodyClass=hdr.MessageBodyClassName
+Set bodyId=hdr.MessageBodyId
+If bodyClass="" {{ Write "ERROR:MESSAGE_NOT_FOUND" Quit }}
+Set body=$ClassMethod(bodyClass,"%OpenId",bodyId)
+If '$IsObject(body) {{ Write "ERROR:MESSAGE_NOT_FOUND" Quit }}
+If body.%IsA("Ens.StreamContainer") {{
+  Set stream=body.Stream
+  If '$IsObject(stream) {{ Write "ERROR:STREAM_READ_ERROR:no stream object" Quit }}
+  Set full=stream.Size
+  Set content=stream.Read({max_bytes})
+  Write "OK:"_full_":"
+  Write content
+}} ElseIf body.%IsA("%Stream.Object") {{
+  Set full=body.Size
+  Set content=body.Read({max_bytes})
+  Write "OK:"_full_":"
+  Write content
+}} ElseIf body.%IsA("Ens.StringContainer") {{
+  Set content=body.StringValue
+  Set full=$Length(content)
+  If full>{max_bytes} {{ Set content=$Extract(content,1,{max_bytes}) }}
+  Write "OK:"_full_":"
+  Write content
+}} Else {{
+  Write "ERROR:UNSUPPORTED_BODY_CLASS:"_bodyClass
+}}"#
+    );
+
+    match iris
+        .execute_via_generator(&code, &params.namespace, &client)
+        .await
+    {
+        Ok(out) => {
+            if out.starts_with("ERROR:MESSAGE_NOT_FOUND") {
+                return err_json(
+                    "MESSAGE_NOT_FOUND",
+                    &format!("No body found for message ID {message_id}"),
+                );
+            }
+            if let Some(rest) = out.strip_prefix("ERROR:STREAM_READ_ERROR:") {
+                return err_json("STREAM_READ_ERROR", rest.trim());
+            }
+            if let Some(rest) = out.strip_prefix("ERROR:UNSUPPORTED_BODY_CLASS:") {
+                return err_json(
+                    "UNSUPPORTED_BODY_CLASS",
+                    &format!(
+                        "Body class '{}' is not a recognized stream/text body type",
+                        rest.trim()
+                    ),
+                );
+            }
+            let Some(rest) = out.strip_prefix("OK:") else {
+                return err_json("IRIS_EXECUTE_ERROR", &out);
+            };
+            let mut parts = rest.splitn(2, ':');
+            // The prefix is the body's FULL size. IRIS caps what it hands back at
+            // max_bytes, so the returned content alone cannot say how much was left
+            // behind — reporting its length would understate a truncated body.
+            let full_size: usize = parts.next().and_then(|s| s.parse().ok()).unwrap_or(0);
+            let body_content = parts.next().unwrap_or("");
+
+            let (truncated_body, locally_truncated, _) =
+                truncate_body(body_content, max_bytes as usize);
+            let actual_size = full_size.max(body_content.len());
+            let was_truncated = locally_truncated || actual_size > body_content.len();
+            let content_type = detect_content_type(&truncated_body);
+
+            let final_body = if data_policy == "redact" {
+                redact_hl7v2(&truncated_body)
+            } else {
+                truncated_body
+            };
+
+            let mut resp = serde_json::json!({
+                "success": true,
+                "message_id": params.message_id,
+                "content_type": content_type,
+                "body": final_body,
+                "truncated": was_truncated,
+                "actual_size": actual_size,
+                "redacted": data_policy == "redact",
+            });
+            if max_bytes_clamped {
+                resp["max_bytes_clamped"] = serde_json::Value::Bool(true);
+            }
+            ok_json(resp)
+        }
+        Err(e) => err_json(
+            if is_network_error(&e.to_string()) {
+                "IRIS_UNREACHABLE"
+            } else {
+                "IRIS_EXECUTE_ERROR"
+            },
+            &e.to_string(),
+        ),
+    }
+}
+
+/// List the namespace's business rule sets, or describe one.
+/// `Ens.Rule.RuleSet` is the rule-set persistent class (upstream's research
+/// confirmed `EnsLib.Rules.Definition` does not exist).
+pub async fn handle_iris_business_rule_info(
+    iris: Option<&IrisConnection>,
+    params: &BusinessRuleInfoParams,
+) -> Result<CallToolResult, McpError> {
+    match params.action.as_str() {
+        "list" => {}
+        "get" => {
+            if params.rule_name.as_deref().unwrap_or("").trim().is_empty() {
+                return err_json("INVALID_PARAMS", "rule_name is required for action=get");
+            }
+        }
+        other => {
+            return err_json(
+                "INVALID_ACTION",
+                &format!("action must be 'list' or 'get', got '{other}'"),
+            )
+        }
+    }
+
+    let iris = match iris {
+        Some(i) => i,
+        None => return err_json("IRIS_UNREACHABLE", "No IRIS connection"),
+    };
+    let client = IrisConnection::http_client().map_err(|_| iris_unreachable())?;
+
+    let exists_code = r#"Write ##class(%Dictionary.ClassDefinition).%ExistsId("Ens.Rule.RuleSet")"#;
+    match iris
+        .execute_via_generator(exists_code, &params.namespace, &client)
+        .await
+    {
+        Ok(out) if out.trim() == "0" => {
+            return err_json(
+                "INTEROP_NOT_AVAILABLE",
+                &format!(
+                    "Ens.Rule.RuleSet is not available in namespace '{}' — Interoperability is not enabled there",
+                    params.namespace
+                ),
+            )
+        }
+        Ok(_) => {}
+        Err(e) => {
+            return err_json(
+                if is_network_error(&e.to_string()) {
+                    "IRIS_UNREACHABLE"
+                } else {
+                    "IRIS_EXECUTE_ERROR"
+                },
+                &e.to_string(),
+            )
+        }
+    }
+
+    if params.action == "list" {
+        let sql = "SELECT Name, FullName, ShortDescription, TimeModified \
+                   FROM Ens_Rule.RuleSet ORDER BY Name";
+        return match iris.query(sql, vec![], &params.namespace, &client).await {
+            Ok(resp) => {
+                let rows = resp["result"]["content"]
+                    .as_array()
+                    .cloned()
+                    .unwrap_or_default();
+                let rules: Vec<serde_json::Value> = rows
+                    .iter()
+                    .map(|r| {
+                        serde_json::json!({
+                            "name": r["Name"],
+                            "class_name": r["FullName"],
+                            "description": r["ShortDescription"],
+                            "modified": r["TimeModified"],
+                        })
+                    })
+                    .collect();
+                if !rules.is_empty() {
+                    return ok_json(serde_json::json!({
+                        "success": true,
+                        "namespace": params.namespace,
+                        "count": rules.len(),
+                        "rules": rules,
+                        "source": "Ens_Rule.RuleSet",
+                    }));
+                }
+                // Ens_Rule.RuleSet is populated by the rule editor's projection, and
+                // is empty on instances where rules exist only as compiled
+                // Ens.Rule.Definition subclasses. Answering "no rules" there, while
+                // rule classes plainly exist, is the #47 failure again — so fall
+                // back to the class catalog and say which source answered.
+                let (rules, source) =
+                    match rule_classes_from_catalog(iris, &params.namespace, &client).await {
+                        Some(found) if !found.is_empty() => (found, "%Dictionary.CompiledClass"),
+                        _ => (rules, "Ens_Rule.RuleSet"),
+                    };
+                ok_json(serde_json::json!({
+                    "success": true,
+                    "namespace": params.namespace,
+                    "count": rules.len(),
+                    "rules": rules,
+                    "source": source,
+                }))
+            }
+            Err(e) => err_json("IRIS_UNREACHABLE", &e.to_string()),
+        };
+    }
+
+    // action == "get". Ens.Rule.RuleSet's ID is a composite key
+    // (HostClass||Name||Version), not the Name — look the ID up first, newest
+    // version (highest ID) wins. Bound parameter, not interpolation.
+    let rule_name = params.rule_name.as_deref().unwrap_or("").trim();
+    let sql = "SELECT ID, ShortDescription FROM Ens_Rule.RuleSet WHERE Name = ? ORDER BY ID DESC";
+    match iris
+        .query(
+            sql,
+            vec![serde_json::Value::String(rule_name.to_string())],
+            &params.namespace,
+            &client,
+        )
+        .await
+    {
+        Ok(resp) => {
+            let rows = resp["result"]["content"]
+                .as_array()
+                .cloned()
+                .unwrap_or_default();
+            if rows.is_empty() {
+                // Distinguish "no such rule" from "the rule exists as a compiled class
+                // but the RuleSet projection has no row for it" — very different fixes.
+                let known: Vec<String> =
+                    rule_classes_from_catalog(iris, &params.namespace, &client)
+                        .await
+                        .unwrap_or_default()
+                        .iter()
+                        .filter_map(|r| r["name"].as_str().map(|s| s.to_string()))
+                        .collect();
+                if known.iter().any(|k| k == rule_name) {
+                    return err_json(
+                        "RULE_NOT_PROJECTED",
+                        &format!(
+                            "'{rule_name}' is a compiled Ens.Rule.Definition class in '{}', but it has no \
+                             Ens_Rule.RuleSet row — the rule-set projection is written when the rule is saved \
+                             from the Rule Editor. Read the class source with iris_doc to inspect its \
+                             RuleDefinition XData.",
+                            params.namespace
+                        ),
+                    );
+                }
+                return err_json(
+                    "RULE_NOT_FOUND",
+                    &format!(
+                        "No business rule named '{rule_name}' in namespace '{}' — call action=list to see what is there",
+                        params.namespace
+                    ),
+                );
+            }
+            let description = rows[0]["ShortDescription"].clone();
+            let rule_id = rows[0]["ID"].as_str().unwrap_or("").to_string();
+
+            let code = format!(
+                r#"Set rs=##class(Ens.Rule.RuleSet).%OpenId({rule_id_expr})
+If '$IsObject(rs) {{ Write "ERROR:RULE_NOT_FOUND" Quit }}
+Write "OK:"
+Set count=rs.Rules.Count()
+For i=1:1:count {{
+  Set rule=rs.Rules.GetAt(i)
+  Write "COND:"_$Select($IsObject(rule.Conditions):rule.Conditions.Count(),1:0)_"|"
+  Write "ACT:"_$Select($IsObject(rule.Actions):rule.Actions.Count(),1:0)_"|"
+}}"#,
+                rule_id_expr = os_str_expr(&rule_id)
+            );
+            match iris
+                .execute_via_generator(&code, &params.namespace, &client)
+                .await
+            {
+                Ok(out) => {
+                    if out.trim().starts_with("ERROR:RULE_NOT_FOUND") {
+                        return err_json(
+                            "RULE_NOT_FOUND",
+                            &format!("No business rule named '{rule_name}' found"),
+                        );
+                    }
+                    let mut conditions = 0usize;
+                    let mut actions = 0usize;
+                    let mut rule_count = 0usize;
+                    if let Some(rest) = out.trim().strip_prefix("OK:") {
+                        for part in rest.split('|') {
+                            if let Some(n) = part.strip_prefix("COND:") {
+                                conditions += n.parse::<usize>().unwrap_or(0);
+                                rule_count += 1;
+                            } else if let Some(n) = part.strip_prefix("ACT:") {
+                                actions += n.parse::<usize>().unwrap_or(0);
+                            }
+                        }
+                    }
+                    ok_json(serde_json::json!({
+                        "success": true,
+                        "name": rule_name,
+                        "namespace": params.namespace,
+                        "description": description,
+                        "rules": rule_count,
+                        "conditions": conditions,
+                        "actions": actions,
+                    }))
+                }
+                Err(e) => err_json("IRIS_UNREACHABLE", &e.to_string()),
+            }
+        }
+        Err(e) => err_json("IRIS_UNREACHABLE", &e.to_string()),
+    }
+}
+
+/// Compiled `Ens.Rule.Definition` subclasses in `namespace`, excluding the framework's
+/// own. Used when `Ens_Rule.RuleSet` has no rows so the caller still learns what exists.
+async fn rule_classes_from_catalog(
+    iris: &IrisConnection,
+    namespace: &str,
+    client: &reqwest::Client,
+) -> Option<Vec<serde_json::Value>> {
+    let sql = "SELECT Name FROM %Dictionary.CompiledClass \
+               WHERE PrimarySuper LIKE '%Ens.Rule.Definition%' \
+                 AND Name NOT LIKE 'Ens.%' AND Name NOT LIKE 'EnsLib.%' \
+                 AND Name NOT LIKE 'HS.%' AND Name NOT LIKE '\\%%' ESCAPE '\\' \
+               ORDER BY Name";
+    let resp = iris.query(sql, vec![], namespace, client).await.ok()?;
+    Some(
+        resp["result"]["content"]
+            .as_array()?
+            .iter()
+            .filter_map(|r| r["Name"].as_str())
+            .map(|n| {
+                serde_json::json!({
+                    "name": n,
+                    "class_name": n,
+                    "description": serde_json::Value::Null,
+                    "modified": serde_json::Value::Null,
+                })
+            })
+            .collect(),
+    )
+}
+
+/// Diff a running production's config items against the committed class source.
+pub async fn handle_iris_production_diff(
+    iris: Option<&IrisConnection>,
+    params: &ProductionDiffParams,
+) -> Result<CallToolResult, McpError> {
+    let iris = match iris {
+        Some(i) => i,
+        None => return err_json("IRIS_UNREACHABLE", "No IRIS connection"),
+    };
+    let client = IrisConnection::http_client().map_err(|_| iris_unreachable())?;
+    let ns = &params.namespace;
+
+    let prod_name = if let Some(p) = &params.production {
+        p.clone()
+    } else {
+        let status_code = r#"Set sc=##class(Ens.Director).GetProductionStatus(.n,.s) If $System.Status.IsError(sc)||(n="") { Write "ERROR:NO_PRODUCTION" } Else { Write n }"#;
+        match iris.execute_via_generator(status_code, ns, &client).await {
+            Ok(out) => {
+                let out = out.trim().to_string();
+                if out.starts_with("ERROR:NO_PRODUCTION") {
+                    return err_json(
+                        "NO_PRODUCTION",
+                        "No production is running in this namespace — pass `production` to diff a specific one",
+                    );
+                }
+                out
+            }
+            Err(e) => return err_json("IRIS_UNREACHABLE", &e.to_string()),
+        }
+    };
+
+    let doc_name = format!("{prod_name}.cls");
+    let scm_code = format!(
+        r#"Set sc=##class(%Studio.SourceControl.Interface).SourceControlCreate({user_expr},{pass_expr},.created,.flags,.outuser)
+Set isInSC=0
+Set sc=##class(%Studio.SourceControl.Interface).GetStatus({doc_expr},.isInSC,.editable,.isCheckedOut,.owner)
+If $System.Status.IsError(sc)||('isInSC) {{ Write "NO_SCM" }} Else {{ Write "IN_SCM" }}"#,
+        user_expr = os_str_expr(&iris.username),
+        pass_expr = os_str_expr(&iris.password),
+        doc_expr = os_str_expr(&doc_name),
+    );
+    match iris.execute_via_generator(&scm_code, ns, &client).await {
+        Ok(out) if out.trim() == "NO_SCM" => {
+            return err_json(
+                "NO_SCM",
+                &format!(
+                    "No source control is configured for '{doc_name}' in namespace '{ns}' — there is no committed source to diff against"
+                ),
+            )
+        }
+        Ok(_) => {}
+        Err(e) => return err_json("IRIS_UNREACHABLE", &e.to_string()),
+    }
+
+    let exists_code = format!(
+        r#"Write ##class(%Dictionary.ClassDefinition).%ExistsId({prod_expr})"#,
+        prod_expr = os_str_expr(&prod_name)
+    );
+    match iris.execute_via_generator(&exists_code, ns, &client).await {
+        Ok(out) if out.trim() == "0" => {
+            return err_json(
+                "PRODUCTION_NOT_FOUND",
+                &format!("Production '{prod_name}' does not exist in namespace '{ns}'"),
+            )
+        }
+        Ok(_) => {}
+        Err(e) => return err_json("IRIS_UNREACHABLE", &e.to_string()),
+    }
+
+    // Current in-memory item set. Bound parameter, not interpolation.
+    let sql = "SELECT Name, ClassName, Category, Enabled FROM Ens_Config.Item \
+               WHERE Production->Name = ?";
+    let current_items: Vec<(String, String, bool)> = match iris
+        .query(
+            sql,
+            vec![serde_json::Value::String(prod_name.clone())],
+            ns,
+            &client,
+        )
+        .await
+    {
+        Ok(resp) => resp["result"]["content"]
+            .as_array()
+            .cloned()
+            .unwrap_or_default()
+            .iter()
+            .map(|r| {
+                (
+                    r["Name"].as_str().unwrap_or("").to_string(),
+                    r["ClassName"].as_str().unwrap_or("").to_string(),
+                    // Enabled comes back as a SQL boolean on some builds and 0/1 on others.
+                    r["Enabled"]
+                        .as_bool()
+                        .unwrap_or_else(|| r["Enabled"].as_i64().unwrap_or(0) != 0),
+                )
+            })
+            .collect(),
+        Err(e) => return err_json("IRIS_UNREACHABLE", &e.to_string()),
+    };
+
+    // Committed source via Atelier REST GET /doc/<name>.
+    let doc_url = iris.versioned_ns_url(ns, &format!("/doc/{}", urlencoding::encode(&doc_name)));
+    let committed_items: Vec<(String, String, bool)> = match client
+        .get(&doc_url)
+        .basic_auth(&iris.username, Some(&iris.password))
+        .send()
+        .await
+    {
+        Ok(resp) if resp.status().is_success() => {
+            let body: serde_json::Value = resp.json().await.unwrap_or_default();
+            let source = crate::tools::doc::doc_content_to_string(&body);
+            parse_production_items_from_source(&source)
+        }
+        _ => Vec::new(),
+    };
+
+    let mut changes = Vec::new();
+    for (name, class_name, enabled) in &current_items {
+        match committed_items.iter().find(|(n, _, _)| n == name) {
+            None => changes.push(serde_json::json!({
+                "item_name": name, "item_type": class_name, "status": "added"
+            })),
+            Some((_, c_class, c_enabled)) => {
+                if c_class != class_name || c_enabled != enabled {
+                    changes.push(serde_json::json!({
+                        "item_name": name, "item_type": class_name, "status": "modified"
+                    }));
+                }
+            }
+        }
+    }
+    for (name, class_name, _) in &committed_items {
+        if !current_items.iter().any(|(n, _, _)| n == name) {
+            changes.push(serde_json::json!({
+                "item_name": name, "item_type": class_name, "status": "removed"
+            }));
+        }
+    }
+
+    ok_json(serde_json::json!({
+        "success": true,
+        "production": prod_name,
+        "namespace": ns,
+        "in_sync": changes.is_empty(),
+        "changes": changes,
+    }))
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/crates/iris-agentic-dev-core/src/tools/mod.rs
+++ b/crates/iris-agentic-dev-core/src/tools/mod.rs
@@ -119,6 +119,10 @@ pub const INTEROP_TOOLS: &[&str] = &[
     "extract_message_map_routing",
     "find_subclass_implementations",
     "iris_table_info",
+    // 056 interop-depth
+    "iris_message_body",
+    "iris_business_rule_info",
+    "iris_production_diff",
 ];
 
 pub const ERR_NO_TESTS_FOUND: &str = "NO_TESTS_FOUND";
@@ -4817,6 +4821,124 @@ Methods:
         )
         .await;
         self.record_call("iris_production_item", Self::call_ok(&result));
+        result
+    }
+
+    // ─── 056-interop-depth: message bodies, business rules, production diff ───
+
+    #[tool(
+        description = "Read an Ensemble message body by message header ID (Ens.StringContainer, Ens.StreamContainer, %Stream.Object). Message bodies may contain PHI, so this tool refuses by default: pass dataPolicy=redact to blank known HL7 v2 PHI fields (PID-3/5/7/8/11/18, MSH-3), or dataPolicy=allow together with acknowledgePhi=true to read it unredacted. max_bytes caps the read (default 65536, hard cap 1048576) and the response reports actual_size and truncated. Use iris_interop_query first to find message IDs. namespace: optional — defaults to the connection namespace (IRIS_NAMESPACE); must be an interop-enabled namespace."
+    )]
+    async fn iris_message_body(
+        &self,
+        Parameters(p): Parameters<AnyParams>,
+    ) -> Result<CallToolResult, McpError> {
+        let _iris_arc_hold = self.iris_arc();
+        let iris_opt = _iris_arc_hold.as_deref();
+        let namespace =
+            interop::resolve_namespace(p.get("namespace").and_then(|v| v.as_str()), iris_opt);
+        if let Some(iris) = iris_opt {
+            if let Some(blocked) = interop::ensure_interop_namespace(iris, &namespace).await {
+                self.record_call("iris_message_body", false);
+                return blocked;
+            }
+        }
+        // Default block: a body can carry patient data, so reading one is opt-in.
+        let data_policy = p
+            .get("dataPolicy")
+            .and_then(|v| v.as_str())
+            .unwrap_or("block")
+            .to_string();
+        let result = interop::handle_iris_message_body(
+            iris_opt,
+            &interop::MessageBodyParams {
+                message_id: p
+                    .get("message_id")
+                    .map(|v| match v {
+                        serde_json::Value::String(s) => s.clone(),
+                        other => other.to_string(),
+                    })
+                    .unwrap_or_default(),
+                namespace,
+                max_bytes: p.get("max_bytes").and_then(|v| v.as_u64()).unwrap_or(65536) as u32,
+                acknowledge_phi: p
+                    .get("acknowledgePhi")
+                    .and_then(|v| v.as_bool())
+                    .unwrap_or(false),
+            },
+            &data_policy,
+        )
+        .await;
+        self.record_call("iris_message_body", Self::call_ok(&result));
+        result
+    }
+
+    #[tool(
+        description = "Inspect business rule sets (Ens.Rule.RuleSet). action=list returns every rule set in the namespace with its class name, description and last-modified time; action=get with rule_name returns that rule set's description plus its rule/condition/action counts. Use this to find the real rule name before editing a routing rule. namespace: optional — defaults to the connection namespace (IRIS_NAMESPACE); must be an interop-enabled namespace."
+    )]
+    async fn iris_business_rule_info(
+        &self,
+        Parameters(p): Parameters<AnyParams>,
+    ) -> Result<CallToolResult, McpError> {
+        let _iris_arc_hold = self.iris_arc();
+        let iris_opt = _iris_arc_hold.as_deref();
+        let namespace =
+            interop::resolve_namespace(p.get("namespace").and_then(|v| v.as_str()), iris_opt);
+        if let Some(iris) = iris_opt {
+            if let Some(blocked) = interop::ensure_interop_namespace(iris, &namespace).await {
+                self.record_call("iris_business_rule_info", false);
+                return blocked;
+            }
+        }
+        let result = interop::handle_iris_business_rule_info(
+            iris_opt,
+            &interop::BusinessRuleInfoParams {
+                action: p
+                    .get("action")
+                    .and_then(|v| v.as_str())
+                    .unwrap_or("list")
+                    .to_string(),
+                rule_name: p
+                    .get("rule_name")
+                    .and_then(|v| v.as_str())
+                    .map(|s| s.to_string()),
+                namespace,
+            },
+        )
+        .await;
+        self.record_call("iris_business_rule_info", Self::call_ok(&result));
+        result
+    }
+
+    #[tool(
+        description = "Diff a production's live config items against its committed class source, so you can see what was changed in the Management Portal but never saved to source control. Returns in_sync plus a changes array of added/modified/removed items. production: optional — defaults to the running production in the namespace. Requires source control to be configured for the namespace. namespace: optional — defaults to the connection namespace (IRIS_NAMESPACE); must be an interop-enabled namespace."
+    )]
+    async fn iris_production_diff(
+        &self,
+        Parameters(p): Parameters<AnyParams>,
+    ) -> Result<CallToolResult, McpError> {
+        let _iris_arc_hold = self.iris_arc();
+        let iris_opt = _iris_arc_hold.as_deref();
+        let namespace =
+            interop::resolve_namespace(p.get("namespace").and_then(|v| v.as_str()), iris_opt);
+        if let Some(iris) = iris_opt {
+            if let Some(blocked) = interop::ensure_interop_namespace(iris, &namespace).await {
+                self.record_call("iris_production_diff", false);
+                return blocked;
+            }
+        }
+        let result = interop::handle_iris_production_diff(
+            iris_opt,
+            &interop::ProductionDiffParams {
+                production: p
+                    .get("production")
+                    .and_then(|v| v.as_str())
+                    .map(|s| s.to_string()),
+                namespace,
+            },
+        )
+        .await;
+        self.record_call("iris_production_diff", Self::call_ok(&result));
         result
     }
 

--- a/crates/iris-agentic-dev-core/tests/interop_unit_tests.rs
+++ b/crates/iris-agentic-dev-core/tests/interop_unit_tests.rs
@@ -352,3 +352,305 @@ mod env_guard {
         assert!(names.contains("iris_production_item"));
     }
 }
+
+// ── 056 interop-depth: iris_message_body / iris_business_rule_info / iris_production_diff ──
+// Ported from upstream's 056-interop-depth (f92da6d), adapted to this fork's conventions.
+
+mod interop_depth_helpers {
+    use super::*;
+
+    #[test]
+    fn content_type_detects_hl7_json_xml_and_text() {
+        assert_eq!(detect_content_type("MSH|^~\\&|SENDER|..."), "HL7v2");
+        assert_eq!(
+            detect_content_type("  \n MSH|^~\\&|X"),
+            "HL7v2",
+            "leading whitespace is trimmed"
+        );
+        assert_eq!(detect_content_type("{\"a\":1}"), "JSON");
+        assert_eq!(detect_content_type("[1,2]"), "JSON");
+        assert_eq!(detect_content_type("<Root/>"), "XML");
+        assert_eq!(detect_content_type("just words"), "text");
+        assert_eq!(detect_content_type(""), "text");
+    }
+
+    #[test]
+    fn truncate_body_is_a_noop_under_the_limit() {
+        let (out, trunc, len) = truncate_body("hello", 100);
+        assert_eq!(out, "hello");
+        assert!(!trunc);
+        assert_eq!(len, 5);
+    }
+
+    #[test]
+    fn truncate_body_reports_the_original_length_not_the_kept_length() {
+        let (out, trunc, len) = truncate_body("abcdefghij", 4);
+        assert_eq!(out, "abcd");
+        assert!(trunc);
+        assert_eq!(
+            len, 10,
+            "actual_size must reflect the whole body, not the slice"
+        );
+    }
+
+    /// Cutting mid-character would panic on a str slice — the boundary walk is the point.
+    #[test]
+    fn truncate_body_breaks_on_a_utf8_boundary() {
+        let s = "aé€"; // 1 + 2 + 3 bytes
+        let (out, trunc, len) = truncate_body(s, 2);
+        assert_eq!(
+            out, "a",
+            "must back off to the boundary rather than split é"
+        );
+        assert!(trunc);
+        assert_eq!(len, 6);
+        let (out2, _, _) = truncate_body(s, 3);
+        assert_eq!(out2, "aé");
+    }
+
+    #[test]
+    fn redact_hl7v2_blanks_the_phi_fields_and_keeps_the_rest() {
+        let msg = "MSH|^~\\&|SENDAPP|SENDFAC|RECVAPP|RECVFAC|20260824||ADT^A01|MSG1|P|2.5\rPID|1||123456^^^MRN||DOE^JOHN||19700101|M|||742 Evergreen Tce^^Springfield^IL^62704";
+        let out = redact_hl7v2(msg);
+        assert!(
+            !out.contains("DOE^JOHN"),
+            "PID-5 patient name must go: {out}"
+        );
+        assert!(
+            !out.contains("123456^^^MRN"),
+            "PID-3 identifier must go: {out}"
+        );
+        assert!(!out.contains("19700101"), "PID-7 DOB must go: {out}");
+        assert!(!out.contains("Evergreen"), "PID-11 address must go: {out}");
+        assert!(!out.contains("SENDAPP"), "MSH-3 sending app must go: {out}");
+        assert!(
+            out.contains("ADT^A01"),
+            "message type is not PHI and must survive: {out}"
+        );
+        assert!(out.contains("RECVAPP"), "MSH-5 is not redacted: {out}");
+        assert!(
+            out.starts_with("MSH|"),
+            "segment structure must survive: {out}"
+        );
+    }
+
+    #[test]
+    fn redact_hl7v2_leaves_non_hl7_untouched() {
+        let json = "{\"patient\":\"DOE^JOHN\"}";
+        assert_eq!(
+            redact_hl7v2(json),
+            json,
+            "only HL7 v2 has known PHI positions"
+        );
+    }
+
+    #[test]
+    fn redact_hl7v2_handles_crlf_and_lf_segments() {
+        for sep in ["\r", "\n", "\r\n"] {
+            let msg =
+                format!("MSH|^~\\&|APP|F|R|F|20260824||ADT^A01|1|P|2.5{sep}PID|1||MRN1||DOE^JANE");
+            let out = redact_hl7v2(&msg);
+            assert!(!out.contains("DOE^JANE"), "sep {sep:?} not handled: {out}");
+            assert!(
+                out.contains(sep),
+                "the original separator must be preserved: {out:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn production_items_parse_out_of_class_source() {
+        let src = r#"
+Class MyApp.Prod Extends Ens.Production
+{
+XData ProductionDefinition
+{
+<Production Name="MyApp.Prod">
+  <Item Name="FileIn" Category="" ClassName="MyApp.BS.FileService" PoolSize="1" Enabled="true"/>
+  <Item Name="SqlOut" Category="" ClassName="MyApp.BO.SqlOperation" PoolSize="1" Enabled="false"/>
+</Production>
+}
+}
+"#;
+        let items = parse_production_items_from_source(src);
+        assert_eq!(items.len(), 2, "got {items:?}");
+        assert_eq!(
+            items[0],
+            ("FileIn".into(), "MyApp.BS.FileService".into(), true)
+        );
+        assert_eq!(
+            items[1],
+            ("SqlOut".into(), "MyApp.BO.SqlOperation".into(), false)
+        );
+    }
+
+    /// `Name="` also appears inside `ClassName="` — the parser must not confuse them.
+    #[test]
+    fn item_name_is_not_matched_inside_class_name() {
+        let src = r#"<Item ClassName="Pkg.BS.Thing" Name="Real" Enabled="true"/>"#;
+        let items = parse_production_items_from_source(src);
+        assert_eq!(items.len(), 1);
+        assert_eq!(
+            items[0].0, "Real",
+            "Name must not bind to ClassName's suffix"
+        );
+        assert_eq!(items[0].1, "Pkg.BS.Thing");
+    }
+
+    #[test]
+    fn item_without_explicit_enabled_defaults_to_enabled() {
+        let items = parse_production_items_from_source(r#"<Item Name="A" ClassName="P.BS.A"/>"#);
+        assert_eq!(items.len(), 1);
+        assert!(items[0].2, "IRIS treats a missing Enabled as enabled");
+    }
+
+    #[test]
+    fn non_item_lines_are_ignored() {
+        let items = parse_production_items_from_source(
+            "Class X {\n<Production Name=\"P\">\n</Production>\n}",
+        );
+        assert!(items.is_empty(), "got {items:?}");
+    }
+}
+
+mod interop_depth_guards {
+    use super::*;
+
+    /// PHI gating is the reason this tool defaults to refusing: a message body can
+    /// carry patient data, so `block` must stop it before any IRIS call happens.
+    #[test]
+    fn message_body_is_blocked_under_the_default_policy() {
+        let r = rt().block_on(handle_iris_message_body(
+            None,
+            &MessageBodyParams {
+                message_id: "1".into(),
+                namespace: "USER".into(),
+                max_bytes: 65536,
+                acknowledge_phi: false,
+            },
+            "block",
+        ));
+        let v = tool_payload(&r);
+        assert_eq!(v["error_code"], "PHI_POLICY_BLOCKED", "{v}");
+    }
+
+    #[test]
+    fn allow_policy_still_requires_an_explicit_acknowledgement() {
+        let r = rt().block_on(handle_iris_message_body(
+            None,
+            &MessageBodyParams {
+                message_id: "1".into(),
+                namespace: "USER".into(),
+                max_bytes: 65536,
+                acknowledge_phi: false,
+            },
+            "allow",
+        ));
+        let v = tool_payload(&r);
+        assert_eq!(v["error_code"], "PHI_ACK_REQUIRED", "{v}");
+    }
+
+    #[test]
+    fn a_non_numeric_message_id_is_rejected_before_reaching_iris() {
+        let r = rt().block_on(handle_iris_message_body(
+            None,
+            &MessageBodyParams {
+                message_id: "not-a-number".into(),
+                namespace: "USER".into(),
+                max_bytes: 65536,
+                acknowledge_phi: true,
+            },
+            "allow",
+        ));
+        let v = tool_payload(&r);
+        assert_eq!(v["error_code"], "INVALID_MESSAGE_ID", "{v}");
+    }
+
+    #[test]
+    fn business_rule_info_rejects_an_unknown_action() {
+        let r = rt().block_on(handle_iris_business_rule_info(
+            None,
+            &BusinessRuleInfoParams {
+                action: "delete".into(),
+                rule_name: None,
+                namespace: "USER".into(),
+            },
+        ));
+        let v = tool_payload(&r);
+        assert_eq!(v["error_code"], "INVALID_ACTION", "{v}");
+    }
+
+    #[test]
+    fn business_rule_get_requires_a_rule_name() {
+        let r = rt().block_on(handle_iris_business_rule_info(
+            None,
+            &BusinessRuleInfoParams {
+                action: "get".into(),
+                rule_name: None,
+                namespace: "USER".into(),
+            },
+        ));
+        let v = tool_payload(&r);
+        assert_eq!(v["error_code"], "INVALID_PARAMS", "{v}");
+    }
+
+    #[test]
+    fn each_depth_tool_reports_no_connection_rather_than_panicking() {
+        let r = rt().block_on(handle_iris_business_rule_info(
+            None,
+            &BusinessRuleInfoParams {
+                action: "list".into(),
+                rule_name: None,
+                namespace: "USER".into(),
+            },
+        ));
+        assert_eq!(tool_payload(&r)["error_code"], "IRIS_UNREACHABLE");
+
+        let r = rt().block_on(handle_iris_production_diff(
+            None,
+            &ProductionDiffParams {
+                production: None,
+                namespace: "USER".into(),
+            },
+        ));
+        assert_eq!(tool_payload(&r)["error_code"], "IRIS_UNREACHABLE");
+    }
+}
+
+mod interop_depth_redaction_detail {
+    use super::*;
+
+    /// Truncation happens before redaction, so a redacted body can be longer than
+    /// max_bytes ([REDACTED] is wider than what it replaces). What must stay true is
+    /// that no PHI survives and the caller can still tell it got a partial body.
+    #[test]
+    fn redaction_after_truncation_still_removes_phi() {
+        let msg =
+            "MSH|^~\\&|SENDAPP|F|R|F|20260825||ADT^A01|1|P|2.5\rPID|1||MRN9||DOE^JOHN||19700101";
+        let (cut, truncated, full) = truncate_body(msg, 60);
+        assert!(truncated);
+        assert_eq!(full, msg.len(), "the reported size is the whole body");
+        let out = redact_hl7v2(&cut);
+        assert!(
+            !out.contains("SENDAPP"),
+            "MSH-3 must go even in a partial body: {out}"
+        );
+    }
+
+    /// A body cut mid-segment must not lose its HL7 identity — content_type drives
+    /// whether redaction runs at all.
+    #[test]
+    fn a_partial_hl7_body_is_still_detected_as_hl7() {
+        let (cut, _, _) = truncate_body("MSH|^~\\&|APP|FAC|R|F|20260825||ADT^A01", 12);
+        assert_eq!(detect_content_type(&cut), "HL7v2", "got {cut:?}");
+    }
+}
+
+/// Pull the JSON payload out of a tool result for assertions.
+fn tool_payload(r: &Result<rmcp::model::CallToolResult, rmcp::ErrorData>) -> serde_json::Value {
+    let r = r.as_ref().expect("tool returned a transport error");
+    match &r.content[0].raw {
+        rmcp::model::RawContent::Text(t) => serde_json::from_str(&t.text).expect("payload is JSON"),
+        _ => panic!("expected text content"),
+    }
+}

--- a/crates/iris-agentic-dev-core/tests/mcp_handshake.rs
+++ b/crates/iris-agentic-dev-core/tests/mcp_handshake.rs
@@ -144,11 +144,12 @@ fn mcp_server_tools_list_returns_interop_profile() {
 
     let tool_names: Vec<_> = tools.iter().filter_map(|t| t["name"].as_str()).collect();
 
-    // Interop profile (this fork's default toolset) exposes exactly the 20 interop tools.
+    // Interop profile (this fork's default toolset) exposes exactly the interop
+    // keep-list: 20 tools, plus the 3 added by the 056 interop-depth port.
     assert_eq!(
         tool_names.len(),
-        20,
-        "expected the 20-tool interop profile, got {}: {:?}",
+        23,
+        "expected the 23-tool interop profile, got {}: {:?}",
         tool_names.len(),
         tool_names
     );


### PR DESCRIPTION
Ports upstream's 056-interop-depth (`f92da6d`) — the top pick on #24 — as our own change against 0.7.x rather than by merging their history. The re-sync assessment on #24 measured that merge at 49 conflicted files with 112 hunks in `tools/mod.rs` alone; this is ~700 lines of additive code instead.

| Tool | What it does |
|---|---|
| `iris_message_body` | Read an Ensemble message body by header ID (`Ens.StringContainer`, `Ens.StreamContainer`, `%Stream.Object`) |
| `iris_business_rule_info` | `list` / `get` business rule sets |
| `iris_production_diff` | Diff live config items against the committed class source |

## Adapted, not copied

- **ObjectScript embedding** goes through `os_str_expr` (#6) instead of hand-rolled quote doubling, and the two SQL lookups use **bound parameters** rather than interpolating a rule or production name into the statement.
- **Namespace** follows this fork's contract: `AnyParams` → `interop::resolve_namespace` + `ensure_interop_namespace`, so omitting `namespace` uses the connection's rather than a hardcoded `USER` (#15), and the schema text tells models to omit it (#43).
- **`dataPolicy`** is a tool parameter defaulting to `block`, keeping upstream's PHI gate without their `policy::gate` / server-manager subsystem, which this fork does not have.

## Two fixes on top of the port

Both found by running it against a live IRIS, not by reading it.

**1. `actual_size` understated a truncated body.** IRIS caps the read at `max_bytes`, and the generated code wrote back the length of what it returned — so a 154-byte body read with `max_bytes=40` reported `actual_size: 41`. That is the one field whose job is to tell you what you did *not* get. The codegen now emits the full size (`stream.Size` / `$Length` before `$Extract`) and truncation is derived from it.

```jsonc
// before                        // after
"actual_size": 41,               "actual_size": 153,
"truncated": true                "truncated": true
```

**2. `action=list` answered "no rules" while a rule class plainly existed.** On this dev instance `Ens_Rule.RuleSet` is empty even with a compiled `Ens.Rule.Definition` class — the projection is written when the rule is saved from the Rule Editor. Returning an empty list there is #47's failure repeating, so `list` falls back to the class catalog and reports which `source` answered, and `get` returns **`RULE_NOT_PROJECTED`** — naming the actual cause and what to do — instead of a flat `RULE_NOT_FOUND`.

## Verification

Live against the dev IRIS, with a purpose-built HL7 message fixture (removed afterwards):

- PHI gates: `PHI_POLICY_BLOCKED` by default, `PHI_ACK_REQUIRED` for `dataPolicy=allow` without acknowledgement
- Redaction: MRN, patient name, DOB, sex, address and MSH-3 blanked; `ADT^A01`, MSH-5 and segment structure intact
- Truncation, `MESSAGE_NOT_FOUND`, `INVALID_MESSAGE_ID`
- Rule `list` via both sources, `RULE_NOT_PROJECTED`, `RULE_NOT_FOUND`
- `NO_PRODUCTION` (nothing running) and `NO_SCM` (real production class, no source control)

15 new unit tests in the `--lib`/CI gate cover the pure helpers (content-type detection, UTF-8-boundary truncation, HL7 redaction across CR/LF/CRLF, `<Item>` parsing incl. the `Name` vs `ClassName` trap) and the pre-flight guards. Full local gate green: fmt, clippy `-D warnings`, the CI test list, `interop_e2e_tests --ignored` 10/10, and `test_interop_toolset_exact`.

The interop profile is now **23 tools**; `mcp_handshake`'s exact-count assertion is updated to match.

🤖 Generated with [Claude Code](https://claude.com/claude-code)