### PR TITLE
chore(release): 0.8.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -945,7 +945,7 @@ dependencies = [
 
 [[package]]
 name = "iris-agentic-dev"
-version = "0.7.3"
+version = "0.8.0"
 dependencies = [
  "anyhow",
  "clap",
@@ -962,7 +962,7 @@ dependencies = [
 
 [[package]]
 name = "iris-agentic-dev-core"
-version = "0.7.3"
+version = "0.8.0"
 dependencies = [
  "anyhow",
  "bollard",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "0.7.3"
+version = "0.8.0"
 edition = "2021"
 authors = ["Thomas Dyar <thomas.dyar@intersystems.com>"]
 license = "MIT"


### PR DESCRIPTION
Version bump for the 0.8.0 release. The release workflow's provenance guard (#3) refuses to publish unless the tag, `Cargo.toml` and the built binary's `--version` agree, so this lands before `v0.8.0-interop` is tagged.

**Minor, not patch.** 0.7.x were fix-only releases; this one adds three tools and moves the interop profile from 20 to 23, which is a visible surface change for anything pinning the tool list.

| Issue | PR | What it adds |
|---|---|---|
| #24 (partial) | #55 | `iris_message_body`, `iris_business_rule_info`, `iris_production_diff` — upstream's 056-interop-depth, ported as our own change and adapted to this fork's `os_str_expr` embedding, bound SQL parameters, namespace resolution, and a `dataPolicy` PHI gate defaulting to `block`. Two defects fixed on top of the port, both found by running it against a live IRIS. |

#24 stays open — it tracks the remaining upstream ports, not just this one.

Local binary confirms `iris-interop-dev 0.8.0`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)