### PR TITLE
feat(observability): opt-in IRIS_LOG_FILE so a session's traces outlive it (fixes #58)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -948,6 +948,7 @@ name = "iris-agentic-dev"
 version = "0.8.0"
 dependencies = [
  "anyhow",
+ "chrono",
  "clap",
  "iris-agentic-dev-core",
  "rmcp",

--- a/crates/iris-agentic-dev-bin/Cargo.toml
+++ b/crates/iris-agentic-dev-bin/Cargo.toml
@@ -20,6 +20,7 @@ serde_json.workspace = true
 urlencoding = "2"
 tracing.workspace = true
 tracing-subscriber.workspace = true
+chrono = { version = "0.4" }
 
 [dev-dependencies]
 tempfile = "3"

--- a/crates/iris-agentic-dev-bin/src/main.rs
+++ b/crates/iris-agentic-dev-bin/src/main.rs
@@ -1,6 +1,8 @@
 use anyhow::Result;
 use clap::{Parser, Subcommand};
-use tracing_subscriber::EnvFilter;
+use std::io::Write;
+use std::sync::{Arc, Mutex};
+use tracing_subscriber::{layer::SubscriberExt, util::SubscriberInitExt, EnvFilter};
 
 mod cmd;
 
@@ -36,19 +38,94 @@ enum Commands {
     Install(cmd::install::InstallCommand),
 }
 
+/// A file handle shared by the tracing layer. Cloned per write; a poisoned lock is
+/// recovered rather than panicked on — losing a log line must never take the server
+/// down, since logging is a diagnostic aid, not a feature.
+#[derive(Clone)]
+struct FileSink(Arc<Mutex<std::fs::File>>);
+
+impl Write for FileSink {
+    fn write(&mut self, buf: &[u8]) -> std::io::Result<usize> {
+        let mut f = self.0.lock().unwrap_or_else(|e| e.into_inner());
+        f.write(buf)
+    }
+    fn flush(&mut self) -> std::io::Result<()> {
+        let mut f = self.0.lock().unwrap_or_else(|e| e.into_inner());
+        f.flush()
+    }
+}
+
+/// Issue #58: traces used to exist only on stderr, which an MCP stdio client does
+/// not persist — so nothing survived a session, exactly when a post-mortem is
+/// wanted. `IRIS_LOG_FILE=<path>` mirrors the same output (same RUST_LOG/--verbose
+/// filter) to a file, appending, and is off unless set.
+///
+/// Opening the file must never be fatal: on failure we warn once on stderr and run
+/// without it.
+fn init_tracing(verbose: bool) {
+    let filter = EnvFilter::from_default_env().add_directive(if verbose {
+        tracing::Level::DEBUG.into()
+    } else {
+        tracing::Level::WARN.into()
+    });
+    let stderr_layer = tracing_subscriber::fmt::layer()
+        .with_writer(std::io::stderr)
+        .with_ansi(false);
+
+    let sink = std::env::var("IRIS_LOG_FILE")
+        .ok()
+        .filter(|p| !p.trim().is_empty())
+        .and_then(|path| match open_log_file(&path) {
+            Ok(sink) => Some(sink),
+            Err(e) => {
+                eprintln!("iris-interop-dev: cannot write IRIS_LOG_FILE={path}: {e} — continuing without a log file");
+                None
+            }
+        });
+
+    match sink {
+        Some(sink) => {
+            let file_layer = tracing_subscriber::fmt::layer()
+                .with_writer(move || sink.clone())
+                .with_ansi(false);
+            tracing_subscriber::registry()
+                .with(filter)
+                .with(stderr_layer)
+                .with(file_layer)
+                .init();
+        }
+        None => {
+            tracing_subscriber::registry()
+                .with(filter)
+                .with(stderr_layer)
+                .init();
+        }
+    }
+}
+
+/// Open the log file for append and stamp a session banner, so consecutive runs in
+/// one file are separable and every session records which build produced it.
+/// Deliberately records no environment values — IRIS_PASSWORD must never land here.
+fn open_log_file(path: &str) -> std::io::Result<FileSink> {
+    let mut file = std::fs::OpenOptions::new()
+        .create(true)
+        .append(true)
+        .open(path)?;
+    let _ = writeln!(
+        file,
+        "=== iris-interop-dev {} session start {} pid={} ===",
+        env!("CARGO_PKG_VERSION"),
+        chrono::Utc::now().format("%Y-%m-%dT%H:%M:%SZ"),
+        std::process::id()
+    );
+    Ok(FileSink(Arc::new(Mutex::new(file))))
+}
+
 #[tokio::main]
 async fn main() -> Result<()> {
     let cli = Cli::parse();
 
-    tracing_subscriber::fmt()
-        .with_env_filter(EnvFilter::from_default_env().add_directive(if cli.verbose {
-            tracing::Level::DEBUG.into()
-        } else {
-            tracing::Level::WARN.into()
-        }))
-        .with_writer(std::io::stderr)
-        .with_ansi(false)
-        .init();
+    init_tracing(cli.verbose);
 
     if cli.list_plugins {
         cmd::plugin::list_plugins();

--- a/crates/iris-agentic-dev-core/src/tools/envelope.rs
+++ b/crates/iris-agentic-dev-core/src/tools/envelope.rs
@@ -59,6 +59,10 @@ pub fn fail_with(
 ///
 /// `context` names the operation for the message; `err` is the underlying error.
 pub fn transport_fail(context: &str, err: &str) -> Result<CallToolResult, McpError> {
+    // #58: record it server-side too. Before #57 this condition surfaced as an rmcp
+    // "response error" WARN; routing it through the envelope removed that line, so
+    // without this the server would go quiet about the failure it just reported.
+    tracing::warn!(context, error = err, "IRIS request failed");
     if crate::tools::interop::is_network_error(err) {
         fail(
             "IRIS_UNREACHABLE",

--- a/crates/iris-agentic-dev-core/tests/mcp_handshake.rs
+++ b/crates/iris-agentic-dev-core/tests/mcp_handshake.rs
@@ -416,3 +416,118 @@ fn unreachable_iris_returns_the_error_envelope_not_a_protocol_error() {
         "an unreachable IRIS has a mechanical fix — say it: {v}"
     );
 }
+
+/// The two log-file tests spawn several servers each. Run them one at a time so the
+/// suite's peak process count stays where it was — `mcp_server_startup_latency_under_100ms`
+/// measures real startup and reads spawn contention as a regression.
+static LOG_TEST_GUARD: std::sync::Mutex<()> = std::sync::Mutex::new(());
+
+/// #58: with IRIS_LOG_FILE set, the session's traces must survive the process, so a
+/// failed workshop run can be reconstructed afterwards. Off unless set, and never
+/// fatal when the path cannot be opened.
+#[test]
+fn log_file_is_written_when_requested_and_absent_otherwise() {
+    let _serialized = LOG_TEST_GUARD.lock().unwrap_or_else(|e| e.into_inner());
+    std::thread::sleep(std::time::Duration::from_millis(500));
+    let bin = iris_dev_bin();
+    if !bin.exists() {
+        eprintln!("Skipping: binary not found at {}", bin.display());
+        return;
+    }
+    let log = std::env::temp_dir().join(format!("iris-mcp-log-test-{}.log", std::process::id()));
+    let _ = std::fs::remove_file(&log);
+
+    let run = |log_env: Option<&std::path::Path>| {
+        let mut cmd = Command::new(&bin);
+        cmd.arg("mcp")
+            .env("IRIS_WEB_PORT", "9")
+            .env("IRIS_PASSWORD", "shouldnotappear")
+            .stdin(Stdio::piped())
+            .stdout(Stdio::piped())
+            .stderr(Stdio::null());
+        if let Some(p) = log_env {
+            cmd.env("IRIS_LOG_FILE", p);
+        }
+        let mut child = cmd.spawn().expect("spawn");
+        let mut stdin = child.stdin.take().unwrap();
+        let mut reader = BufReader::new(child.stdout.take().unwrap());
+        send_jsonrpc(
+            &mut stdin,
+            1,
+            "initialize",
+            r#"{"protocolVersion":"2024-11-05","capabilities":{},"clientInfo":{"name":"t","version":"1"}}"#,
+        );
+        let _ = read_jsonrpc(&mut reader);
+        let _ = child.kill();
+        let _ = child.wait();
+    };
+
+    // Not set → nothing is created.
+    run(None);
+    assert!(
+        !log.exists(),
+        "the log file must be opt-in — nothing should be written without IRIS_LOG_FILE"
+    );
+
+    // Set → the session is recorded, stamped with the build that produced it.
+    run(Some(&log));
+    let body = std::fs::read_to_string(&log).expect("log file should exist once requested");
+    assert!(
+        body.contains("session start"),
+        "each run must be delimited so consecutive sessions are separable: {body}"
+    );
+    assert!(
+        body.contains(env!("CARGO_PKG_VERSION")),
+        "the banner must record which build produced the log: {body}"
+    );
+    assert!(
+        !body.contains("shouldnotappear"),
+        "credentials must never reach the log file: {body}"
+    );
+
+    // A second run appends rather than truncating — a cohort's runs accumulate.
+    run(Some(&log));
+    let body = std::fs::read_to_string(&log).unwrap();
+    assert_eq!(
+        body.matches("session start").count(),
+        2,
+        "second session must append, not truncate: {body}"
+    );
+
+    let _ = std::fs::remove_file(&log);
+}
+
+/// #58: an unopenable path is a diagnostic problem, not a fatal one — the server
+/// must still serve.
+#[test]
+fn an_unwritable_log_path_does_not_stop_the_server() {
+    let _serialized = LOG_TEST_GUARD.lock().unwrap_or_else(|e| e.into_inner());
+    std::thread::sleep(std::time::Duration::from_millis(500));
+    let bin = iris_dev_bin();
+    if !bin.exists() {
+        return;
+    }
+    let mut child = Command::new(&bin)
+        .arg("mcp")
+        .env("IRIS_WEB_PORT", "9")
+        .env("IRIS_LOG_FILE", "/nonexistent-dir-for-test/x.log")
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::null())
+        .spawn()
+        .expect("spawn");
+    let mut stdin = child.stdin.take().unwrap();
+    let mut reader = BufReader::new(child.stdout.take().unwrap());
+    send_jsonrpc(
+        &mut stdin,
+        1,
+        "initialize",
+        r#"{"protocolVersion":"2024-11-05","capabilities":{},"clientInfo":{"name":"t","version":"1"}}"#,
+    );
+    let frame = read_jsonrpc(&mut reader);
+    let _ = child.kill();
+    assert_eq!(
+        frame["result"]["serverInfo"]["name"], "iris-interop-dev",
+        "server must still handshake with an unusable log path: {frame}"
+    );
+}


### PR DESCRIPTION
Closes #58.

## The gap

Traces went to **stderr only**, and an MCP stdio client does not persist that. The local Claude Code log directory for this server holds 53 records — every one the client's own connection-lifecycle line, none of the server's. After a workshop session there was nothing to read back, which is exactly when you want a post-mortem.

## What this adds

`IRIS_LOG_FILE=<path>` mirrors the same tracing output to a file, honouring the same `RUST_LOG` / `--verbose` filter. **Off unless set** — nothing changes for anyone who does not ask for it.

- **Appends**, and stamps a session banner (version, UTC time, pid) so consecutive runs in one file stay separable and every session records which build produced it.
- **Never fatal.** An unopenable path produces one warning on stderr and the server runs without it — a workshop machine with a bad path must still work.
- Writes go through a cloneable handle whose **poisoned lock is recovered, not unwrapped**: losing a log line must never take the server down.
- **No secrets.** The banner records no environment values, and a test asserts a password passed via `IRIS_PASSWORD` never appears in the file.

## A gap #57 created, closed here

#57 routed connection failures through the envelope — which removed the `rmcp` "response error" WARN that had been the *only* server-side trace of one. Without this, the server would report the failure to the model and stay silent in its own log. `transport_fail` now logs it. The two together:

```
=== iris-interop-dev 0.8.0 session start 2026-08-25T06:57:45Z pid=51189 ===
2026-08-25T06:57:45.909844Z  WARN ...envelope: IRIS request failed
    context="iris_query" error="error sending request for url (http://127.0.0.1:9/api/atelier/v1/USER/action/query)"
```

The model gets a classified envelope with a hint; the operator gets a durable trace naming the tool and the URL; the password used in that same run appears nowhere.

## Verification

Three tests in the CI-gated `mcp_handshake` target: written-when-asked / absent otherwise, appends across sessions, no credentials in the file, and unwritable-path-still-serves. Verified by hand too, including the append and leak checks.

They spawn several servers each, so they take a mutex — `mcp_server_startup_latency_under_100ms` measures real startup and reads spawn contention as a regression. It failed once under the added parallel load before I serialized them; four consecutive full runs are green after.

Full local gate: fmt, clippy `-D warnings`, the CI test list run twice, `interop_e2e_tests --ignored` 10/10 live.

## Not included

`agent_history` (the 50-call ring that is recorded but pruned from this fork's profile) is left alone — it is a separate call, noted in #58 for a follow-up decision rather than swept in here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)