### PR TITLE
chore(release): 0.8.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -945,7 +945,7 @@ dependencies = [
 
 [[package]]
 name = "iris-agentic-dev"
-version = "0.8.0"
+version = "0.8.1"
 dependencies = [
  "anyhow",
  "chrono",
@@ -963,7 +963,7 @@ dependencies = [
 
 [[package]]
 name = "iris-agentic-dev-core"
-version = "0.8.0"
+version = "0.8.1"
 dependencies = [
  "anyhow",
  "bollard",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "0.8.0"
+version = "0.8.1"
 edition = "2021"
 authors = ["Thomas Dyar <thomas.dyar@intersystems.com>"]
 license = "MIT"


### PR DESCRIPTION
Version bump for 0.8.1. The release workflow's provenance guard (#3) refuses to publish unless the tag, `Cargo.toml` and the built binary's `--version` agree, so this lands before `v0.8.1-interop` is tagged.

**Patch, not minor** — both changes fix existing behaviour and add no tools, unlike 0.8.0.

| Issue | PR | What changes for the user |
|---|---|---|
| #57 | #59 | An unreachable IRIS returns `IRIS_UNREACHABLE` with a hint (check the instance is running, check `IRIS_HOST`/`IRIS_WEB_PORT`, call `check_config`) instead of a `-32603` frame with no `result`. The most common workshop failure, and previously invisible to any telemetry keyed on `error_code`. |
| #58 | #60 | `IRIS_LOG_FILE=<path>` mirrors the server's traces to a file — opt-in, appending, stamped with a session banner, never fatal on a bad path, and carrying no environment values. A failed session can now be reconstructed afterwards. |

Local binary confirms `iris-interop-dev 0.8.1`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)