### PR TITLE
fix(interop): iris_production reads the production name it documents (fixes #63)

### DIFF
--- a/crates/iris-agentic-dev-core/src/tools/interop.rs
+++ b/crates/iris-agentic-dev-core/src/tools/interop.rs
@@ -46,6 +46,28 @@ pub fn resolve_namespace(requested: Option<&str>, iris: Option<&IrisConnection>)
     }
 }
 
+/// Issue #63: `iris_production` read the production name from `production_name`
+/// in start/stop but from `production` in set_autostart, while the parameter
+/// struct and the tool description both say `production`. A name passed under the
+/// documented key was dropped, and the resulting empty name still went on to
+/// `Ens.Director`, which answers `<Ens>ErrInvalidProduction` — the SAME error
+/// IRIS gives when the production class was never compiled in the namespace. A
+/// parameter typo was therefore indistinguishable from a real deployment
+/// failure, and the correct next move looked like "compile it again".
+///
+/// One reader, every spelling; blank is treated as absent so it cannot reach a
+/// lifecycle call.
+pub const PRODUCTION_NAME_KEYS: [&str; 3] = ["production", "production_name", "name"];
+
+pub fn production_name_arg(p: &serde_json::Value) -> Option<String> {
+    PRODUCTION_NAME_KEYS
+        .iter()
+        .filter_map(|k| p.get(k).and_then(|v| v.as_str()))
+        .map(str::trim)
+        .find(|s| !s.is_empty())
+        .map(|s| s.to_string())
+}
+
 /// Positive probe results, keyed "base_url|namespace". Never invalidated: a
 /// namespace does not lose Interoperability within a server process lifetime.
 /// Negatives are NOT cached — a namespace can gain interop (or be created)
@@ -361,14 +383,33 @@ pub async fn interop_production_start_impl(
     iris: Option<&IrisConnection>,
     params: ProductionNameParams,
 ) -> Result<CallToolResult, McpError> {
+    // #63: a missing name is a PARAMETER error. Answer it here — an empty name
+    // reaching StartProduction comes back as ErrInvalidProduction, which is what
+    // IRIS says when the production was never compiled in this namespace.
+    let prod = match params.production.as_deref().map(str::trim) {
+        Some(p) if !p.is_empty() => p,
+        _ => {
+            return crate::tools::envelope::fail_with(
+                "MISSING_PARAMETER",
+                "iris_production action=start needs the production class name — nothing was sent to Ens.Director.",
+                serde_json::json!({
+                    "accepted_parameters": PRODUCTION_NAME_KEYS,
+                    "namespace": &params.namespace,
+                    "hint": "Pass production=<Package.ProductionName> (production_name and name are also accepted). \
+                             To see what is registered in this namespace: iris_query \
+                             \"SELECT ID FROM Ens_Config.Production\".",
+                }),
+            )
+        }
+    };
     let iris = match iris {
         Some(i) => i,
         None => return err_json("IRIS_UNREACHABLE", "No IRIS connection"),
     };
-    let prod = params.production.as_deref().unwrap_or("");
+    // #6: every user string reaching ObjectScript goes through os_str_expr.
     let code = format!(
-        r#"Set sc=##class(Ens.Director).StartProduction("{}") If $$$ISERR(sc) {{ Write "ERROR:"_$System.Status.GetErrorText(sc) }} Else {{ Write "OK" }}"#,
-        prod
+        r#"Set sc=##class(Ens.Director).StartProduction({}) If $$$ISERR(sc) {{ Write "ERROR:"_$System.Status.GetErrorText(sc) }} Else {{ Write "OK" }}"#,
+        os_str_expr(prod)
     );
     // Bug 7: use params.namespace, not iris.namespace.
     match exec_http(iris, &code, &params.namespace).await {
@@ -3292,5 +3333,44 @@ mod tests {
         ).unwrap();
         assert_eq!(p2.enabled, Some(true));
         assert_eq!(p2.production.as_deref(), Some("MyApp.Production"));
+    }
+
+    // ─── #63: one reader for the production-name argument ───
+
+    #[test]
+    fn production_name_arg_reads_every_documented_spelling() {
+        for key in PRODUCTION_NAME_KEYS {
+            let p = serde_json::json!({ key: "EvalOps.Production" });
+            assert_eq!(
+                production_name_arg(&p).as_deref(),
+                Some("EvalOps.Production"),
+                "key {key} must be accepted"
+            );
+        }
+    }
+
+    #[test]
+    fn production_name_arg_treats_blank_as_absent() {
+        assert_eq!(production_name_arg(&serde_json::json!({})), None);
+        assert_eq!(
+            production_name_arg(&serde_json::json!({"production": "   "})),
+            None
+        );
+        // A blank under one spelling must not mask a real name under another.
+        assert_eq!(
+            production_name_arg(
+                &serde_json::json!({"production": "", "production_name": "P.Prod"})
+            )
+            .as_deref(),
+            Some("P.Prod")
+        );
+    }
+
+    #[test]
+    fn production_name_arg_trims() {
+        assert_eq!(
+            production_name_arg(&serde_json::json!({"name": " P.Prod "})).as_deref(),
+            Some("P.Prod")
+        );
     }
 }

--- a/crates/iris-agentic-dev-core/src/tools/mod.rs
+++ b/crates/iris-agentic-dev-core/src/tools/mod.rs
@@ -4443,7 +4443,7 @@ Methods:
     // Note: iris_debug already exists above as a real tool — it IS the merged debug dispatcher.
 
     #[tool(
-        description = "Interoperability production lifecycle (merged). action: status=get current state, start=start named production, stop=stop production, restart=recycle ONE config item (pass item=<config item name>), update=hot-apply config, check=check if update needed, recover=recover troubled production. namespace: optional — defaults to the connection namespace (IRIS_NAMESPACE); must be an interop-enabled namespace."
+        description = "Interoperability production lifecycle (merged). action: status=get current state, start=start a production — pass production=<Package.ProductionName> (production_name and name are accepted too), stop=stop the running production, restart=recycle ONE config item (pass item=<config item name>), update=hot-apply config, check=check if update needed, recover=recover troubled production, get_autostart/set_autostart=read or set this namespace's autostart production. namespace: optional — defaults to the connection namespace (IRIS_NAMESPACE); must be an interop-enabled namespace."
     )]
     async fn iris_production(
         &self,
@@ -4475,10 +4475,8 @@ Methods:
                 interop::interop_production_start_impl(
                     iris_opt,
                     interop::ProductionNameParams {
-                        production: p
-                            .get("production_name")
-                            .and_then(|v| v.as_str())
-                            .map(|s| s.to_string()),
+                        // #63: production / production_name / name all work.
+                        production: interop::production_name_arg(&p),
                         namespace: namespace.clone(),
                     },
                 )
@@ -4488,10 +4486,8 @@ Methods:
                 interop::interop_production_stop_impl(
                     iris_opt,
                     interop::ProductionStopParams {
-                        production: p
-                            .get("production_name")
-                            .and_then(|v| v.as_str())
-                            .map(|s| s.to_string()),
+                        // #63: production / production_name / name all work.
+                        production: interop::production_name_arg(&p),
                         namespace: namespace.clone(),
                         timeout: p.get("timeout").and_then(|v| v.as_u64()).unwrap_or(30) as u32,
                         force: p.get("force").and_then(|v| v.as_bool()).unwrap_or(false),
@@ -4546,7 +4542,7 @@ Methods:
                         action: "set_autostart".into(),
                         namespace: namespace.clone(),
                         enabled: p.get("enabled").and_then(|v| v.as_bool()),
-                        production: p.get("production").and_then(|v| v.as_str()).map(|s| s.to_string()),
+                        production: interop::production_name_arg(&p),
                     },
                 ).await
             }

--- a/crates/iris-agentic-dev-core/tests/interop_unit_tests.rs
+++ b/crates/iris-agentic-dev-core/tests/interop_unit_tests.rs
@@ -118,6 +118,48 @@ mod interop_production_start {
     }
 }
 
+mod production_start_missing_name {
+    use super::*;
+
+    /// #63: an absent or blank name never reaches Ens.Director. It used to be
+    /// passed through as `StartProduction("")`, which answers
+    /// `<Ens>ErrInvalidProduction` — the same error IRIS gives when the production
+    /// class was never compiled in the namespace, so a parameter slip read as a
+    /// deployment failure and the "fix" looked like recompiling.
+    #[test]
+    fn is_a_parameter_error_not_a_lifecycle_error() {
+        for missing in [None, Some("   ".to_string())] {
+            let r = rt().block_on(interop_production_start_impl(
+                None,
+                ProductionNameParams {
+                    production: missing.clone(),
+                    namespace: "APP".into(),
+                },
+            ));
+            let result = r.unwrap();
+            assert_eq!(result.is_error, Some(true), "for {missing:?}");
+            let text = result.content[0].raw.as_text().unwrap().text.clone();
+            let v: serde_json::Value = serde_json::from_str(&text).unwrap();
+            assert_eq!(v["error_code"], "MISSING_PARAMETER", "for {missing:?}");
+            let err = v["error"].as_str().unwrap();
+            assert!(
+                !err.contains("ErrInvalidProduction"),
+                "must not look like a real IRIS lifecycle failure: {err}"
+            );
+            let accepted: Vec<&str> = v["accepted_parameters"]
+                .as_array()
+                .unwrap()
+                .iter()
+                .map(|x| x.as_str().unwrap())
+                .collect();
+            for key in ["production", "production_name", "name"] {
+                assert!(accepted.contains(&key), "{key} must be named in the error");
+            }
+            assert_eq!(v["namespace"], "APP");
+        }
+    }
+}
+
 mod interop_production_stop {
     use super::*;
 


### PR DESCRIPTION
Fixes #63.

## The defect

`iris_production` read the production name from **`production_name`** in `start`/`stop`, from **`production`** in `set_autostart`, while `ProductionNameParams` / `ProductionStopParams` and the tool description both say **`production`**. A name passed under the documented key was silently dropped — and the resulting empty name still went on to `Ens.Director`:

```
ERROR:ERROR <Ens>ErrInvalidProduction: Invalid Production
```

That is a real diagnostic with a specific meaning: the production class is not in this namespace, typically because it was never compiled there. Returning it for a wrong argument name makes a parameter error indistinguishable from a genuine deployment problem, so the correct-looking next move is "compile it again" — a loop on an action that already succeeded.

Reproduced verbatim on the installed 0.8.1 before the fix, against a namespace where `SELECT ID FROM Ens_Config.Production` lists the production.

## The fix

- **`interop::production_name_arg`** — one reader for all three name-taking actions, accepting `production`, `production_name` and `name`. Blank is treated as absent so it can never reach a lifecycle call. `restart` already showed this `.or_else()` tolerance for `item`/`component`.
- **`start` refuses a missing name itself** with `MISSING_PARAMETER` + `isError`, naming the accepted keys and how to list what is registered, instead of calling `Ens.Director`. `stop` is unchanged in that respect — `StopProduction(timeout, force)` takes no name, so requiring one there would break valid calls.
- **The description names the key** it reads, and now also lists `get_autostart`/`set_autostart` (already valid actions, already named in the `INVALID_ACTION` message).
- **`os_str_expr` on the embed** — the name was interpolated into ObjectScript raw; every other embed in this file goes through `os_str_expr` (#6). One line, on a line already being changed.

## Verification

Unit: `production_name_arg` over every spelling, blank-vs-absent, trimming, and a blank under one key not masking a real name under another; plus a `start` test asserting `MISSING_PARAMETER` (not `ErrInvalidProduction`) with the accepted keys named.

Live, against IRIS 2026.1 in namespace `APP`:

| call | before | after |
|---|---|---|
| `start` + `production=APPPKG.FoundationProduction` | `ErrInvalidProduction` | `{"state":"Running"}` |
| `start` + `production_name=…` | `{"state":"Running"}` | `{"state":"Running"}` |
| `start` + `name=…` | `ErrInvalidProduction` | `{"state":"Running"}` |
| `start`, no name | `ErrInvalidProduction` | `MISSING_PARAMETER`, `isError`, nothing sent to `Ens.Director` |
| `start` + `production="   "` | `ErrInvalidProduction` | `MISSING_PARAMETER` |
| `start` + `production=No.Such.Production` | `ErrInvalidProduction` | `ErrInvalidProduction` — now unambiguous |

The namespace was left as found (stopped).

Gates: `cargo fmt --check`, `clippy --all-targets -D warnings`, and the full ci.yml test list green. (`mcp_server_startup_latency_under_100ms` failed once under parallel load and passes on re-run — the known load sensitivity, unrelated to this change: it spawns no new servers.)

## Not done here

A genuinely absent production still returns a bare `ErrInvalidProduction` with no hint. Listing the namespace's registered productions on that path would close the loop the way `did_you_mean` did for #47 — worth a follow-up, kept out of this fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)