### PR TITLE
fix(codegen): every ObjectScript embed goes through os_str_expr (fixes #67)

### DIFF
--- a/crates/iris-agentic-dev-core/src/tools/dict.rs
+++ b/crates/iris-agentic-dev-core/src/tools/dict.rs
@@ -1,6 +1,7 @@
 //! %Dictionary introspection tools for dynamic dispatch resolution.
 
 use crate::iris::connection::IrisConnection;
+use crate::objectscript::os_str_expr;
 use schemars::JsonSchema;
 use serde::Deserialize;
 use std::collections::HashMap;
@@ -79,8 +80,10 @@ pub async fn handle_resolve_dynamic_dispatch(
     }
 
     let has_prefix = !prefix.is_empty();
-    let method_esc = p.method_name.replace('"', "\\\"");
-    let prefix_esc = prefix.replace('"', "\\\"");
+    // #67: bound-style values still travel inside generated ObjectScript, so they are
+    // rendered as ObjectScript expressions, not wrapped in hand-written quotes.
+    let method_esc = os_str_expr(&p.method_name);
+    let prefix_esc = os_str_expr(prefix);
 
     // Build ObjectScript — use q=$CHAR(34) for embedded JSON quotes
     let mut lines: Vec<String> = vec!["Set q=$CHAR(34)".into()];
@@ -95,7 +98,7 @@ pub async fn handle_resolve_dynamic_dispatch(
     lines.push(format!(r#"Set sql="{}""#, sql));
     if has_prefix {
         lines.push(format!(
-            r#"Set rs=##class(%SQL.Statement).%ExecDirect(,sql,"{}","{}")"#,
+            r#"Set rs=##class(%SQL.Statement).%ExecDirect(,sql,{},{})"#,
             method_esc, prefix_esc
         ));
     } else {
@@ -254,7 +257,7 @@ pub struct FindSubclassImplementationsParams {
 fn build_expand_hierarchy_code(base_classes: &[String]) -> String {
     let bases_list = base_classes
         .iter()
-        .map(|c| format!(r#"$LISTBUILD("{}")"#, c.replace('"', "\\\"")))
+        .map(|c| format!(r#"$LISTBUILD({})"#, os_str_expr(c)))
         .collect::<Vec<_>>()
         .join("_");
     format!(
@@ -321,16 +324,16 @@ pub async fn handle_find_subclass_implementations(
         return ok_json(r);
     }
 
-    let method_esc = p.method_name.replace('"', "\\\"");
+    let method_esc = os_str_expr(&p.method_name);
     let desc_list = descendants
         .iter()
-        .map(|c| format!(r#"$LISTBUILD("{}")"#, c.replace('"', "\\\"")))
+        .map(|c| format!(r#"$LISTBUILD({})"#, os_str_expr(c)))
         .collect::<Vec<_>>()
         .join("_");
 
     let mut lines: Vec<String> = vec!["Set q=$CHAR(34)".into()];
     lines.push(format!("Set descList={}", desc_list));
-    lines.push(format!(r#"Set rs=##class(%SQL.Statement).%ExecDirect(,"SELECT m.parent, m.FormalSpec FROM %Dictionary.CompiledMethod m WHERE m.Name = ? AND m.Origin = m.parent ORDER BY m.parent FETCH FIRST {} ROWS ONLY","{}")"#, limit, method_esc));
+    lines.push(format!(r#"Set rs=##class(%SQL.Statement).%ExecDirect(,"SELECT m.parent, m.FormalSpec FROM %Dictionary.CompiledMethod m WHERE m.Name = ? AND m.Origin = m.parent ORDER BY m.parent FETCH FIRST {} ROWS ONLY",{})"#, limit, method_esc));
     lines.push(r#"If rs.%SQLCODE<0 { Write "ERROR:"_rs.%Message,! Quit }"#.into());
     lines.push(r#"Set out="[",sep="""#.into());
     lines.push("While rs.%Next() {".into());
@@ -373,6 +376,20 @@ pub async fn handle_find_subclass_implementations(
 }
 
 // ── Unit tests ────────────────────────────────────────────────────────────────
+
+#[cfg(test)]
+mod objectscript_escaping_tests {
+    use super::build_expand_hierarchy_code;
+
+    /// #67: class names reach $LISTBUILD as escaped expressions. A quote is doubled;
+    /// a backslash escape would end the literal and break the generated code.
+    #[test]
+    fn a_quote_in_a_class_name_is_doubled() {
+        let code = build_expand_hierarchy_code(&[r#"Pkg."Odd"Name"#.to_string()]);
+        assert!(code.contains(r#"$LISTBUILD("Pkg.""Odd""Name")"#), "{code}");
+        assert!(!code.contains("\\\""), "{code}");
+    }
+}
 
 #[cfg(test)]
 mod tests {

--- a/crates/iris-agentic-dev-core/src/tools/info.rs
+++ b/crates/iris-agentic-dev-core/src/tools/info.rs
@@ -4,6 +4,7 @@
 //! iris_generate — LLM-based class/test generation.
 
 use crate::iris::connection::IrisConnection;
+use crate::objectscript::os_str_expr;
 use crate::tools::log_store;
 use schemars::JsonSchema;
 use serde::Deserialize;
@@ -223,8 +224,8 @@ pub async fn handle_iris_debug(
         "map_int" => {
             let err = p.error_string.as_deref().unwrap_or("");
             let code = format!(
-                "set err=\"{}\" set routine=$piece($piece(err,\"^\",2),\".\",1) set offset=$piece(err,\"+\",2) set offset=$piece(offset,\"^\",1) write ##class(%Studio.Debugger).SourceLine(routine,+offset)",
-                err.replace('"', "\\\"")
+                "set err={} set routine=$piece($piece(err,\"^\",2),\".\",1) set offset=$piece(err,\"+\",2) set offset=$piece(offset,\"^\",1) write ##class(%Studio.Debugger).SourceLine(routine,+offset)",
+                os_str_expr(err)
             );
             // execute_via_generator works over plain Atelier HTTP — no docker exec
             // needed (issue #20; the DOCKER_REQUIRED bail-out made iris_debug fail on
@@ -456,7 +457,7 @@ pub async fn handle_iris_table_info(
     // Look up class projection: find a compiled class whose SQL mapping matches.
     let lookup_code = format!(
         r#"
-set sqlSchema = "{schema}", sqlTable = "{table}"
+set sqlSchema = {schema}, sqlTable = {table}
 // Check table exists at all via INFORMATION_SCHEMA
 set rsEx = ##class(%SQL.Statement).%ExecDirect(,"SELECT COUNT(*) FROM INFORMATION_SCHEMA.TABLES WHERE TABLE_SCHEMA = ? AND TABLE_NAME = ?", sqlSchema, sqlTable)
 if rsEx.%Next() && (rsEx.%GetData(1) = 0) {{ write "NOT_FOUND",! quit }}
@@ -472,8 +473,8 @@ if rs.%Next() {{
     write "DDL_TABLE",!
 }}
 "#,
-        schema = sql_schema.replace('"', "\\\""),
-        table = sql_table.replace('"', "\\\""),
+        schema = os_str_expr(&sql_schema),
+        table = os_str_expr(&sql_table),
     );
 
     let output = match iris
@@ -557,11 +558,14 @@ async fn get_row_count(
     schema: &str,
     table: &str,
 ) -> serde_json::Value {
+    // #67: build the SQL in Rust, then hand the whole statement to ObjectScript as ONE
+    // escaped expression. The delimited-identifier quotes around the schema are part of the
+    // SQL text, and os_str_expr doubles them for the ObjectScript literal.
+    let sql = format!(r#"SELECT COUNT(*) FROM "{schema}".{table}"#);
     let code = format!(
-        r#"set rs = ##class(%SQL.Statement).%ExecDirect(,"SELECT COUNT(*) FROM ""{schema}"".{table}")
+        r#"set rs = ##class(%SQL.Statement).%ExecDirect(,{sql})
 if rs.%Next() {{ write rs.%GetData(1),! }} else {{ write "error",! }}"#,
-        schema = schema.replace('"', "\\\""),
-        table = table.replace('"', "\\\""),
+        sql = os_str_expr(&sql),
     );
     match iris.execute_via_generator(&code, namespace, client).await {
         Ok(out) => out

--- a/crates/iris-agentic-dev-core/src/tools/mod.rs
+++ b/crates/iris-agentic-dev-core/src/tools/mod.rs
@@ -1,5 +1,6 @@
 use crate::elicitation::ElicitationStore;
 use crate::iris::connection::IrisConnection;
+use crate::objectscript::os_str_expr;
 
 /// Remediation hint appended to DOCKER_REQUIRED error strings.
 /// Guides native IRIS users (no Docker) toward the HTTP/Atelier REST path.
@@ -357,15 +358,18 @@ pub async fn probe_test_class_shape(
 /// terminal as well as the HTTP path. A stale or invalid root makes RunTest fail with
 /// "Directory ... is invalid" and report 0 tests. (A6.2)
 pub fn build_class_test_run_code(pattern: &str, flags: &str, token: &str) -> String {
+    // #67: one escaped expression, reused. ObjectScript doubles quotes; a backslash escapes
+    // nothing, so the old `"{pattern}"` broke the moment a pattern contained one.
+    let pattern = os_str_expr(pattern);
     format!(
         r#"set tIsWin=($zcvt($system.Version.GetOS(),"U")="WINDOWS")
 set ^UnitTestRoot=$select(tIsWin:##class(%File).NormalizeDirectory("httest",##class(%File).GetDirectory(##class(%File).TempFilename())),1:"/tmp/httest/")
 do ##class(%File).CreateDirectoryChain(^UnitTestRoot)
-set specDir=##class(%File).NormalizeDirectory($translate("{pattern}",".","/"),^UnitTestRoot)
+set specDir=##class(%File).NormalizeDirectory($translate({pattern},".","/"),^UnitTestRoot)
 do ##class(%File).CreateDirectoryChain(specDir)
-set tCls="{pattern}"
+set tCls={pattern}
 set tCC=##class(%Dictionary.CompiledClass).%OpenId(tCls)
-if $isobject(tCC)&&(tCC.PrimarySuper["%UnitTest.TestProduction") {{ do $classmethod(tCls,"Run") }} elseif $isobject(tCC)&&(tCC.PrimarySuper["%UnitTest.TestCase") {{ do ##class(%UnitTest.Manager).DebugRunTestCase("",tCls,"{flags}","","{token}") }} else {{ do ##class(%UnitTest.Manager).RunTest("{pattern}","{flags}","{token}") }}"#,
+if $isobject(tCC)&&(tCC.PrimarySuper["%UnitTest.TestProduction") {{ do $classmethod(tCls,"Run") }} elseif $isobject(tCC)&&(tCC.PrimarySuper["%UnitTest.TestCase") {{ do ##class(%UnitTest.Manager).DebugRunTestCase("",tCls,"{flags}","","{token}") }} else {{ do ##class(%UnitTest.Manager).RunTest({pattern},"{flags}","{token}") }}"#,
         token = token,
         pattern = pattern,
         flags = flags,
@@ -2523,8 +2527,8 @@ impl IrisTools {
 
         // US3: namespace existence check before running tests.
         let ns_check_code = format!(
-            "write ##class(%SYS.Namespace).Exists(\"{}\")",
-            namespace.replace('"', "\\\"")
+            "write ##class(%SYS.Namespace).Exists({})",
+            os_str_expr(&namespace)
         );
         let ns_exists = tokio::time::timeout(
             std::time::Duration::from_secs(10),
@@ -2550,14 +2554,16 @@ impl IrisTools {
 
         // Generate a UUID correlation token; used as UserParam in RunTest.
         let correlation_token = log_store::new_log_id();
-        let safe_pattern = p.pattern.replace('"', "\\\"");
 
         // Detect whether the pattern is a compiled class name or a filesystem directory path.
         // Class names contain dots and no path separators: "ISC.sql.Tests", "MyApp.Tests.*"
         // Directory paths contain / or \ : "MyApp/Tests", "/tmp/tests/MyApp"
         // When the pattern is a class name, pass /noload so RunTest looks in the compiled
         // database rather than scanning the filesystem under ^UnitTestRoot.
-        let is_class_pattern = !safe_pattern.contains('/') && !safe_pattern.contains('\\');
+        // #67: classify the pattern the caller actually sent. It used to be classified after
+        // C-style quote escaping, so a pattern containing `"` grew a backslash and was taken
+        // for a directory path.
+        let is_class_pattern = !p.pattern.contains('/') && !p.pattern.contains('\\');
         let flags = if is_class_pattern {
             "/verbose=1/nodelete/noload"
         } else {
@@ -2568,7 +2574,7 @@ impl IrisTools {
         // After RunTest completes, ^UnitTest.Result global IS persisted (globals bypass
         // the objectgenerator transaction boundary; SQL %Save() does not).
         let run_code = if is_class_pattern {
-            build_class_test_run_code(&safe_pattern, flags, &correlation_token)
+            build_class_test_run_code(&p.pattern, flags, &correlation_token)
         } else {
             // Directory path: set ^UnitTestRoot and pre-create the pattern subdirectory.
             // ^UnitTestRoot is platform-aware: a portable temp dir on Windows (mgr/Temp via
@@ -2577,12 +2583,12 @@ impl IrisTools {
                 r#"set tIsWin=($zcvt($system.Version.GetOS(),"U")="WINDOWS")
 set utRoot=$select(tIsWin:##class(%File).NormalizeDirectory("httest",##class(%File).GetDirectory(##class(%File).TempFilename())),1:"/tmp/httest/")
 if '##class(%File).DirectoryExists(utRoot) {{ do ##class(%File).CreateDirectoryChain(utRoot) }}
-set pkgDir=##class(%File).NormalizeDirectory("{pattern}",utRoot)
+set pkgDir=##class(%File).NormalizeDirectory({pattern},utRoot)
 if '##class(%File).DirectoryExists(pkgDir) {{ do ##class(%File).CreateDirectoryChain(pkgDir) }}
 set ^UnitTestRoot=utRoot
-do ##class(%UnitTest.Manager).RunTest("{pattern}","{flags}","{token}")"#,
+do ##class(%UnitTest.Manager).RunTest({pattern},"{flags}","{token}")"#,
                 token = correlation_token,
-                pattern = safe_pattern,
+                pattern = os_str_expr(&p.pattern),
                 flags = flags,
             )
         };
@@ -3849,8 +3855,8 @@ do ##class(%UnitTest.Manager).RunTest("{pattern}","{flags}","{token}")"#,
         let namespace = interop::resolve_namespace(p.namespace.as_deref(), Some(&iris));
         let _client = self.http_client();
         let code = format!(
-            "Write ##class(%Studio.Debugger).SourceLine(\"{}\",{})",
-            p.routine.replace('"', "\\\""),
+            "Write ##class(%Studio.Debugger).SourceLine({},{})",
+            os_str_expr(&p.routine),
             p.offset
         );
         match iris.execute(&code, &namespace).await {
@@ -3946,8 +3952,8 @@ do ##class(%UnitTest.Manager).RunTest("{pattern}","{flags}","{token}")"#,
         let namespace = interop::resolve_namespace(p.namespace.as_deref(), Some(&iris));
         // Build source map by querying %Studio.Debugger for each .INT method
         let code = format!(
-            "set cls=\"{}\" set rtn=$translate(cls,\".\",\".\") set map=\"{{\" set first=1 set method=\"\" for {{ set method=$order(^rIndex(rtn,method)) quit:method=\"\"  set intline=$get(^rIndex(rtn,method)) if 'first {{ set map=map_\",\" }} set map=map_\"\\\"\"_method_\"\\\":\\\"\"_intline_\"\\\"\" set first=0 }} set map=map_\"}}\" write map",
-            cls_name.replace('"', "\\\"")
+            "set cls={} set rtn=$translate(cls,\".\",\".\") set map=\"{{\" set first=1 set method=\"\" for {{ set method=$order(^rIndex(rtn,method)) quit:method=\"\"  set intline=$get(^rIndex(rtn,method)) if 'first {{ set map=map_\",\" }} set map=map_\"\\\"\"_method_\"\\\":\\\"\"_intline_\"\\\"\" set first=0 }} set map=map_\"}}\" write map",
+            os_str_expr(cls_name)
         );
         // Bug 23: use namespace, not the hardcoded "USER".
         match iris.execute(&code, &namespace).await {
@@ -4151,7 +4157,7 @@ Methods:
         Parameters(p): Parameters<SkillNameParams>,
     ) -> Result<CallToolResult, McpError> {
         if let Some(iris) = self.iris_arc().as_deref() {
-            let code = format!("Write $Get(^SKILLS(\"{}\"))", p.name.replace('"', "\\\""));
+            let code = format!("Write $Get(^SKILLS({}))", os_str_expr(&p.name));
             if let Ok(output) = iris
                 .execute(&code, &crate::tools::skills_tools::skills_namespace())
                 .await
@@ -4207,10 +4213,7 @@ Methods:
         Parameters(p): Parameters<SkillNameParams>,
     ) -> Result<CallToolResult, McpError> {
         if let Some(iris) = self.iris_arc().as_deref() {
-            let code = format!(
-                "Kill ^SKILLS(\"{}\") Write \"OK\"",
-                p.name.replace('"', "\\\"")
-            );
+            let code = format!("Kill ^SKILLS({}) Write \"OK\"", os_str_expr(&p.name));
             if iris
                 .execute(&code, &crate::tools::skills_tools::skills_namespace())
                 .await
@@ -6123,6 +6126,19 @@ mod class_run_code_tests {
         let code = build_class_test_run_code("MyApp.Tests.Thing", FLAGS, "tok");
         assert!(code.contains("set ^UnitTestRoot="), "{code}");
         assert!(code.contains("CreateDirectoryChain(specDir)"), "{code}");
+    }
+
+    /// #67: the pattern is caller text. ObjectScript doubles a quote inside a literal, so
+    /// the old `"{pattern}"` with C-style escaping produced code that could not compile —
+    /// and the tool reported it as "no tests found", never as a broken call.
+    #[test]
+    fn a_quote_in_the_pattern_is_doubled_not_backslashed() {
+        let code = build_class_test_run_code(r#"Foo"Bar.Tests"#, FLAGS, "tok");
+        assert!(code.contains(r#"set tCls="Foo""Bar.Tests""#), "{code}");
+        assert!(
+            !code.contains("\\\""),
+            "no C-style escaping may survive: {code}"
+        );
     }
 
     /// The dispatch stays on ONE line: this code is piped through a docker-exec terminal as

--- a/crates/iris-agentic-dev-core/src/tools/skills_tools.rs
+++ b/crates/iris-agentic-dev-core/src/tools/skills_tools.rs
@@ -1,6 +1,22 @@
 //! skill, skill_community, kb, agent_info tools via docker exec + ^SKILLS global.
 
 use crate::iris::connection::IrisConnection;
+use crate::objectscript::os_str_expr;
+
+/// Issue #67: write one `^SKILLS` entry. Each field is its own escaped ObjectScript
+/// expression, concatenated with the pipe separators the readers `$piece` back apart —
+/// the old form pasted all four into ONE literal after C-style `\"` escaping, so a
+/// description or a skill body containing a quote (or, for an installed skill, a newline,
+/// which a literal cannot hold at all) produced code that could not compile.
+fn skills_set_code(name: &str, description: &str, body: &str, now: &str) -> String {
+    format!(
+        "set ^SKILLS({})={}_\"|\"_{}_\"|0|\"_{} write \"ok\"",
+        os_str_expr(name),
+        os_str_expr(description),
+        os_str_expr(body),
+        os_str_expr(now),
+    )
+}
 use crate::tools::ToolCallEntry;
 use schemars::JsonSchema;
 use serde::Deserialize;
@@ -63,7 +79,11 @@ pub async fn handle_skill(
     match p.action.as_str() {
         "list" => {
             // Bug 9: use separator variable so empty global yields "[]" not "]".
-            let code = "set key=\"\" set out=\"[\" set sep=\"\" for  { set key=$order(^SKILLS(key)) quit:key=\"\"  set data=$get(^SKILLS(key)) set out=out_sep_\"{\"_\"\\\"name\\\":\\\"\"_key_\"\\\",\\\"description\\\":\\\"\"_$piece(data,\"|\",1)_\"\\\",\\\"usage_count\\\":\"_$piece(data,\"|\",3)_\"}\" set sep=\",\" } set out=out_\"]\" write out";
+            // #67: a JSON quote inside an ObjectScript literal is $CHAR(34), never \" —
+            // backslash escapes nothing, so the old form was not valid ObjectScript and this
+            // tool could only ever answer []. Stored values are stripped of quotes/newlines
+            // so the assembled JSON stays parseable.
+            let code = "set q=$CHAR(34) set key=\"\" set out=\"[\" set sep=\"\" for  { set key=$order(^SKILLS(key)) quit:key=\"\"  set data=$get(^SKILLS(key)) set out=out_sep_\"{\"_q_\"name\"_q_\":\"_q_$translate(key,q_$CHAR(13,10),\"   \")_q_\",\"_q_\"description\"_q_\":\"_q_$translate($piece(data,\"|\",1),q_$CHAR(13,10),\"   \")_q_\",\"_q_\"usage_count\"_q_\":\"_+$piece(data,\"|\",3)_\"}\" set sep=\",\" } set out=out_\"]\" write out";
             let raw = xecute(iris, client, code, &ns).await.unwrap_or_default();
             let skills: serde_json::Value =
                 serde_json::from_str(&raw).unwrap_or(serde_json::json!([]));
@@ -71,10 +91,7 @@ pub async fn handle_skill(
         }
         "describe" => {
             let name = p.name.as_deref().unwrap_or("");
-            let code = format!(
-                "set data=$get(^SKILLS(\"{}\")) write data",
-                name.replace('"', "\\\"")
-            );
+            let code = format!("set data=$get(^SKILLS({})) write data", os_str_expr(name));
             let raw = xecute(iris, client, &code, &ns).await.unwrap_or_default();
             if raw.is_empty() {
                 return err_json("NOT_FOUND", &format!("Skill '{}' not found", name));
@@ -93,8 +110,8 @@ pub async fn handle_skill(
             let query = p.query.as_deref().unwrap_or("").to_lowercase();
             // Bug 9: use separator variable so empty results yield "[]" not "]".
             let code = format!(
-                "set key=\"\" set out=\"[\" set sep=\"\" for {{ set key=$order(^SKILLS(key)) quit:key=\"\"  set data=$get(^SKILLS(key)) if $find($zconvert(key_data,\"L\"),\"{}\")>0 {{ set out=out_sep_\"{{\\\"name\\\":\\\"\"_key_\"\\\",\\\"description\\\":\\\"\"_$piece(data,\"|\",1)_\"\\\"}}\" set sep=\",\" }} }} set out=out_\"]\" write out",
-                query.replace('"', "\\\"")
+                "set q=$CHAR(34) set key=\"\" set out=\"[\" set sep=\"\" for {{ set key=$order(^SKILLS(key)) quit:key=\"\"  set data=$get(^SKILLS(key)) if $find($zconvert(key_data,\"L\"),{})>0 {{ set out=out_sep_\"{{\"_q_\"name\"_q_\":\"_q_$translate(key,q_$CHAR(13,10),\"   \")_q_\",\"_q_\"description\"_q_\":\"_q_$translate($piece(data,\"|\",1),q_$CHAR(13,10),\"   \")_q_\"}}\" set sep=\",\" }} }} set out=out_\"]\" write out",
+                os_str_expr(&query)
             );
             let raw = xecute(iris, client, &code, &ns).await.unwrap_or_default();
             let results: serde_json::Value =
@@ -103,10 +120,7 @@ pub async fn handle_skill(
         }
         "forget" => {
             let name = p.name.as_deref().unwrap_or("");
-            let code = format!(
-                "kill ^SKILLS(\"{}\") write \"ok\"",
-                name.replace('"', "\\\"")
-            );
+            let code = format!("kill ^SKILLS({}) write \"ok\"", os_str_expr(name));
             xecute(iris, client, &code, &ns).await.unwrap_or_default();
             ok_json(serde_json::json!({"success": true, "name": name, "action": "forgotten"}))
         }
@@ -149,13 +163,7 @@ pub async fn handle_skill(
                     .join(" → ")
             );
             let now = chrono::Utc::now().format("%Y-%m-%dT%H:%M:%SZ").to_string();
-            let code = format!(
-                "set ^SKILLS(\"{}\")=\"{}|{}|0|{}\" write \"ok\"",
-                skill_name.replace('"', "\\\""),
-                description.replace('"', "\\\""),
-                body.replace('"', "\\\""),
-                now,
-            );
+            let code = skills_set_code(&skill_name, &description, &body, &now);
             xecute(iris, client, &code, &ns).await.unwrap_or_default();
             ok_json(serde_json::json!({
                 "success": true,
@@ -217,13 +225,7 @@ pub async fn handle_skill_community(
                 Some((sname, sdesc, scontent)) => {
                     let ns = skills_namespace();
                     let now = chrono::Utc::now().format("%Y-%m-%dT%H:%M:%SZ").to_string();
-                    let code = format!(
-                        "set ^SKILLS(\"{}\")=\"{}|{}|0|{}\" write \"ok\"",
-                        sname.replace('"', "\\\""),
-                        sdesc.replace('"', "\\\""),
-                        scontent.replace('"', "\\\""),
-                        now,
-                    );
+                    let code = skills_set_code(&sname, &sdesc, &scontent, &now);
                     xecute(iris, client, &code, &ns).await.unwrap_or_default();
                     ok_json(serde_json::json!({"success": true, "installed": sname}))
                 }
@@ -290,15 +292,15 @@ pub async fn handle_kb(
                         .unwrap_or(false)
                     {
                         if let Ok(content) = std::fs::read_to_string(&fp) {
-                            let fname = fp
-                                .file_name()
-                                .and_then(|n| n.to_str())
-                                .unwrap_or("")
-                                .replace('"', "\\\"");
+                            let fname = fp.file_name().and_then(|n| n.to_str()).unwrap_or("");
                             let chunk: String = content.chars().take(2000).collect();
-                            let chunk_escaped = chunk.replace('"', "\\\"").replace('\n', "\\n");
+                            // #67: newlines cannot appear inside an ObjectScript literal at
+                            // all — the old `\\n` stored two literal characters. os_str_expr
+                            // splices them as $CHAR(10), so the chunk is stored verbatim.
                             let code = format!(
-                                "set ^KBCHUNKS(\"{fname}\")=\"{chunk_escaped}\" write \"ok\""
+                                "set ^KBCHUNKS({})={} write \"ok\"",
+                                os_str_expr(fname),
+                                os_str_expr(&chunk)
                             );
                             xecute(iris, client, &code, &ns).await.unwrap_or_default();
                             indexed += 1;
@@ -312,9 +314,13 @@ pub async fn handle_kb(
             let query = p.query.as_deref().unwrap_or("").to_lowercase();
             let top_k = p.top_k;
             // Bug 9: use separator variable so empty results yield "[]" not "]".
+            // #67: the loop's postconditional needs its own parentheses. ObjectScript has no
+            // operator precedence — `key="" || count>=N` groups as `((key="")||count)>=N`,
+            // which is false on the terminating pass, so the loop read ^KBCHUNKS("") and died
+            // with <SUBSCRIPT>. Every recall answered [] because the error was swallowed.
             let code = format!(
-                "set key=\"\" set out=\"[\" set sep=\"\" set count=0 for {{ set key=$order(^KBCHUNKS(key)) quit:(key=\"\" || count>={top_k})  set data=$get(^KBCHUNKS(key)) if $find($zconvert(data,\"L\"),\"{query}\")>0 {{ set out=out_sep_\"{{\\\"file\\\":\\\"\"_key_\"\\\",\\\"excerpt\\\":\\\"\"_$extract(data,1,200)_\"\\\"}}\" set sep=\",\" set count=count+1 }} }} set out=out_\"]\" write out",
-                query = query.replace('"', "\\\""),
+                "set q=$CHAR(34) set key=\"\" set out=\"[\" set sep=\"\" set count=0 for {{ set key=$order(^KBCHUNKS(key)) quit:((key=\"\")||(count>={top_k}))  set data=$get(^KBCHUNKS(key)) if $find($zconvert(data,\"L\"),{query})>0 {{ set out=out_sep_\"{{\"_q_\"file\"_q_\":\"_q_$translate(key,q_$CHAR(13,10),\"   \")_q_\",\"_q_\"excerpt\"_q_\":\"_q_$translate($extract(data,1,200),q_$CHAR(13,10),\"   \")_q_\"}}\" set sep=\",\" set count=count+1 }} }} set out=out_\"]\" write out",
+                query = os_str_expr(&query),
                 top_k = top_k,
             );
             let raw = xecute(iris, client, &code, &ns).await.unwrap_or_default();
@@ -391,5 +397,41 @@ pub async fn handle_agent_info(
             "INVALID_PARAM",
             &format!("Unknown what='{}'. Use: stats, history", other),
         ),
+    }
+}
+
+#[cfg(test)]
+mod objectscript_escaping_tests {
+    use super::*;
+
+    /// #67: ObjectScript doubles a quote inside a literal; `\\"` escapes nothing, so the
+    /// backslash survives and the quote ends the string. Nothing generated here may use it.
+    #[test]
+    fn a_quote_in_any_field_is_doubled_never_backslashed() {
+        let code = skills_set_code(
+            r#"say "hi""#,
+            r#"a "quoted" description"#,
+            "body",
+            "2026-08-25T00:00:00Z",
+        );
+        assert!(code.contains(r#""say ""hi""""#), "{code}");
+        assert!(
+            !code.contains(r#"\""#),
+            "no C-style escaping may survive: {code}"
+        );
+    }
+
+    /// A skill body is multi-line. A literal cannot span source lines at all — the old code
+    /// wrote a two-character `\\n` instead, which stored a backslash and an `n`.
+    #[test]
+    fn a_newline_in_a_body_is_spliced_as_char_not_written_into_a_literal() {
+        let code = skills_set_code("s", "d", "line one\nline two", "2026-08-25T00:00:00Z");
+        assert!(code.contains("$CHAR(10)"), "{code}");
+        assert!(!code.contains(r#"\n"#), "{code}");
+        assert_eq!(
+            code.lines().count(),
+            1,
+            "generated code stays on one line: {code}"
+        );
     }
 }


### PR DESCRIPTION
Fixes #67.

## What was wrong

ObjectScript doubles a quote inside a literal (`""`). A backslash escapes nothing — it stays literal and the quote ends the string. 28 sites still escaped C-style, so any caller value containing a quote produced code that could not compile. Because each tool reads its own silence differently, that never surfaced as a failure:

```jsonc
// before
iris_table_info {"table":"Foo\".Bar","namespace":"APP"}
// -> {"success":true,"type":"ddl_table",
//     "data_global":"^Foo\".BarD","index_global":"^Foo\".BarI", ...}   // invented
```

## The conversion

All 28 embeds now render through `os_str_expr` — mod.rs 6, dict.rs 5, info.rs 5, skills_tools.rs 12. The three sites in `manifest/resolve.rs` write TOML, where backslash escaping is correct, and are deliberately untouched.

Three of them needed more than a swap:

- **`safe_pattern` is gone from `iris_test`.** The pattern is now classified class-vs-directory on what the caller actually sent. Escaping first *added* a backslash, so a pattern containing a quote was taken for a directory path — a second, invisible consequence of the same bug.
- **`get_row_count` builds its SQL in Rust** and embeds the whole statement as one expression. The delimited-identifier quotes around the schema are SQL text; `os_str_expr` doubles them for the ObjectScript literal.
- **`skills_set_code`** replaces the two copies of the `^SKILLS` writer: each field is its own expression concatenated with the pipe separators the readers `$piece` back apart, instead of four values pasted into one literal. `kb index` likewise stores its chunk verbatim — newlines splice as `$CHAR(10)` instead of the old two-character `\n`, which an ObjectScript literal cannot hold at all.

## Two defects in the same statements, fixed rather than left half-done

Both sit in lines this PR already rewrites; fixing the embed while leaving them would have produced code that is correctly escaped and still useless.

1. **`skill list` / `skill search` / `kb recall` built their JSON with `\"` inside ObjectScript literals.** Not valid ObjectScript — those tools could only ever answer `[]`. They now use `q=$CHAR(34)` (the idiom `dict.rs` already uses), and values are stripped of quotes/CR/LF so the assembled JSON parses.
2. **`kb recall`'s loop postconditional needed its own parentheses.** ObjectScript has no operator precedence, so `key="" || count>=N` groups as `((key="")||count)>=N`, which is never true on the terminating pass: the loop read `^KBCHUNKS("")` and died with `<SUBSCRIPT>`, swallowed into an empty result.

## Verification

Live against IRIS 2026.1 (ns APP), interop profile:

| call | before | after |
|---|---|---|
| `iris_table_info` `Foo".Bar` | `success:true`, `ddl_table`, invented globals | `TABLE_NOT_FOUND` |
| `iris_table_info` `Ens_Config.Production` | class_projection + real globals | unchanged |
| `iris_test` `Foo"Bar.Tests` | classified as a *directory* pattern | classified as a class pattern, honest `NO_TESTS_FOUND` |
| `find_subclass_implementations` `On"Request` | broken codegen | clean empty result |
| `iris_debug` map_int with a quoted error string | broken codegen | answers |

The skills/kb transport is docker-exec (`iris session`), which silently no-ops without a working container login — `kb index` reports `indexed: 1` having stored nothing. So those codegens were verified by executing the generated ObjectScript directly against IRIS:

- the `^KBCHUNKS` write stores the chunk with **real** newlines and quotes (`LF_STORED:1 QUOTE_STORED:1`);
- `skill list` returns `[{"name":"say  hi ","description":"a  quoted  description","usage_count":0}]`;
- `kb recall` returns `[{"file":"notes.md","excerpt":"Interop notes The operation said  route it  and then quit. …"}]`.

Test globals were removed afterwards (`^KBCHUNKS` and `^SKILLS` back to `$data()=0`).

Unit tests added over the generated ObjectScript: a quoted pattern is doubled in `build_class_test_run_code`, a quoted class name in `build_expand_hierarchy_code`, and both a quote and a newline in `skills_set_code` — each also asserting no `\"` survives anywhere in the output.

Gates: `cargo fmt --check`, `clippy --all-targets -D warnings`, full ci.yml test list — all green.

## Worth knowing, not fixed here

`kb index` counting a file it never stored is the same honesty problem as #62 in a different tool: `xecute(...).unwrap_or_default()` swallows the transport error and the count increments regardless. Left alone — the skills/kb tools are pruned from this fork's interop profile, and it is a transport/reporting fix rather than a codegen one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)