### PR TITLE
chore(release): 0.8.2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -945,7 +945,7 @@ dependencies = [
 
 [[package]]
 name = "iris-agentic-dev"
-version = "0.8.1"
+version = "0.8.2"
 dependencies = [
  "anyhow",
  "chrono",
@@ -963,7 +963,7 @@ dependencies = [
 
 [[package]]
 name = "iris-agentic-dev-core"
-version = "0.8.1"
+version = "0.8.2"
 dependencies = [
  "anyhow",
  "bollard",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "0.8.1"
+version = "0.8.2"
 edition = "2021"
 authors = ["Thomas Dyar <thomas.dyar@intersystems.com>"]
 license = "MIT"


### PR DESCRIPTION
Version bump only — `Cargo.toml` + `Cargo.lock`. Patch, not minor: four fixes to existing behaviour, no tools added, no schema change (the interop profile stays at 23 tools).

| issue | what it fixed | PR |
|---|---|---|
| #63 | `iris_production` read `production_name` while its struct and description said `production`; the dropped name reached `Ens.Director` as `""` and returned `<Ens>ErrInvalidProduction` — indistinguishable from a class that was never compiled | #64 |
| #62 | `NO_TESTS_FOUND` covered two states needing opposite actions and always reported the first; `did_you_mean` proposed the caller's own input back | #65 |
| #66 | a compiled `%UnitTest.TestCase` class was never discovered — `RunTest` takes a suite spec, so the class name named an empty directory and the run reported "All PASSED" having run nothing | #68 |
| #67 | 28 ObjectScript embeds escaped quotes C-style; a quoted argument produced code that could not compile, and `iris_table_info` answered with invented globals rather than failing | #69 |

The one behaviour change worth calling out for the workshop: after #66, a plain `%UnitTest.TestCase` class runs its tests instead of reporting nothing. Test classes written against the skills' `%UnitTest.TestProduction` guidance are unaffected — they still dispatch through `Run()`.

After merge: tag `v0.8.2-interop` to publish.

🤖 Generated with [Claude Code](https://claude.com/claude-code)