### PR TITLE
fix(iris_message_body): read EDI/VDoc bodies, and redact them properly (fixes #72)

### DIFF
--- a/crates/iris-agentic-dev-core/src/tools/interop.rs
+++ b/crates/iris-agentic-dev-core/src/tools/interop.rs
@@ -2325,13 +2325,6 @@ pub fn redact_hl7v2(body: &str) -> String {
     if detect_content_type(body) != "HL7v2" {
         return body.to_string();
     }
-    let line_ending = if body.contains("\r\n") {
-        "\r\n"
-    } else if body.contains('\r') {
-        "\r"
-    } else {
-        "\n"
-    };
     let redact_fields = |line: &str, segment: &str, field_indices: &[usize]| -> String {
         let mut fields: Vec<&str> = line.split('|').collect();
         if fields.first().copied() != Some(segment) {
@@ -2344,15 +2337,37 @@ pub fn redact_hl7v2(body: &str) -> String {
         }
         fields.join("|")
     };
-    body.split(line_ending)
-        .map(|line| {
-            // MSH-1 is the implicit field-separator char (not a split element), so
-            // fields[1] = MSH-2 (encoding chars) and fields[2] = MSH-3 (sending app).
-            let redacted = redact_fields(line, "MSH", &[2]);
-            redact_fields(&redacted, "PID", &[3, 5, 7, 8, 11, 18])
-        })
-        .collect::<Vec<_>>()
-        .join(line_ending)
+    let redact_segment = |seg: &str| -> String {
+        // MSH-1 is the implicit field-separator char (not a split element), so
+        // fields[1] = MSH-2 (encoding chars) and fields[2] = MSH-3 (sending app).
+        let redacted = redact_fields(seg, "MSH", &[2]);
+        redact_fields(&redacted, "PID", &[3, 5, 7, 8, 11, 18])
+    };
+
+    // #72: a body can MIX separators — `EnsLib.HL7.Message.OutputToString()` separates
+    // segments with CR and ends the last one with CRLF. Picking ONE line ending (the old
+    // behaviour: "contains \r\n" wins) then made the whole message a single line, so only
+    // MSH was ever examined and every PID field was returned in the clear under
+    // dataPolicy=redact. Walk the boundaries instead, keeping each separator as it was so
+    // the body comes back byte-identical apart from the redactions.
+    let mut out = String::with_capacity(body.len());
+    let mut rest = body;
+    loop {
+        match rest.find(['\r', '\n']) {
+            Some(pos) => {
+                let (seg, tail) = rest.split_at(pos);
+                out.push_str(&redact_segment(seg));
+                let sep_len = if tail.starts_with("\r\n") { 2 } else { 1 };
+                out.push_str(&tail[..sep_len]);
+                rest = &tail[sep_len..];
+            }
+            None => {
+                out.push_str(&redact_segment(rest));
+                break;
+            }
+        }
+    }
+    out
 }
 
 /// Parse `<Item Name="..." ClassName="..." Enabled="..."/>` entries out of a
@@ -2390,6 +2405,68 @@ fn extract_xml_attr(line: &str, attr: &str) -> Option<String> {
 /// Read an Ensemble message body (`Ens.StringContainer`, `Ens.StreamContainer`,
 /// `%Stream.Object`). `data_policy` gates PHI: `block` refuses outright, `allow`
 /// requires an explicit acknowledgement, `redact` blanks known HL7 v2 PHI fields.
+/// Issue #72: read one message body, whatever shape it is in.
+///
+/// Two things this codegen gets wrong if written the obvious way:
+///
+/// 1. **`%IsA` is not the membership test.** It walks only the PRIMARY superclass chain.
+///    `EnsLib.HL7.Message` reaches `EnsLib.EDI.Document` through its SECOND superclass
+///    (`Super = %Persistent, EnsLib.EDI.BatchDocument, EnsLib.EDI.Segmented, …`), so
+///    `%IsA("EnsLib.EDI.Document")` is 0 on a live HL7 message while `%Extends(...)` is 1.
+///    Verified on IRIS 2026.1 — the issue's suggested `%IsA` branch would never fire. All
+///    four branches use `%Extends`; for the three that already worked it is equivalent
+///    (checked against StreamContainer, %Stream.GlobalCharacter and StringContainer) and it
+///    removes the same trap for any body class that inherits them secondarily.
+/// 2. **`EnsLib.EDI.Document` is the branch, not `EnsLib.HL7.Message`.** HL7, X12, ASTM,
+///    EDIFACT and `EnsLib.EDI.XML.Document` all extend it, and `OutputToString()` renders
+///    each one, so one branch covers every EDI/VDoc body instead of just HL7.
+///
+/// `OutputToString()` materialises the whole document as a string, which a very large batch
+/// can refuse to do (`<MAXSTRING>`); that is caught and reported rather than escaping as a
+/// raw execute error.
+pub fn build_message_body_code(message_id: i64, max_bytes: u32) -> String {
+    format!(
+        r#"Set hdr=##class(Ens.MessageHeader).%OpenId({message_id})
+If '$IsObject(hdr) {{ Write "ERROR:MESSAGE_NOT_FOUND" Quit }}
+Set bodyClass=hdr.MessageBodyClassName
+Set bodyId=hdr.MessageBodyId
+If bodyClass="" {{ Write "ERROR:MESSAGE_NOT_FOUND" Quit }}
+Set body=$ClassMethod(bodyClass,"%OpenId",bodyId)
+If '$IsObject(body) {{ Write "ERROR:MESSAGE_NOT_FOUND" Quit }}
+If body.%Extends("Ens.StreamContainer") {{
+  Set stream=body.Stream
+  If '$IsObject(stream) {{ Write "ERROR:STREAM_READ_ERROR:no stream object" Quit }}
+  Set full=stream.Size
+  Set content=stream.Read({max_bytes})
+  Write "OK:"_full_":"
+  Write content
+}} ElseIf body.%Extends("%Stream.Object") {{
+  Set full=body.Size
+  Set content=body.Read({max_bytes})
+  Write "OK:"_full_":"
+  Write content
+}} ElseIf body.%Extends("Ens.StringContainer") {{
+  Set content=body.StringValue
+  Set full=$Length(content)
+  If full>{max_bytes} {{ Set content=$Extract(content,1,{max_bytes}) }}
+  Write "OK:"_full_":"
+  Write content
+}} ElseIf body.%Extends("EnsLib.EDI.Document") {{
+  Try {{
+    Set content=body.OutputToString()
+    Set full=$Length(content)
+    If full>{max_bytes} {{ Set content=$Extract(content,1,{max_bytes}) }}
+    Write "OK:"_full_":"
+    Write content
+  }} Catch ex {{
+    Write "ERROR:BODY_READ_ERROR:"_ex.DisplayString()
+  }}
+}} Else {{
+  Write "ERROR:UNSUPPORTED_BODY_CLASS:"_bodyClass
+}}"#
+    )
+}
+
 pub async fn handle_iris_message_body(
     iris: Option<&IrisConnection>,
     params: &MessageBodyParams,
@@ -2436,36 +2513,7 @@ pub async fn handle_iris_message_body(
 
     // message_id is an i64 and max_bytes a u32 — both are numeric, so nothing
     // user-controlled reaches the generated source as a string here.
-    let code = format!(
-        r#"Set hdr=##class(Ens.MessageHeader).%OpenId({message_id})
-If '$IsObject(hdr) {{ Write "ERROR:MESSAGE_NOT_FOUND" Quit }}
-Set bodyClass=hdr.MessageBodyClassName
-Set bodyId=hdr.MessageBodyId
-If bodyClass="" {{ Write "ERROR:MESSAGE_NOT_FOUND" Quit }}
-Set body=$ClassMethod(bodyClass,"%OpenId",bodyId)
-If '$IsObject(body) {{ Write "ERROR:MESSAGE_NOT_FOUND" Quit }}
-If body.%IsA("Ens.StreamContainer") {{
-  Set stream=body.Stream
-  If '$IsObject(stream) {{ Write "ERROR:STREAM_READ_ERROR:no stream object" Quit }}
-  Set full=stream.Size
-  Set content=stream.Read({max_bytes})
-  Write "OK:"_full_":"
-  Write content
-}} ElseIf body.%IsA("%Stream.Object") {{
-  Set full=body.Size
-  Set content=body.Read({max_bytes})
-  Write "OK:"_full_":"
-  Write content
-}} ElseIf body.%IsA("Ens.StringContainer") {{
-  Set content=body.StringValue
-  Set full=$Length(content)
-  If full>{max_bytes} {{ Set content=$Extract(content,1,{max_bytes}) }}
-  Write "OK:"_full_":"
-  Write content
-}} Else {{
-  Write "ERROR:UNSUPPORTED_BODY_CLASS:"_bodyClass
-}}"#
-    );
+    let code = build_message_body_code(message_id, max_bytes);
 
     match iris
         .execute_via_generator(&code, &params.namespace, &client)
@@ -2481,11 +2529,19 @@ If body.%IsA("Ens.StreamContainer") {{
             if let Some(rest) = out.strip_prefix("ERROR:STREAM_READ_ERROR:") {
                 return err_json("STREAM_READ_ERROR", rest.trim());
             }
+            // #72: an EDI document renders through OutputToString, which a very large batch
+            // can refuse (<MAXSTRING>). Report it as a body-read failure naming the IRIS
+            // error, not as an unsupported class or a raw execute error.
+            if let Some(rest) = out.strip_prefix("ERROR:BODY_READ_ERROR:") {
+                return err_json("BODY_READ_ERROR", rest.trim());
+            }
             if let Some(rest) = out.strip_prefix("ERROR:UNSUPPORTED_BODY_CLASS:") {
                 return err_json(
                     "UNSUPPORTED_BODY_CLASS",
                     &format!(
-                        "Body class '{}' is not a recognized stream/text body type",
+                        "Body class '{}' is not a supported body type — this tool reads \
+                         Ens.StringContainer, Ens.StreamContainer, %Stream.Object and any \
+                         EnsLib.EDI.Document (HL7 v2, X12, ASTM, EDIFACT, EDI XML)",
                         rest.trim()
                     ),
                 );
@@ -3333,6 +3389,117 @@ mod tests {
         ).unwrap();
         assert_eq!(p2.enabled, Some(true));
         assert_eq!(p2.production.as_deref(), Some("MyApp.Production"));
+    }
+
+    // ─── #72: PHI redaction over real segment separators ───
+
+    /// The HL7 standard segment terminator is CR, and OutputToString() ends the LAST segment
+    /// with CRLF. Choosing one line ending made that whole message a single line: only MSH
+    /// was examined, and every PID field came back in the clear under dataPolicy=redact.
+    #[test]
+    fn mixed_cr_and_crlf_separators_still_redact_every_segment() {
+        let body = "MSH|^~\\&|SENDAPP|SENDFAC|RECVAPP|RECVFAC|20260825||ADT^A01|M1|P|2.5\r\
+                    PID|1||123456^^^MRN||DOE^JOHN||19700101|M\r\
+                    PV1|1|I|WARD^101^A\r\n";
+        let out = redact_hl7v2(body);
+        assert!(!out.contains("SENDAPP"), "MSH-3 must be redacted: {out}");
+        assert!(
+            !out.contains("123456^^^MRN"),
+            "PID-3 must be redacted: {out}"
+        );
+        assert!(!out.contains("DOE^JOHN"), "PID-5 must be redacted: {out}");
+        assert!(!out.contains("19700101"), "PID-7 must be redacted: {out}");
+        assert!(
+            out.contains("PV1|1|I|WARD^101^A"),
+            "PV1 is not PHI-listed: {out}"
+        );
+    }
+
+    /// Separators survive byte-for-byte — a redacted HL7 message must still parse as HL7.
+    #[test]
+    fn separators_are_preserved_exactly() {
+        for body in [
+            "MSH|^~\\&|A|B|C|D|20260825||ADT^A01|M1|P|2.5\rPID|1||X||Y\r",
+            "MSH|^~\\&|A|B|C|D|20260825||ADT^A01|M1|P|2.5\nPID|1||X||Y\n",
+            "MSH|^~\\&|A|B|C|D|20260825||ADT^A01|M1|P|2.5\r\nPID|1||X||Y\r\n",
+        ] {
+            let out = redact_hl7v2(body);
+            assert_eq!(
+                out.matches('\r').count(),
+                body.matches('\r').count(),
+                "CR count changed: {out:?}"
+            );
+            assert_eq!(
+                out.matches('\n').count(),
+                body.matches('\n').count(),
+                "LF count changed: {out:?}"
+            );
+        }
+    }
+
+    /// Non-HL7 bodies are returned untouched — redaction is HL7 v2 field knowledge, and
+    /// mangling JSON or XML would be worse than leaving it alone.
+    #[test]
+    fn a_non_hl7_body_is_left_alone() {
+        let json = "{\"patient\":\"DOE^JOHN\"}";
+        assert_eq!(redact_hl7v2(json), json);
+    }
+
+    // ─── #72: message bodies of every shape ───
+
+    /// `%IsA` walks only the primary superclass chain, and `EnsLib.HL7.Message` reaches
+    /// `EnsLib.EDI.Document` through its second superclass — verified live: `%IsA` is 0
+    /// there, `%Extends` is 1. A branch written with `%IsA` would never fire.
+    #[test]
+    fn every_body_branch_tests_membership_with_extends() {
+        let code = build_message_body_code(16, 65536);
+        assert!(
+            !code.contains("%IsA("),
+            "%IsA misses secondary superclasses — the bug this fixes: {code}"
+        );
+        for cls in [
+            "Ens.StreamContainer",
+            "%Stream.Object",
+            "Ens.StringContainer",
+            "EnsLib.EDI.Document",
+        ] {
+            assert!(
+                code.contains(&format!("%Extends(\"{cls}\")")),
+                "missing branch for {cls}: {code}"
+            );
+        }
+    }
+
+    /// The EDI branch is `EnsLib.EDI.Document`, not `EnsLib.HL7.Message`: HL7 v2, X12, ASTM,
+    /// EDIFACT and EDI XML all extend it and all render through OutputToString().
+    #[test]
+    fn the_edi_branch_covers_every_vdoc_not_just_hl7() {
+        let code = build_message_body_code(16, 65536);
+        assert!(code.contains("body.OutputToString()"), "{code}");
+        assert!(
+            !code.contains("EnsLib.HL7.Message"),
+            "branching on HL7 alone would leave X12/ASTM/EDIFACT/XML unreadable: {code}"
+        );
+    }
+
+    /// OutputToString materialises the whole document; a large batch can raise <MAXSTRING>.
+    /// That must come back as a named body-read failure, not a raw execute error.
+    #[test]
+    fn a_document_too_large_to_render_is_reported_not_thrown() {
+        let code = build_message_body_code(16, 4096);
+        assert!(code.contains("Catch ex"), "{code}");
+        assert!(code.contains("ERROR:BODY_READ_ERROR:"), "{code}");
+    }
+
+    /// max_bytes still caps what comes back, and the FULL length is reported before the cut
+    /// — the #55 defect (a truncated body understating its own size) must not return.
+    #[test]
+    fn the_edi_branch_reports_full_size_before_truncating() {
+        let code = build_message_body_code(16, 4096);
+        let edi = code.split("EnsLib.EDI.Document").nth(1).unwrap();
+        assert!(edi.contains("Set full=$Length(content)"), "{edi}");
+        assert!(edi.contains("If full>4096"), "{edi}");
+        assert!(edi.contains("$Extract(content,1,4096)"), "{edi}");
     }
 
     // ─── #63: one reader for the production-name argument ───


### PR DESCRIPTION
Fixes #72.

## The gap

`EnsLib.HL7.Message` fell through the three-way `%IsA` dispatch to `UNSUPPORTED_BODY_CLASS`. On a health product that is *the* body class for a large share of productions, so the only way to read a body — the thing this tool exists for — was hand-written `iris_execute` ObjectScript, which the skills steer agents away from.

Reproduced on the installed 0.8.2 against a real header:

```jsonc
iris_message_body {"message_id":"25","namespace":"APP","dataPolicy":"redact"}
// -> {"error_code":"UNSUPPORTED_BODY_CLASS",
//     "error":"Body class 'EnsLib.HL7.Message' is not a recognized stream/text body type"}
```

## The issue's suggested branch would never have fired

#72 proposed `body.%IsA("EnsLib.EDI.Document")`. **`%IsA` walks only the PRIMARY superclass chain**, and `EnsLib.HL7.Message` reaches `EnsLib.EDI.Document` through its *second* superclass:

```
Super = %Library.Persistent, EnsLib.EDI.BatchDocument, EnsLib.EDI.Segmented, EnsLib.HL7.Util.MsgBodyMethods
```

Measured on IRIS 2026.1 against a live imported message:

| test | result |
|---|---|
| `msg.%IsA("EnsLib.EDI.Document")` | **0** |
| `msg.%IsA("EnsLib.EDI.Segmented")` | **0** |
| `msg.%Extends("EnsLib.EDI.Document")` | **1** |
| `##class(EnsLib.EDI.XML.Document).%New().%Extends("EnsLib.EDI.Document")` | **1** |

So the branch is `%Extends`, and `EnsLib.EDI.Document` covers HL7 v2, X12, ASTM, EDIFACT and EDI XML in one arm.

## What changed

- **New EDI/VDoc branch** rendering through `OutputToString()`, with `max_bytes` truncation and the full length reported before the cut (the #55 defect must not return — asserted in a test).
- **The three existing branches move to `%Extends`.** Equivalent for what they already matched — verified against `Ens.StreamContainer`, `%Stream.GlobalCharacter` and `Ens.StringContainer`, all `1` under both — and free of the same trap for any body class that inherits them secondarily.
- **`<MAXSTRING>` is caught.** `OutputToString()` materialises the whole document; a large batch can refuse. That returns `BODY_READ_ERROR` naming the IRIS error rather than escaping as a raw execute failure.
- **`UNSUPPORTED_BODY_CLASS` now lists what is supported**, keeping the class name it refused (that field is what made this diagnosable).
- The codegen moves into `build_message_body_code` so the branches are asserted directly.

## A PHI defect found while verifying — fixed here

The first live read came back with `MSH-3` redacted and **every PID field in the clear** under `dataPolicy=redact`.

`redact_hl7v2` picked one line ending, and `contains("\r\n")` won. `OutputToString()` separates segments with **CR** and terminates the last with **CRLF** — so the whole message counted as a single line, only `MSH` was examined, and PID-3/5/7/8/11/18 were never touched. Redaction now walks segment boundaries and keeps each separator exactly as it was, so a redacted message still parses as HL7.

This is fixed here rather than filed separately because this PR is what makes HL7 bodies readable at all: shipping the branch without it would have turned a refusal into a PHI leak.

## Verification

Live, IRIS 2026.1, on an `Ens.MessageHeader` whose body is a real `EnsLib.HL7.Message`:

| call | result |
|---|---|
| `dataPolicy=redact` | `MSH\|^~\&\|[REDACTED]\|…` and `PID\|1\|\|[REDACTED]\|\|[REDACTED]\|\|[REDACTED]\|[REDACTED]`, `PV1` untouched, `content_type: HL7v2` |
| `dataPolicy=allow` + `acknowledgePhi` | full message, `redacted: false` |
| `max_bytes=40` | `truncated: true`, `actual_size: 140` (the full size, not the returned length) |
| unknown id | `MESSAGE_NOT_FOUND` |

Unit tests: every branch tests membership with `%Extends` and none with `%IsA`; the EDI branch is `EnsLib.EDI.Document` and not `EnsLib.HL7.Message`; `<MAXSTRING>` is caught; full size is reported before truncation; mixed CR/CRLF redacts every segment; separators survive byte-for-byte; a non-HL7 body is left alone.

Gates: `cargo fmt --check`, `clippy --all-targets -D warnings`, full ci.yml test list — all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)