### PR TITLE
chore(release): 0.8.3

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -945,7 +945,7 @@ dependencies = [
 
 [[package]]
 name = "iris-agentic-dev"
-version = "0.8.2"
+version = "0.8.3"
 dependencies = [
  "anyhow",
  "chrono",
@@ -963,7 +963,7 @@ dependencies = [
 
 [[package]]
 name = "iris-agentic-dev-core"
-version = "0.8.2"
+version = "0.8.3"
 dependencies = [
  "anyhow",
  "bollard",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "0.8.2"
+version = "0.8.3"
 edition = "2021"
 authors = ["Thomas Dyar <thomas.dyar@intersystems.com>"]
 license = "MIT"


### PR DESCRIPTION
Version bump only — `Cargo.toml` + `Cargo.lock`. Patch: two fixes to existing behaviour, no tools added, interop profile stays at 23.

| issue | what it fixed | PR |
|---|---|---|
| #72 | `iris_message_body` could not read an `EnsLib.HL7.Message` — the commonest body class on a health product. The dispatch used `%IsA`, which walks only the primary superclass chain; it now uses `%Extends` and branches on `EnsLib.EDI.Document`, covering HL7 v2, X12, ASTM, EDIFACT and EDI XML | #74 |
| #71 | `iris_doc(put)` rejected a bare class name with `#16006: name is invalid`, blaming the name when the type suffix was missing | #75 |

**Worth flagging in this release: a PHI fix rides along with #72.** `redact_hl7v2` picked a single line ending, and `contains("\r\n")` won. `OutputToString()` separates segments with CR and terminates the last with CRLF, so the whole message counted as one line: only `MSH` was examined and **every PID field was returned in the clear under `dataPolicy=redact`**. Redaction now walks segment boundaries and preserves each separator, so a redacted message still parses as HL7.

Anyone relying on `dataPolicy=redact` with an HL7 body on 0.8.2 or earlier should take this build. (In practice HL7 bodies could not be read at all before #72, so the exposure was via the stream/string container paths carrying CR-terminated ER7.)

After merge: tag `v0.8.3-interop` to publish.

🤖 Generated with [Claude Code](https://claude.com/claude-code)