### PR TITLE
fix: iris_get_log addressing (#78), ^SKILLS JSON (upstream #119), toolset drift

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,7 +35,8 @@ jobs:
             --test manifest_tests \
             --test skills_tests \
             --test vscode_config_tests \
-            --test mcp_handshake
+            --test mcp_handshake \
+            --test test_toolset
         env:
           RUST_LOG: warn
 

--- a/crates/iris-agentic-dev-bin/src/cmd/mcp.rs
+++ b/crates/iris-agentic-dev-bin/src/cmd/mcp.rs
@@ -68,9 +68,9 @@ pub struct McpCommand {
     pub subscribe: Vec<String>,
     #[arg(long, default_value = ".")]
     pub workspace: String,
-    /// Tool set to register: interop (~20 interop-focused tools — DEFAULT for this fork),
-    /// merged (stubs removed + consolidated), nostub (stubs removed), or baseline (all tools).
-    /// Also read from IRIS_TOOLSET env var.
+    /// Tool set to register: interop (23 interop-focused tools — DEFAULT for this fork),
+    /// merged (46: stubs removed + consolidated), nostub (50: stubs removed),
+    /// or baseline (54: all tools). Also read from IRIS_TOOLSET env var.
     #[arg(long, env = "IRIS_TOOLSET", default_value = "interop")]
     pub toolset: String,
 }

--- a/crates/iris-agentic-dev-core/src/objectscript.rs
+++ b/crates/iris-agentic-dev-core/src/objectscript.rs
@@ -6,45 +6,67 @@
 //! span source lines, and `build_exec_class` splits generated code on `\n`, so
 //! control characters must never appear inside a literal; they are spliced in
 //! via `$CHAR(n,...)` instead.
+//!
+//! #119 follow-up: the same is true of every NON-ASCII character. Generated
+//! source reaches IRIS over two transports, and only one of them is charset
+//! transparent: `execute_via_generator` PUTs the source as UTF-8 JSON, but
+//! `IrisConnection::execute` pipes it into `docker exec -i <c> iris session`,
+//! whose stdin is decoded 8-bit — the two UTF-8 bytes of `é` arrive as the two
+//! characters `Ã©`, and a CJK character arrives as three. A search needle or a
+//! skill name embedded as a raw literal therefore silently stops matching the
+//! data actually stored in IRIS. So the output of `os_str_expr` is always pure
+//! 7-bit ASCII: anything outside `0x20..=0x7E` is spliced via `$CHAR`, which
+//! means the source survives ANY transport byte-for-byte.
 
 /// Render `s` as a single-line ObjectScript *expression* that evaluates to
-/// exactly `s`: printable runs become quoted literals with `"` doubled,
-/// control characters become `$CHAR(n,...)` splices.
+/// exactly `s`: printable-ASCII runs become quoted literals with `"` doubled,
+/// everything else (control characters AND all non-ASCII) becomes a
+/// `$CHAR(n,...)` splice, so the rendered expression is pure ASCII.
 ///
 /// `os_str_expr(r#"say "hi""#)` → `"say ""hi"""`
 /// `os_str_expr("a\r\nb")` → `"a"_$CHAR(13,10)_"b"`
+/// `os_str_expr("café")` → `"caf"_$CHAR(233)`
+///
+/// A character outside the BMP is spliced as its two UTF-16 surrogate code
+/// units — that is how IRIS stores it. `$CHAR` of a code point above 65535
+/// does NOT round-trip: on IRIS 2026.2 `$char(128512)` returns the EMPTY
+/// string (verified live), so splicing the raw code point would silently drop
+/// the character.
 pub fn os_str_expr(s: &str) -> String {
     if s.is_empty() {
         return "\"\"".into();
     }
     let mut parts: Vec<String> = Vec::new();
     let mut lit = String::new();
-    let mut ctl: Vec<u32> = Vec::new();
+    let mut spliced: Vec<u32> = Vec::new();
     let flush_lit = |lit: &mut String, parts: &mut Vec<String>| {
         if !lit.is_empty() {
             parts.push(format!("\"{}\"", lit.replace('"', "\"\"")));
             lit.clear();
         }
     };
-    let flush_ctl = |ctl: &mut Vec<u32>, parts: &mut Vec<String>| {
-        if !ctl.is_empty() {
-            let codes: Vec<String> = ctl.iter().map(|c| c.to_string()).collect();
+    let flush_spliced = |spliced: &mut Vec<u32>, parts: &mut Vec<String>| {
+        if !spliced.is_empty() {
+            let codes: Vec<String> = spliced.iter().map(|c| c.to_string()).collect();
             parts.push(format!("$CHAR({})", codes.join(",")));
-            ctl.clear();
+            spliced.clear();
         }
     };
+    let mut utf16 = [0u16; 2];
     for ch in s.chars() {
         let code = ch as u32;
-        if code < 0x20 || code == 0x7f {
-            flush_lit(&mut lit, &mut parts);
-            ctl.push(code);
-        } else {
-            flush_ctl(&mut ctl, &mut parts);
+        if (0x20..0x7f).contains(&code) {
+            flush_spliced(&mut spliced, &mut parts);
             lit.push(ch);
+        } else {
+            flush_lit(&mut lit, &mut parts);
+            for unit in ch.encode_utf16(&mut utf16) {
+                spliced.push(*unit as u32);
+            }
         }
     }
     flush_lit(&mut lit, &mut parts);
-    flush_ctl(&mut ctl, &mut parts);
+    flush_spliced(&mut spliced, &mut parts);
     parts.join("_")
 }
 
@@ -99,9 +121,47 @@ mod tests {
         assert_eq!(os_str_expr("\n"), "$CHAR(10)");
     }
 
+    /// #119: a raw non-ASCII literal does NOT survive `docker exec … iris session`
+    /// (8-bit stdin turns the two UTF-8 bytes of `ñ` into two characters), so it is
+    /// spliced as `$CHAR` — the same treatment control characters already got.
     #[test]
-    fn unicode_passes_through() {
-        assert_eq!(os_str_expr("señal"), "\"señal\"");
+    fn non_ascii_is_char_spliced_not_written_raw() {
+        assert_eq!(os_str_expr("señal"), "\"se\"_$CHAR(241)_\"al\"");
+        assert_eq!(os_str_expr("café"), "\"caf\"_$CHAR(233)");
+        // A run of non-ASCII collapses into ONE $CHAR list.
+        assert_eq!(os_str_expr("中文"), "$CHAR(20013,25991)");
+        assert_eq!(
+            os_str_expr("producción"),
+            "\"producci\"_$CHAR(243)_\"n\"",
+            "the shipped Spanish trigger vocabulary must round-trip"
+        );
+    }
+
+    /// A code point above the BMP must be spliced as its two UTF-16 units: verified
+    /// live on IRIS 2026.2, `$char(128512)` returns "" (length 0) while
+    /// `$char(55357,56832)` returns the emoji.
+    #[test]
+    fn astral_chars_are_spliced_as_utf16_surrogate_pairs() {
+        assert_eq!(os_str_expr("😀"), "$CHAR(55357,56832)");
+        assert!(!os_str_expr("😀").contains("128512"));
+    }
+
+    /// The whole point: generated source is transport-independent because it is 7-bit.
+    #[test]
+    fn every_expr_is_pure_ascii() {
+        for s in [
+            "señal",
+            "café ñ 中文 description",
+            "unicode-café-中",
+            "😀 mixed \u{7f} and \t",
+            "producción/notificación",
+        ] {
+            let expr = os_str_expr(s);
+            assert!(
+                expr.is_ascii(),
+                "generated source must be pure ASCII to survive an 8-bit transport: {expr}"
+            );
+        }
     }
 
     #[test]
@@ -111,6 +171,7 @@ mod tests {
             r#"<entry table="G" key="M">1</entry>"#,
             "multi\nline\r\nwith\ttabs",
             "quote\"and'apostrophe",
+            "acentuación \"citada\" 中",
         ];
         for s in samples {
             let expr = os_str_expr(s);

--- a/crates/iris-agentic-dev-core/src/tools/mod.rs
+++ b/crates/iris-agentic-dev-core/src/tools/mod.rs
@@ -58,17 +58,29 @@ pub use scm::ScmParams;
 /// Read from `IRIS_TOOLSET` env var or `--toolset` CLI flag.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum Toolset {
-    /// Every tool the binary carries (54 as of 0.8.3). NOT this fork's default — the
-    /// `--toolset` flag defaults to `interop`; baseline is opt-in via IRIS_TOOLSET/--toolset.
+    /// 54 tools advertised (measured 2026-08-26 on v0.8.3). NOT this fork's default —
+    /// `--toolset` defaults to `interop`; baseline is opt-in via IRIS_TOOLSET/--toolset.
+    /// Note this is already a pruned router: the 58 tools the `#[tool_router]` macro
+    /// registers minus the 4 merged-only ones.
     Baseline,
-    /// 29 tools — stub tools/actions removed; no merged tools.
+    /// 50 tools advertised (measured 2026-08-26). Baseline minus the 4 NOT_IMPLEMENTED
+    /// stubs (skill_propose, skill_optimize, skill_share, skill_community_install).
+    /// No merged dispatchers. Not this fork's default.
     Nostub,
-    /// 23 tools — stubs removed + 4 merger groups consolidated.
+    /// 46 tools advertised (measured 2026-08-26). Nostub (50) minus 8 — the 4 debug_*
+    /// folded into iris_debug, the 3 container tools folded into iris_containers, and
+    /// agent_info dropped outright — plus the 4 merged-only tools iris_debug,
+    /// iris_containers, iris_admin, iris_get_log. 50 - 8 + 4 = 46.
+    /// Not this fork's default.
     Merged,
-    /// ~20 tools — interop-skills-focused profile (see `INTEROP_TOOLS`).
-    /// Keeps only the tools the iris-interop skills actually exercise; everything
-    /// else (skill_*/kb_*/agent_*/generate_*/individual debug_*/container/scm) is pruned.
-    /// Default for this fork. Additive: tool *code* is unchanged so upstream stays mergeable.
+    /// 23 tools advertised (measured 2026-08-26) — exactly `INTEROP_TOOLS`. THIS FORK'S
+    /// DEFAULT: `--toolset` carries `default_value = "interop"` (see
+    /// crates/iris-agentic-dev-bin/src/cmd/mcp.rs). Keeps only the tools the iris-interop
+    /// skills actually exercise; everything else (skill_*/kb_*/agent_*/generate_*/
+    /// individual debug_*/container/scm) is pruned. Two of the 23 (iris_production_item,
+    /// iris_credential_manage) are write-gated off when the connection is not
+    /// write-allowed, so a Live-mode server advertises 21.
+    /// Additive: tool *code* is unchanged so upstream stays mergeable.
     Interop,
 }
 
@@ -93,8 +105,9 @@ impl Toolset {
     }
 }
 
-/// The interop-focused keep-list (Toolset::Interop). Source of truth for the
-/// `Interop` pruning AND the `registered_tool_names()` Interop branch. A unit test
+/// The interop-focused keep-list (Toolset::Interop). Source of truth for the `Interop`
+/// pruning; `registered_tool_names()` now derives from the pruned router for every
+/// toolset, so this list and the advertised surface cannot diverge. A unit test
 /// (`test_interop_toolset_exact`) asserts the live router exposes exactly these,
 /// which also guards against typos / upstream renames.
 pub const INTEROP_TOOLS: &[&str] = &[
@@ -1086,13 +1099,197 @@ pub struct NoParams {}
 
 #[derive(Debug, Deserialize, JsonSchema)]
 pub struct GetLogParams {
-    /// UUID of a stored log entry. If omitted, lists all stored entries.
+    /// The log_id a previous truncated:true result returned. If omitted, lists all
+    /// stored entries. `log_id` is accepted as an alias — that is the name every
+    /// truncating tool emits (issue #78).
+    #[serde(alias = "log_id")]
     pub id: Option<String>,
     /// Max entries to return from the stored result. Must be > 0 if provided.
     pub limit: Option<usize>,
     /// Start index into the stored result. Default 0.
     #[serde(default)]
     pub offset: usize,
+    /// Issue #78: every key serde did not recognise. Captured rather than dropped so a
+    /// mistyped addressing key (`logid`) can be NAMED instead of silently falling through
+    /// to the index listing, which is a different response shape. Not a caller-facing
+    /// parameter: schemars emits no property for a flattened map, only
+    /// `additionalProperties: true` (which `drop_default_additional_properties` removes
+    /// again on the wire).
+    #[serde(flatten)]
+    pub extra: serde_json::Map<String, serde_json::Value>,
+}
+
+/// Issue #78: the keys iris_get_log tolerates without acting on them.
+///
+/// Not leniency for its own sake. `namespace` is advertised by 11 of the 23 tools in
+/// this fork's default (interop) profile — the only key that spans tool families — and
+/// the agent harness sends it on nearly every call, including the correct index call in
+/// the issue's own repro. It cannot mean anything here: the log store is a single
+/// process-global ring buffer (`log_store::LogStore`) with no namespace dimension, so
+/// ignoring it cannot hide a filter the caller asked for. Rejecting it would turn a call
+/// that is correct today into a hard error.
+const GET_LOG_IGNORED_PARAMS: &[&str] = &["namespace"];
+
+/// The parameters iris_get_log actually reads — named in the error so the next call is a
+/// correction, not another guess (same contract as `no_tests_found_guidance`, issue #47).
+const GET_LOG_VALID_PARAMS: &[&str] = &["id", "limit", "offset"];
+
+/// Issue #78: what an empty index must say. `{"logs":[]}` alone reads as "there is no
+/// relevant log", which is the wrong and expensive conclusion the issue documents.
+const EMPTY_LOG_INDEX_NOTE: &str = "Empty because no tool in THIS session has truncated \
+    its output yet. This store holds only results a PREVIOUS tool marked truncated:true \
+    and handed back a log_id for — it is NOT the IRIS event log. To read IRIS \
+    interoperability logs use iris_interop_query with what='logs' (Ens_Util.Log entries; \
+    filter with component / session_id / since_id), or what='trace' with session_id (one \
+    message flow plus its Event Log events).";
+
+/// Issue #78: leftover keys that must not be swallowed. Sorted, so the message is
+/// deterministic. Keys beginning with `_` are skipped: those are client/protocol
+/// extension markers (`_meta`), never tool parameters.
+fn unknown_get_log_params(extra: &serde_json::Map<String, serde_json::Value>) -> Vec<String> {
+    let mut keys: Vec<String> = extra
+        .keys()
+        .filter(|k| !k.starts_with('_'))
+        .filter(|k| !GET_LOG_IGNORED_PARAMS.contains(&k.as_str()))
+        .cloned()
+        .collect();
+    keys.sort();
+    keys
+}
+
+/// Issue #78: `logid`, `logId`, `LOG-ID` all mean `log_id`, which serde already aliases to
+/// `id`. Normalise away case and separators so the error can name the fix.
+fn is_log_id_near_miss(key: &str) -> bool {
+    let norm: String = key
+        .chars()
+        .filter(char::is_ascii_alphanumeric)
+        .map(|c| c.to_ascii_lowercase())
+        .collect();
+    matches!(
+        norm.as_str(),
+        "logid" | "logids" | "loguuid" | "entryid" | "logentryid"
+    )
+}
+
+/// Issue #78: all of iris_get_log, as a free function over the store. The handler touches
+/// no IRIS connection, so this is unit-testable with nothing but a `LogStore` — no
+/// connection, no runtime. Mirrors `search::handle_iris_search`, which is already handed
+/// the store rather than `&self`.
+fn get_log_impl(
+    store: &Arc<std::sync::Mutex<log_store::LogStore>>,
+    p: GetLogParams,
+) -> Result<CallToolResult, McpError> {
+    // #78: a mistyped addressing key must never fall through to the index form. `id`
+    // absent + an unrecognised key present means the caller asked for something this tool
+    // does not offer; answering with the index is a DIFFERENT RESPONSE SHAPE that reads as
+    // "the log is empty" — the failure this issue was filed for. With `id` present the
+    // shape is unambiguous (the entry, or LOG_NOT_FOUND), so an extra key is harmless there.
+    if p.id.is_none() {
+        let unknown = unknown_get_log_params(&p.extra);
+        if !unknown.is_empty() {
+            let named = unknown
+                .iter()
+                .map(|k| format!("'{k}'"))
+                .collect::<Vec<_>>()
+                .join(", ");
+            let mut extra = serde_json::json!({
+                "unknown_params": unknown,
+                "valid_params": GET_LOG_VALID_PARAMS,
+                "hint": "Pass `id` (alias `log_id`) — the value a previous truncated:true \
+                         result returned — to retrieve that result; limit/offset paginate it. \
+                         Call iris_get_log with NO parameters to list the stored entries. \
+                         `namespace` is accepted and ignored (the store is process-global).",
+            });
+            if unknown.iter().any(|k| is_log_id_near_miss(k)) {
+                extra["did_you_mean"] = serde_json::json!(["id"]);
+            }
+            return envelope::fail_with(
+                "INVALID_PARAMS",
+                &format!(
+                    "iris_get_log: unknown parameter(s) {named}. This call did NOT list the \
+                     log index — an unrecognised parameter is an error here, not a different mode."
+                ),
+                extra,
+            );
+        }
+    }
+
+    match p.id {
+        None => {
+            // List all non-expired entries
+            let summaries = store.lock().map(|mut s| s.list()).unwrap_or_default();
+            let empty = summaries.is_empty();
+            let mut out = serde_json::json!({
+                "success": true,
+                "logs": summaries,
+            });
+            if empty {
+                // #78: an empty index must say what this store is and is NOT, or the
+                // agent concludes "no logs exist" and stops looking.
+                out["note"] = serde_json::Value::String(EMPTY_LOG_INDEX_NOTE.to_string());
+            }
+            ok_json(out)
+        }
+        Some(ref id) => {
+            // Validate limit
+            if let Some(lim) = p.limit {
+                if lim == 0 {
+                    return err_json("INVALID_PARAMS", "limit must be > 0");
+                }
+            }
+
+            // Check TTL / existence first
+            let get_result = store
+                .lock()
+                .map(|s| s.get(id))
+                .unwrap_or(log_store::GetResult::NotFound);
+
+            match get_result {
+                log_store::GetResult::NotFound => err_json(
+                    "LOG_NOT_FOUND",
+                    &format!("No log entry found with id '{}'", id),
+                ),
+                log_store::GetResult::Expired => err_json(
+                    "LOG_EXPIRED",
+                    &format!("Log entry '{}' has expired (TTL exceeded)", id),
+                ),
+                log_store::GetResult::Found(_) => {
+                    // Now handle pagination
+                    let paginated = store
+                        .lock()
+                        .ok()
+                        .and_then(|s| s.get_paginated(id, p.limit, p.offset));
+
+                    match paginated {
+                        None => err_json(
+                            "LOG_EXPIRED",
+                            &format!("Log entry '{}' expired during retrieval", id),
+                        ),
+                        Some((result, has_more, total_count)) => {
+                            if p.limit.is_some() {
+                                ok_json(serde_json::json!({
+                                    "success": true,
+                                    "log_id": id,
+                                    "total_count": total_count,
+                                    "offset": p.offset,
+                                    "limit": p.limit,
+                                    "has_more": has_more,
+                                    "result": result,
+                                }))
+                            } else {
+                                ok_json(serde_json::json!({
+                                    "success": true,
+                                    "log_id": id,
+                                    "total_count": total_count,
+                                    "result": result,
+                                }))
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
 }
 
 #[derive(Debug, Deserialize, JsonSchema)]
@@ -1737,35 +1934,20 @@ pub struct IrisTools {
 
 #[tool_router]
 impl IrisTools {
+    /// Baseline-toolset constructor. Delegates to `with_registry_and_toolset` so the
+    /// router is PRUNED the same way every other constructor prunes it — it used to
+    /// stamp `toolset: Toolset::Baseline` while assigning the raw 58-tool
+    /// `Self::tool_router()`, i.e. it carried the 4 merged-only tools baseline does not
+    /// advertise. Harmless only while `registered_tool_names` ignored the router; now
+    /// that it derives from the router (2026-08-26) the two must agree.
     pub fn new(iris: Option<IrisConnection>) -> anyhow::Result<Self> {
-        let client = Arc::new(IrisConnection::http_client()?);
-        let conn_state = match iris {
-            Some(c) => ConnectionState::from_iris(c, ConnectionSource::EnvVars, None),
-            None => ConnectionState::new_disconnected(ConnectionSource::EnvVars),
-        };
-        let log_max = std::env::var("IRIS_LOG_STORE_MAX")
-            .ok()
-            .and_then(|v| v.parse().ok())
-            .unwrap_or(50usize);
-        let log_ttl = std::env::var("IRIS_LOG_TTL_MINUTES")
-            .ok()
-            .and_then(|v| v.parse().ok())
-            .unwrap_or(60u64);
-        Ok(Self {
-            connection: Arc::new(std::sync::Mutex::new(conn_state)),
-            config_watcher: Arc::new(std::sync::Mutex::new(None)),
-            registry: Arc::new(crate::skills::SkillRegistry::new()),
-            client,
-            history: Arc::new(std::sync::Mutex::new(VecDeque::with_capacity(50))),
-            elicitation_store: Arc::new(ElicitationStore::new()),
-            checkout_cache: Arc::new(crate::elicitation::CheckoutCache::new()),
-            log_store: Arc::new(std::sync::Mutex::new(log_store::LogStore::new(
-                log_max, log_ttl,
-            ))),
-            metadata_cache: Arc::new(std::sync::Mutex::new(HashMap::new())),
-            toolset: Toolset::Baseline,
-            tool_router: Self::tool_router(),
-        })
+        Self::with_registry_and_toolset(
+            iris,
+            crate::skills::SkillRegistry::new(),
+            Toolset::Baseline,
+            None,
+            None,
+        )
     }
     /// Convenience constructor for tests — same as `new` but with explicit toolset.
     pub fn new_with_toolset(
@@ -1783,127 +1965,21 @@ impl IrisTools {
 
     /// Returns the set of tool names registered for the current toolset.
     /// Used by tests and by the benchmark harness to build valid_tool_names.
+    ///
+    /// Derived from the live `tool_router` for EVERY toolset. The router is built in
+    /// `with_registry_and_toolset`, which applies toolset pruning AND the write gate,
+    /// so this can never disagree with what `tools/list` advertises.
+    /// (Until 2026-08-26 the non-Interop tiers used a hardcoded list last audited
+    /// against v0.4.x; it had drifted 17 tools short and carried one phantom —
+    /// `iris_admin`, which the router removes for baseline/nostub. The tests that
+    /// guarded it compared the hardcoded list against itself, so the drift was
+    /// invisible; `test_toolset_counts_match_doc_comments` now pins the real numbers.)
     pub fn registered_tool_names(&self) -> std::collections::HashSet<String> {
-        // The Interop profile is pruned directly from the live router, so derive its
-        // names from the router itself — always in sync, no hardcoded duplicate to drift.
-        if self.toolset == Toolset::Interop {
-            return self
-                .tool_router
-                .list_all()
-                .into_iter()
-                .map(|t| t.name.to_string())
-                .collect();
-        }
-        // Authoritative baseline list — 34 tools matching v0.4.x (audit 2026-04-28).
-        // REST(14) + Docker(16) + Local(4) = 34
-        // 34 - stubs(4) = nostub(30); 30 - merged_removed(10) + merged_added(4) = merged(24)
-        // Note: iris_symbols_local is no longer a stub (025-symbols-local-ts)
-        let all_tools: &[&str] = &[
-            // REST — 14
-            "iris_compile",
-            "iris_execute",
-            "iris_doc",
-            "iris_query",
-            "iris_symbols",
-            "iris_symbols_local",
-            "docs_introspect",
-            "iris_search",
-            "iris_info",
-            "iris_macro",
-            "iris_table_info",
-            "resolve_dynamic_dispatch",
-            "extract_message_map_routing",
-            "find_subclass_implementations",
-            "debug_capture_packet",
-            "debug_get_error_logs",
-            "iris_generate",
-            "iris_generate_class",
-            // Docker exec
-            "iris_test",
-            "debug_map_int_to_cls",
-            "debug_source_map",
-            "iris_source_control",
-            "skill",
-            "skill_propose",
-            "skill_optimize",
-            // Local/CLI — 4
-            "skill_share",
-            "skill_community",
-            "skill_community_install",
-            "kb",
-            // Interoperability — available in all tiers (036: removed individual stubs)
-            "iris_production",
-            "iris_interop_query",
-            "iris_production_item",
-            "iris_credential_list",
-            "iris_credential_manage",
-            "iris_lookup_manage",
-            "iris_lookup_transfer",
-            // 026-admin-tools
-            "iris_admin",
-            // 034-live-connection-reload
-            "check_config",
-        ];
-
-        // Tools removed in nostub — 4 stubs returning NOT_IMPLEMENTED
-        // iris_symbols_local is NO LONGER a stub (025-symbols-local-ts)
-        let stub_tools: &[&str] = &[
-            "skill_propose",
-            "skill_optimize",
-            "skill_share",
-            "skill_community_install",
-        ];
-
-        // Tools removed in merged (on top of stubs)
-        // 036: individual interop stubs removed entirely; merged dispatchers now in all tiers
-        let merged_removed: &[&str] = &[
-            "debug_capture_packet",
-            "debug_get_error_logs",
-            "debug_map_int_to_cls",
-            "debug_source_map",
-        ];
-        let merged_removed_2: &[&str] = &[] as &[&str]; // placeholder
-        let merged_added: &[&str] = &[
-            "iris_debug",
-            "iris_containers",
-            // 026-admin-tools
-            "iris_admin",
-            // 027-progressive-disclosure
-            "iris_get_log",
-        ];
-
-        let mut names: std::collections::HashSet<String> =
-            all_tools.iter().map(|s| s.to_string()).collect();
-
-        match self.toolset {
-            Toolset::Interop => unreachable!("derived from router and returned early above"),
-            Toolset::Baseline => {}
-            Toolset::Nostub => {
-                for s in stub_tools {
-                    names.remove(*s);
-                }
-            }
-            Toolset::Merged => {
-                for s in stub_tools {
-                    names.remove(*s);
-                }
-                for s in merged_removed {
-                    names.remove(*s);
-                }
-                let _ = merged_removed_2; // unused in this path
-                for s in merged_added {
-                    names.insert(s.to_string());
-                }
-                // Apply write-gate: remove write-only tools if not write-allowed
-                if !self.write_tools_enabled() {
-                    let write_gated: &[&str] = &["iris_production_item", "iris_credential_manage"];
-                    for s in write_gated {
-                        names.remove(*s);
-                    }
-                }
-            }
-        }
-        names
+        self.tool_router
+            .list_all()
+            .into_iter()
+            .map(|t| t.name.to_string())
+            .collect()
     }
 
     pub fn with_registry(
@@ -4135,77 +4211,112 @@ Methods:
         )
     }
 
-    #[tool(description = "List all synthesized skills in the registry.")]
+    // ── ^SKILLS readers (issue #119) ─────────────────────────────────────────
+    // All three used to hand-build JSON by concatenating the RAW pipe-delimited value
+    // into an array literal, never emitting the subscript (the skill NAME). serde then
+    // rejected the payload and every failure fell through to an empty list / NOT_FOUND —
+    // indistinguishable from "no IRIS". The assembly now lives in ONE place,
+    // `skills_tools::skills_list_json_code` / `skills_describe_json_code`, which uses
+    // %DynamicArray + %ToJSON so IRIS does the escaping.
+
+    #[tool(
+        description = "List all synthesized skills in the ^SKILLS registry (name, description, usage_count, created_at)."
+    )]
     async fn skill_list(&self, _: Parameters<NoParams>) -> Result<CallToolResult, McpError> {
-        if let Some(iris) = self.iris_arc().as_deref() {
-            let code = "Set key=\"\" Set result=\"[\" Set sep=\"\" For { Set key=$Order(^SKILLS(key)) Quit:key=\"\" Set skill=$Get(^SKILLS(key)) Set result=result_sep_skill Set sep=\",\" } Set result=result_\"]\" Write result";
-            if let Ok(output) = iris
-                .execute(code, &crate::tools::skills_tools::skills_namespace())
-                .await
-            {
-                if let Ok(skills) = serde_json::from_str::<serde_json::Value>(output.trim()) {
-                    let count = skills.as_array().map(|a| a.len()).unwrap_or(0);
-                    return ok_json(serde_json::json!({"skills": skills, "count": count}));
-                }
+        let ns = skills_tools::skills_namespace();
+        let Some(iris) = self.iris_arc() else {
+            return skills_tools::skills_read_fail(
+                "skill_list",
+                &ns,
+                skills_tools::SkillsReadError::Unreachable("no IRIS connection configured".into()),
+            );
+        };
+        let code = skills_tools::skills_list_json_code(None, false);
+        match skills_tools::read_skills_json(&iris, &code, &ns).await {
+            Ok(skills) => {
+                let count = skills.as_array().map(|a| a.len()).unwrap_or(0);
+                ok_json(serde_json::json!({
+                    "success": true, "skills": skills, "count": count,
+                    "namespace": ns, "source": "^SKILLS"
+                }))
             }
+            Err(e) => skills_tools::skills_read_fail("skill_list", &ns, e),
         }
-        ok_json(serde_json::json!({"skills": [], "count": 0}))
     }
 
-    #[tool(description = "Describe a skill by name.")]
+    #[tool(description = "Describe one skill in the ^SKILLS registry by name.")]
     async fn skill_describe(
         &self,
         Parameters(p): Parameters<SkillNameParams>,
     ) -> Result<CallToolResult, McpError> {
-        if let Some(iris) = self.iris_arc().as_deref() {
-            let code = format!("Write $Get(^SKILLS({}))", os_str_expr(&p.name));
-            if let Ok(output) = iris
-                .execute(&code, &crate::tools::skills_tools::skills_namespace())
-                .await
-            {
-                if let Ok(skill) = serde_json::from_str::<serde_json::Value>(output.trim()) {
-                    return ok_json(serde_json::json!({"success": true, "skill": skill}));
-                }
+        let ns = skills_tools::skills_namespace();
+        let Some(iris) = self.iris_arc() else {
+            return skills_tools::skills_read_fail(
+                "skill_describe",
+                &ns,
+                skills_tools::SkillsReadError::Unreachable("no IRIS connection configured".into()),
+            );
+        };
+        // #119: was `Write $Get(^SKILLS(name))` parsed as JSON — a pipe-delimited string
+        // never parses, so this tool returned NOT_FOUND for every skill that existed.
+        let code = skills_tools::skills_describe_json_code(&p.name);
+        match skills_tools::read_skills_json(&iris, &code, &ns).await {
+            Ok(v) if v.get("found").and_then(|f| f.as_i64()) == Some(1) => {
+                ok_json(serde_json::json!({
+                    "success": true, "name": p.name, "skill": v,
+                    "namespace": ns, "source": "^SKILLS"
+                }))
             }
+            // The `found` sentinel is what separates "IRIS answered, no such skill" from
+            // "IRIS never answered" — an empty payload cannot tell them apart.
+            Ok(_) => envelope::fail_with(
+                "NOT_FOUND",
+                &format!(
+                    "Skill '{}' not found in ^SKILLS (namespace '{}')",
+                    p.name, ns
+                ),
+                serde_json::json!({"namespace": ns, "source": "^SKILLS"}),
+            ),
+            Err(e) => skills_tools::skills_read_fail("skill_describe", &ns, e),
         }
-        err_json("NOT_FOUND", &format!("Skill '{}' not found", p.name))
     }
 
     #[tool(
-        description = "Search synthesized skills by name and description. Returns skills whose name or description contains the query terms."
+        description = "Search the ^SKILLS registry by name and description. Returns skills whose name or description contains the query (case-insensitive substring)."
     )]
     async fn skill_search(
         &self,
         Parameters(p): Parameters<SkillSearchParams>,
     ) -> Result<CallToolResult, McpError> {
-        if let Some(iris) = self.iris_arc().as_deref() {
-            let query_lower = p.query.to_lowercase();
-            let q = query_lower.replace('"', "");
-            let code = format!(
-                concat!(
-                    r#"Set key="",results="[",sep="" "#,
-                    r#"For {{ Set key=$Order(^SKILLS(key)) Quit:key="" "#,
-                    r#"Set skill=$Get(^SKILLS(key)) "#,
-                    r#"If ($ZConvert(skill,"L")["{0}")||($ZConvert(key,"L")["{0}") "#,
-                    r#"{{ Set results=results_sep_skill Set sep="," }} }} "#,
-                    r#"Set results=results_"]" Write results"#
-                ),
-                q
+        let ns = skills_tools::skills_namespace();
+        let Some(iris) = self.iris_arc() else {
+            return skills_tools::skills_read_fail(
+                "skill_search",
+                &ns,
+                skills_tools::SkillsReadError::Unreachable("no IRIS connection configured".into()),
             );
-            if let Ok(output) = iris
-                .execute(&code, &crate::tools::skills_tools::skills_namespace())
-                .await
-            {
-                if let Ok(skills) = serde_json::from_str::<Vec<serde_json::Value>>(output.trim()) {
-                    let limited: Vec<_> = skills.into_iter().take(p.top_k).collect();
-                    let count = limited.len();
-                    return ok_json(
-                        serde_json::json!({"query": p.query, "results": limited, "count": count}),
-                    );
-                }
+        };
+        // #67: the needle goes through os_str_expr inside the builder. The old form
+        // hand-stripped quotes (`query_lower.replace('"', "")`) and interpolated the
+        // result raw into an ObjectScript literal — a query with a newline could not
+        // compile at all.
+        let query_lower = p.query.to_lowercase();
+        let code = skills_tools::skills_list_json_code(Some(&query_lower), false);
+        match skills_tools::read_skills_json(&iris, &code, &ns).await {
+            Ok(skills) => {
+                let all = skills.as_array().cloned().unwrap_or_default();
+                let matched = all.len();
+                // top_k of 0 used to silently return nothing; clamp to at least 1.
+                let limited: Vec<_> = all.into_iter().take(p.top_k.max(1)).collect();
+                let count = limited.len();
+                ok_json(serde_json::json!({
+                    "success": true, "query": p.query, "results": limited,
+                    "count": count, "matched": matched,
+                    "namespace": ns, "source": "^SKILLS"
+                }))
             }
+            Err(e) => skills_tools::skills_read_fail("skill_search", &ns, e),
         }
-        ok_json(serde_json::json!({"query": p.query, "results": [], "count": 0}))
     }
 
     #[tool(description = "Remove a skill from the registry by name.")]
@@ -5442,87 +5553,15 @@ Methods:
     // ── iris_get_log (027 — progressive disclosure, Merged tier only) ──────────
 
     #[tool(
-        description = "Retrieve a stored result by log_id from the progressive disclosure store. With id: returns the full result (optionally paginated with limit/offset). Without id: lists all stored log entries with their IDs, tools, timestamps, and total counts. Use after any tool returns truncated:true."
+        description = "Retrieve a result a PREVIOUS tool truncated, from this server's in-memory result store. This is NOT the IRIS event log — for interoperability logs use iris_interop_query (what=logs, or what=trace with session_id). With id (alias: log_id — the value a truncated:true result handed back): returns the full result, optionally paginated with limit/offset. With NO parameters: lists the stored entries (id, tool, timestamp, total_count). Any other parameter name is an error, not a fallback to the listing. Use after any tool returns truncated:true."
     )]
     async fn iris_get_log(
         &self,
         Parameters(p): Parameters<GetLogParams>,
     ) -> Result<CallToolResult, McpError> {
-        match p.id {
-            None => {
-                // List all non-expired entries
-                let summaries = self
-                    .log_store
-                    .lock()
-                    .map(|mut s| s.list())
-                    .unwrap_or_default();
-                ok_json(serde_json::json!({
-                    "success": true,
-                    "logs": summaries,
-                }))
-            }
-            Some(ref id) => {
-                // Validate limit
-                if let Some(lim) = p.limit {
-                    if lim == 0 {
-                        return err_json("INVALID_PARAMS", "limit must be > 0");
-                    }
-                }
-
-                // Check TTL / existence first
-                let get_result = self
-                    .log_store
-                    .lock()
-                    .map(|s| s.get(id))
-                    .unwrap_or(log_store::GetResult::NotFound);
-
-                match get_result {
-                    log_store::GetResult::NotFound => err_json(
-                        "LOG_NOT_FOUND",
-                        &format!("No log entry found with id '{}'", id),
-                    ),
-                    log_store::GetResult::Expired => err_json(
-                        "LOG_EXPIRED",
-                        &format!("Log entry '{}' has expired (TTL exceeded)", id),
-                    ),
-                    log_store::GetResult::Found(_) => {
-                        // Now handle pagination
-                        let paginated = self
-                            .log_store
-                            .lock()
-                            .ok()
-                            .and_then(|s| s.get_paginated(id, p.limit, p.offset));
-
-                        match paginated {
-                            None => err_json(
-                                "LOG_EXPIRED",
-                                &format!("Log entry '{}' expired during retrieval", id),
-                            ),
-                            Some((result, has_more, total_count)) => {
-                                if p.limit.is_some() {
-                                    ok_json(serde_json::json!({
-                                        "success": true,
-                                        "log_id": id,
-                                        "total_count": total_count,
-                                        "offset": p.offset,
-                                        "limit": p.limit,
-                                        "has_more": has_more,
-                                        "result": result,
-                                    }))
-                                } else {
-                                    ok_json(serde_json::json!({
-                                        "success": true,
-                                        "log_id": id,
-                                        "total_count": total_count,
-                                        "result": result,
-                                    }))
-                                }
-                            }
-                        }
-                    }
-                }
-            }
-        }
+        // #78: the body lives in the free function `get_log_impl` so it is unit-testable
+        // with nothing but a LogStore — this handler reaches no IRIS connection at all.
+        get_log_impl(&self.log_store, p)
     }
 }
 
@@ -5552,6 +5591,7 @@ impl ServerHandler for IrisTools {
         for tool in tools.iter_mut() {
             let schema = std::sync::Arc::make_mut(&mut tool.input_schema);
             normalize_schema_openapi3(schema);
+            drop_default_additional_properties(schema);
         }
         Ok(rmcp::model::ListToolsResult {
             tools,
@@ -5645,6 +5685,18 @@ fn normalize_schema_openapi3(schema: &mut serde_json::Map<String, serde_json::Va
             serde_json::json!({"type": "null"}),
         ]),
     );
+}
+
+/// Issue #78: `#[serde(flatten)]` on GetLogParams makes schemars emit
+/// `"additionalProperties": true` — JSON Schema's DEFAULT, so dropping it changes nothing
+/// for any validator, and it keeps every advertised inputSchema byte-identical to the
+/// pre-#78 one. No tool in either profile emits this keyword today; strict clients are the
+/// reason `AnyParams` carries a hand-written JsonSchema impl (see also #113/#115).
+/// Top level only — a nested `additionalProperties` would be load-bearing.
+fn drop_default_additional_properties(schema: &mut serde_json::Map<String, serde_json::Value>) {
+    if schema.get("additionalProperties") == Some(&serde_json::Value::Bool(true)) {
+        schema.remove("additionalProperties");
+    }
 }
 
 fn parse_iris_error_string(s: &str) -> Option<(String, i64)> {
@@ -5888,7 +5940,9 @@ mod config_watcher_tests {
 
 #[cfg(test)]
 mod schema_normalization_tests {
+    use super::drop_default_additional_properties;
     use super::normalize_schema_openapi3;
+    use super::GetLogParams;
     use super::DOCKER_REQUIRED_HINT;
 
     #[test]
@@ -5998,6 +6052,66 @@ mod schema_normalization_tests {
             conn_src_pos < host_pos,
             "connection_source must appear before host in check_config output (got positions {conn_src_pos} vs {host_pos})"
         );
+    }
+
+    // ── Issue #78: GetLogParams' advertised schema ───────────────────────────
+
+    /// The flattened leftover-capture map must not leak a property, and the one keyword it
+    /// does add (`additionalProperties: true`, JSON Schema's default) must be stripped on
+    /// the wire — no tool in either profile emits that keyword, and strict clients are why
+    /// `AnyParams` carries a hand-written JsonSchema impl (#113/#115).
+    #[test]
+    fn get_log_input_schema_still_advertises_exactly_id_limit_offset() {
+        let schema = serde_json::to_value(schemars::schema_for!(GetLogParams)).unwrap();
+        let props = schema["properties"].as_object().unwrap();
+        let mut keys: Vec<&str> = props.keys().map(String::as_str).collect();
+        keys.sort();
+        assert_eq!(
+            keys,
+            vec!["id", "limit", "offset"],
+            "the #[serde(flatten)] capture must not surface as a caller-facing parameter"
+        );
+        assert!(
+            props["id"]["description"]
+                .as_str()
+                .unwrap()
+                .contains("log_id"),
+            "the alias must be documented where the agent reads it: {}",
+            props["id"]["description"]
+        );
+        assert_eq!(
+            schema["additionalProperties"],
+            serde_json::Value::Bool(true),
+            "schemars emits exactly this for a flattened map — if that changes, revisit \
+             drop_default_additional_properties"
+        );
+
+        let mut obj = schema.as_object().unwrap().clone();
+        drop_default_additional_properties(&mut obj);
+        assert!(
+            obj.get("additionalProperties").is_none(),
+            "the advertised schema must stay byte-identical to the pre-#78 one"
+        );
+    }
+
+    /// `normalize_schema_openapi3` lists "additionalProperties" among the keys it relocates
+    /// into an `anyOf` branch — but only where the schema has a nullable TYPE ARRAY.
+    /// GetLogParams' top level is `"type": "object"`, so it must never take that path.
+    #[test]
+    fn normalize_leaves_the_get_log_object_schema_intact() {
+        let schema = serde_json::to_value(schemars::schema_for!(GetLogParams)).unwrap();
+        let mut obj = schema.as_object().unwrap().clone();
+        normalize_schema_openapi3(&mut obj);
+        assert!(
+            obj["properties"]["id"]["anyOf"].is_array(),
+            "the nullable rewrite must still fire on Option<String>: {obj:?}"
+        );
+        assert_eq!(
+            obj["additionalProperties"],
+            serde_json::Value::Bool(true),
+            "the object level must not be rewritten into an anyOf branch"
+        );
+        assert!(obj.get("anyOf").is_none(), "{obj:?}");
     }
 
     // ── DOCKER_REQUIRED remediation hint ─────────────────────────────────────
@@ -6346,5 +6460,244 @@ mod no_tests_found_guidance_tests {
         let cands = v(&["Wk47.Tests.SmokeTest"]);
         let (_, dym) = no_tests_found_guidance("wk47.tests", "APP", &cands, false);
         assert_eq!(dym, v(&["Wk47.Tests.SmokeTest"]));
+    }
+}
+
+// ── Issue #78: iris_get_log addressing ────────────────────────────────────────
+#[cfg(test)]
+mod get_log_params_tests {
+    use super::*;
+    use std::sync::{Arc, Mutex};
+
+    fn empty_store() -> Arc<Mutex<log_store::LogStore>> {
+        Arc::new(Mutex::new(log_store::LogStore::new(50, 60)))
+    }
+
+    /// Stores `n` entries, each holding `items` result rows. Returns the store and the ids.
+    fn store_with(n: usize, items: usize) -> (Arc<Mutex<log_store::LogStore>>, Vec<String>) {
+        let store = empty_store();
+        let mut ids = Vec::new();
+        {
+            let mut s = store.lock().unwrap();
+            for i in 0..n {
+                let rows: Vec<serde_json::Value> =
+                    (0..items).map(|j| serde_json::json!({"row": j})).collect();
+                let id = log_store::new_log_id();
+                s.store(log_store::LogEntry {
+                    id: id.clone(),
+                    tool: format!("iris_test_{i}"),
+                    created_at: std::time::Instant::now(),
+                    preview: rows.iter().take(1).cloned().collect(),
+                    full_result: serde_json::Value::Array(rows.clone()),
+                    total_count: rows.len(),
+                });
+                ids.push(id);
+            }
+        }
+        (store, ids)
+    }
+
+    fn parse(v: serde_json::Value) -> GetLogParams {
+        serde_json::from_value(v).expect("GetLogParams must deserialize")
+    }
+
+    fn payload(r: &CallToolResult) -> serde_json::Value {
+        let text = match &r.content[0].raw {
+            RawContent::Text(t) => &t.text,
+            _ => panic!("expected text content"),
+        };
+        serde_json::from_str(text).unwrap()
+    }
+
+    fn call(
+        store: &Arc<Mutex<log_store::LogStore>>,
+        args: serde_json::Value,
+    ) -> (CallToolResult, serde_json::Value) {
+        let r = get_log_impl(store, parse(args)).unwrap();
+        let v = payload(&r);
+        (r, v)
+    }
+
+    /// Criterion 1: `log_id` is the name every truncating tool emits
+    /// (`log_store::apply_truncation`), so it must address the same entry as `id`.
+    #[test]
+    fn log_id_alias_reaches_the_same_entry_as_id() {
+        let (store, ids) = store_with(1, 3);
+        let (r1, v1) = call(&store, serde_json::json!({"log_id": ids[0]}));
+        let (r2, v2) = call(&store, serde_json::json!({"id": ids[0]}));
+        assert_ne!(r1.is_error, Some(true));
+        assert_ne!(r2.is_error, Some(true));
+        assert_eq!(v1, v2, "log_id and id must be the same addressing key");
+        assert_eq!(v1["total_count"], 3);
+    }
+
+    /// The issue's headline: `log_id` on a missing entry used to return the INDEX
+    /// (`{"logs":[],"success":true}`), a different response shape that reads as
+    /// "no logs exist". It must be LOG_NOT_FOUND, and it must carry no `logs` key.
+    #[test]
+    fn log_id_on_a_missing_entry_is_log_not_found_not_the_index() {
+        let store = empty_store();
+        let (r, v) = call(
+            &store,
+            serde_json::json!({"namespace": "APP", "log_id": "1"}),
+        );
+        assert_eq!(r.is_error, Some(true));
+        assert_eq!(v["error_code"], "LOG_NOT_FOUND");
+        assert!(
+            v.get("logs").is_none(),
+            "the index shape must never answer an addressed call: {v}"
+        );
+    }
+
+    /// Criterion 2: a mistyped addressing key is named, not swallowed.
+    #[test]
+    fn a_mistyped_addressing_key_is_an_error_that_names_it() {
+        let store = empty_store();
+        let (r, v) = call(
+            &store,
+            serde_json::json!({"namespace": "APP", "logid": "1"}),
+        );
+        assert_eq!(r.is_error, Some(true));
+        assert_eq!(v["error_code"], "INVALID_PARAMS");
+        assert!(
+            v["error"].as_str().unwrap().contains("'logid'"),
+            "the error must name the offending key: {v}"
+        );
+        assert_eq!(v["unknown_params"], serde_json::json!(["logid"]));
+        assert_eq!(
+            v["valid_params"],
+            serde_json::json!(["id", "limit", "offset"])
+        );
+        assert_eq!(v["did_you_mean"], serde_json::json!(["id"]));
+        assert!(
+            v.get("logs").is_none(),
+            "an error must not also look like the index: {v}"
+        );
+    }
+
+    /// Criterion 4 (no regression): `namespace` is sprayed by the harness on nearly every
+    /// call, including the correct index call, so it must stay ignorable.
+    #[test]
+    fn bare_namespace_still_lists_the_index() {
+        let store = empty_store();
+        for args in [
+            serde_json::json!({"namespace": "APP"}),
+            serde_json::json!({}),
+        ] {
+            let (r, v) = call(&store, args.clone());
+            assert_ne!(r.is_error, Some(true), "{args} must not be an error");
+            assert_eq!(v["success"], true);
+            assert!(v["logs"].is_array(), "{v}");
+        }
+    }
+
+    #[test]
+    fn namespace_does_not_suppress_a_populated_index() {
+        let (store, _ids) = store_with(2, 1);
+        let (r, v) = call(&store, serde_json::json!({"namespace": "APP"}));
+        assert_ne!(r.is_error, Some(true));
+        assert_eq!(v["logs"].as_array().unwrap().len(), 2);
+        assert!(
+            v.get("note").is_none(),
+            "the note is for the EMPTY index only — it would be noise here: {v}"
+        );
+    }
+
+    /// Criterion 3: an empty index must say what this store is and is NOT, and must point
+    /// at the tools that really read IRIS logs. The tool names are pinned deliberately —
+    /// the whole value of the note is that they are real.
+    #[test]
+    fn the_empty_index_says_what_this_store_is_and_is_not() {
+        let store = empty_store();
+        let (_r, v) = call(&store, serde_json::json!({}));
+        let note = v["note"].as_str().expect("empty index must carry a note");
+        for needle in [
+            "truncated:true",
+            "log_id",
+            "NOT the IRIS event log",
+            "iris_interop_query",
+            "what='logs'",
+            "what='trace'",
+        ] {
+            assert!(note.contains(needle), "note must mention {needle}: {note}");
+        }
+    }
+
+    /// The unknown-key check is deliberately gated on `id.is_none()`: with `id` present the
+    /// response shape is unambiguous, so an extra key cannot be mistaken for the index.
+    #[test]
+    fn an_unknown_key_alongside_id_still_answers_the_id() {
+        let store = empty_store();
+        let (r, v) = call(
+            &store,
+            serde_json::json!({"id": "nope", "tool": "iris_test"}),
+        );
+        assert_eq!(r.is_error, Some(true));
+        assert_eq!(v["error_code"], "LOG_NOT_FOUND");
+    }
+
+    /// `_meta` and friends are client/protocol markers, never tool parameters.
+    #[test]
+    fn underscore_prefixed_keys_are_never_reported() {
+        let store = empty_store();
+        let (r, v) = call(&store, serde_json::json!({"_meta": {"x": 1}}));
+        assert_ne!(r.is_error, Some(true));
+        assert!(v["logs"].is_array(), "{v}");
+    }
+
+    #[test]
+    fn near_miss_normalisation() {
+        for k in [
+            "logid",
+            "logId",
+            "LOG-ID",
+            "log id",
+            "entryid",
+            "log_entry_id",
+        ] {
+            assert!(is_log_id_near_miss(k), "{k} must be a near miss");
+        }
+        for k in ["session_id", "tool", "namespace", "limit", "id"] {
+            assert!(!is_log_id_near_miss(k), "{k} must NOT be a near miss");
+        }
+    }
+
+    #[test]
+    fn unknown_params_are_sorted_for_a_deterministic_message() {
+        let store = empty_store();
+        let (_r, v) = call(&store, serde_json::json!({"zeta": 1, "alpha": 2}));
+        assert_eq!(v["unknown_params"], serde_json::json!(["alpha", "zeta"]));
+    }
+
+    /// `#[serde(flatten)]` switches the struct onto serde's buffered content deserializer —
+    /// pin that limit/offset still deserialize and validate exactly as before.
+    #[test]
+    fn pagination_and_limit_validation_survive_the_flatten() {
+        let (store, ids) = store_with(1, 5);
+        let (r, v) = call(
+            &store,
+            serde_json::json!({"id": ids[0], "limit": 2, "offset": 0}),
+        );
+        assert_ne!(r.is_error, Some(true));
+        assert_eq!(v["total_count"], 5);
+        assert_eq!(v["has_more"], true);
+        assert_eq!(v["result"].as_array().unwrap().len(), 2);
+
+        let (r, v) = call(&store, serde_json::json!({"id": ids[0], "limit": 0}));
+        assert_eq!(r.is_error, Some(true));
+        assert_eq!(v["error_code"], "INVALID_PARAMS");
+        assert!(v["error"].as_str().unwrap().contains("limit must be > 0"));
+    }
+
+    /// Both addressing keys at once is a serde `duplicate field` error, which rmcp surfaces
+    /// as a JSON-RPC -32602 frame — NOT the issue-#2 envelope. Loud rather than silent, which
+    /// is the property that matters here; pinned so a future reader is not surprised by it.
+    #[test]
+    fn both_id_and_log_id_is_rejected_rather_than_listing_the_index() {
+        assert!(
+            serde_json::from_value::<GetLogParams>(serde_json::json!({"id": "a", "log_id": "b"}))
+                .is_err(),
+            "two addressing keys must not silently resolve to one"
+        );
     }
 }

--- a/crates/iris-agentic-dev-core/src/tools/skills_tools.rs
+++ b/crates/iris-agentic-dev-core/src/tools/skills_tools.rs
@@ -17,6 +17,219 @@ fn skills_set_code(name: &str, description: &str, body: &str, now: &str) -> Stri
         os_str_expr(now),
     )
 }
+// ── ^SKILLS → JSON (issue #119, upstream intersystems-community/iris-agentic-dev#119) ──
+//
+// Every reader of `^SKILLS` has to turn a pipe-delimited global into JSON. Hand-rolling
+// that concatenation is what broke `skill_list`/`skill_search`/`skill_describe` in
+// `tools/mod.rs`: they pasted the RAW value into an array literal, never emitted the
+// subscript (the skill NAME), and `serde_json` then rejected the whole payload — silently,
+// as an empty registry. These builders are the ONE place that assembly happens.
+//
+// `$translate(x, q_$CHAR(13,10), "   ")` — the form the `handle_skill` arms below used —
+// is not enough either: it neutralises quote/CR/LF but NOT backslash, which JSON also
+// requires escaped. Verified against IRIS 2026.2, name `a\qb`:
+//     $translate form -> {"name":"a\qb"}   <- serde: `Invalid \escape`, silently []
+//     %ToJSON form    -> {"name":"a\\qb"}  <- correct
+//
+// `%DynamicObject`/`%DynamicArray` + `%ToJSON()` escapes for us. Verified live:
+//     name `quo"te`   -> "quo\"te"          (lossless)
+//     desc with CRLF  -> "desc\r\nline2"    (escaped — payload stays on ONE line)
+//     empty global    -> []                 (not `]`)
+//
+// The pipe is NOT escaped and must not be: it is the storage delimiter `skills_set_code`
+// writes, so `$piece` truncates a description at its first pipe. That is a `^SKILLS`
+// on-disk-format limitation, not a JSON one — the emitted JSON stays valid either way.
+// Changing it means changing the storage format; deliberately out of scope for #119.
+//
+// `do arr.%ToJSON(st)` streams into a temp stream. `write arr.%ToJSON()` would materialise
+// the whole document as one string and can hit <MAXSTRING> on a large registry.
+//
+// The leading/trailing `write !` fence the payload onto its own line: the transport is
+// `docker exec -i <c> iris session`, which interleaves `USER>` prompts with output, and
+// `strip_iris_banner` only drops a prompt line with nothing else on it.
+//
+// #119 follow-up — the payload must also be pure 7-bit ASCII. `%ToJSON` emits a non-ASCII
+// character RAW, and the transport is a `docker exec` terminal device, which is not charset
+// transparent: verified live on IRIS 2026.2, `^SKILLS("unicode-café-中")` came back as
+// `{"name":"unicode-caf<0xE9>-?"}` — the CJK characters replaced by literal `?` by the
+// device and `é` emitted as the single byte 0xE9, which `String::from_utf8_lossy` in
+// `IrisConnection::execute` then turned into U+FFFD. isError was false and success was
+// true: a silently wrong answer, exactly the class of bug #119 exists to kill. So every
+// character above 0x7E is re-emitted as a `\uXXXX` JSON escape (`os_json_ascii_emit`)
+// before it ever reaches the device. `\uXXXX` is valid JSON everywhere a raw character is,
+// `serde_json` decodes it back to the original character, and an ASCII payload cannot be
+// mangled by ANY device translation table.
+
+const SKILLS_GLOBAL: &str = "^SKILLS";
+
+/// Statements that write the JSON of `var` (a `%DynamicObject`/`%DynamicArray`) to the
+/// current device as pure ASCII, fenced onto its own line.
+///
+/// `%ToJSON(st)` streams into a temp stream rather than materialising the document as a
+/// string (<MAXSTRING> on a large registry), then each chunk is re-emitted with every
+/// character above 0x7E replaced by its `\uXXXX` JSON escape.
+///
+/// Chunking is safe at any boundary: IRIS holds an astral character as a UTF-16 surrogate
+/// PAIR, each half is escaped independently, and `😀` reassembles in the JSON
+/// text no matter which chunk each half landed in. (This is why the escape is applied to
+/// the JSON text and not `$zconvert(x,"O","UTF8")` to each value: splitting a surrogate
+/// pair across a `$zconvert` call would corrupt it, and UTF-8 bytes 0x80-0x9F are not
+/// guaranteed to survive the device's output translation table either.)
+fn os_json_ascii_emit(var: &str) -> String {
+    format!(
+        r#"set st=##class(%Stream.TmpCharacter).%New() do {var}.%ToJSON(st) do st.Rewind() write ! while 'st.AtEnd {{ set ch=st.Read(4000) set esc="" for i=1:1:$length(ch) {{ set c=$ascii(ch,i) set esc=esc_$select(c<128:$char(c),1:"\u"_$extract("000"_$zhex(c),*-3,*)) }} write esc }} write !"#
+    )
+}
+
+/// ObjectScript that writes a JSON array of `^SKILLS` entries to the current device.
+///
+/// `filter_lower` is an ALREADY-lowercased substring matched against `name|value`;
+/// `None` (or `Some("")`) lists everything — `$find(x,"")` is 1, so an empty needle
+/// matches every row. `include_body` adds the potentially large skill body; `list`/`search`
+/// leave it out so a listing does not ship every body.
+pub(crate) fn skills_list_json_code(filter_lower: Option<&str>, include_body: bool) -> String {
+    let body = if include_body {
+        r#""body":($piece(data,"|",2)),"#
+    } else {
+        ""
+    };
+    // #67: the needle is embedded from Rust, so it goes through os_str_expr — never
+    // through a hand-rolled `replace('"', "")`, which cannot survive a control character.
+    //
+    // The haystack is name + description + body, NOT `key_"|"_data`: `data` is the
+    // pipe-delimited record, so the old form put a `|` in every haystack and a search for
+    // "|" matched the entire registry. Joining the extracted pieces with a space means a
+    // pipe only matches when a field genuinely contains one.
+    let filter = match filter_lower.unwrap_or("") {
+        "" => String::new(),
+        f => format!(
+            r#"continue:'$find($zconvert(key_" "_$piece(data,"|",1)_" "_$piece(data,"|",2),"L"),{})  "#,
+            os_str_expr(f)
+        ),
+    };
+    format!(
+        r#"set arr=[] set key="" for {{ set key=$order({g}(key)) quit:key=""  set data=$get({g}(key)) {filter}do arr.%Push({{"name":(key),"description":($piece(data,"|",1)),{body}"usage_count":(+$piece(data,"|",3)),"created_at":($piece(data,"|",4))}}) }} {emit}"#,
+        g = SKILLS_GLOBAL,
+        filter = filter,
+        body = body,
+        emit = os_json_ascii_emit("arr")
+    )
+}
+
+/// ObjectScript that writes ONE `^SKILLS` entry as a JSON object, or `{"found":0}` when
+/// the subscript does not exist.
+///
+/// The `found` sentinel is what lets the caller tell "IRIS answered, no such skill" from
+/// "IRIS never answered" — an empty payload cannot, because a dropped connection produces
+/// one too. `$data(...)=0` rather than `data=""` so a skill stored with an empty value is
+/// still reported as found.
+pub(crate) fn skills_describe_json_code(name: &str) -> String {
+    format!(
+        r#"set skname={n} set data=$get({g}(skname)) if $data({g}(skname))=0 {{ set o={{"found":0}} }} else {{ set o={{"found":1,"name":(skname),"description":($piece(data,"|",1)),"body":($piece(data,"|",2)),"usage_count":(+$piece(data,"|",3)),"created_at":($piece(data,"|",4))}} }} {emit}"#,
+        n = os_str_expr(name),
+        g = SKILLS_GLOBAL,
+        emit = os_json_ascii_emit("o")
+    )
+}
+
+/// Why a `^SKILLS` read produced no data. #119: collapsing these two into "return an
+/// empty list" is the bug — a caller cannot tell a broken payload from an empty registry,
+/// and both look identical to "IRIS unreachable".
+#[derive(Debug)]
+pub(crate) enum SkillsReadError {
+    /// Never got an answer: no connection, no IRIS_CONTAINER, docker/HTTP failure.
+    Unreachable(String),
+    /// Got an answer that is not the JSON we asked for. Carries what came back.
+    Unparseable { raw: String, parse_error: String },
+}
+
+/// Last line of `raw` that starts a JSON value. `docker exec … iris session` can leave a
+/// `USER>` prompt on the payload's own line, and `strip_iris_banner` only drops a prompt
+/// line with nothing else on it — so pick the payload out rather than trusting `trim()`.
+pub(crate) fn extract_json_line(raw: &str) -> &str {
+    // `rfind` (not `find`): take the LAST candidate line, so a banner or a prompt echoed
+    // before the payload cannot win over the payload itself. clippy::filter_next requires
+    // this form over `.filter(..).next_back()`.
+    raw.lines()
+        .map(str::trim)
+        .rfind(|l| l.starts_with('[') || l.starts_with('{'))
+        .unwrap_or("")
+}
+
+/// Run one of the builders above and parse what comes back. The single read path for
+/// every `^SKILLS` reader in the crate.
+pub(crate) async fn read_skills_json(
+    iris: &IrisConnection,
+    code: &str,
+    ns: &str,
+) -> Result<serde_json::Value, SkillsReadError> {
+    let raw = iris
+        .execute(code, ns)
+        .await
+        .map_err(|e| SkillsReadError::Unreachable(e.to_string()))?;
+    classify_skills_payload(&raw)
+}
+
+/// Classify what came back off the wire. Split out from `read_skills_json` so the
+/// empty-payload rule below is testable without a live connection.
+///
+/// #119 follow-up: `IrisConnection::execute` discards the child's exit status, so a
+/// `docker exec` that FAILED — missing or stopped container, daemon down, permission
+/// denied — comes back as `Ok("")` rather than an error. Every builder above ends in a
+/// `write`, so a reachable IRIS always answers something: an empty registry writes `[]`,
+/// not nothing at all. Empty therefore means the transport produced no output, and
+/// calling that `Unparseable` would make the tool assert "IRIS WAS reachable" about an
+/// instance it never reached — a worse answer than the empty list this fix replaced.
+pub(crate) fn classify_skills_payload(raw: &str) -> Result<serde_json::Value, SkillsReadError> {
+    if raw.trim().is_empty() {
+        return Err(SkillsReadError::Unreachable(
+            "the execution transport returned no output at all (a failed `docker exec` exits \
+             non-zero with empty stdout, which reaches this crate as an empty payload)"
+                .into(),
+        ));
+    }
+    let line = extract_json_line(raw);
+    serde_json::from_str(line).map_err(|e| SkillsReadError::Unparseable {
+        raw: raw.chars().take(400).collect(),
+        parse_error: e.to_string(),
+    })
+}
+
+/// Turn a `SkillsReadError` into the envelope (issue #2 — one failure surface).
+/// `DOCKER_REQUIRED` is the code `skill_forget` already uses for an unreachable IRIS, so
+/// callers that branch on it keep working; `SKILLS_PARSE_FAILED` is new and says
+/// explicitly that IRIS WAS reached.
+pub(crate) fn skills_read_fail(
+    tool: &str,
+    ns: &str,
+    e: SkillsReadError,
+) -> Result<rmcp::model::CallToolResult, rmcp::ErrorData> {
+    match e {
+        SkillsReadError::Unreachable(err) => crate::tools::envelope::fail_with(
+            "DOCKER_REQUIRED",
+            &format!(
+                "{tool} could not reach IRIS to read ^SKILLS in namespace '{ns}': {err}. \
+                 Set IRIS_CONTAINER=<container_name>.{}",
+                super::DOCKER_REQUIRED_HINT
+            ),
+            serde_json::json!({"namespace": ns, "source": "^SKILLS"}),
+        ),
+        SkillsReadError::Unparseable { raw, parse_error } => crate::tools::envelope::fail_with(
+            "SKILLS_PARSE_FAILED",
+            &format!(
+                "{tool} read ^SKILLS in namespace '{ns}' but could not parse the response as \
+                 JSON: {parse_error}. IRIS WAS reachable — this is NOT an empty registry."
+            ),
+            serde_json::json!({
+                "namespace": ns,
+                "source": "^SKILLS",
+                "parse_error": parse_error,
+                "raw_excerpt": raw,
+            }),
+        ),
+    }
+}
+
 use crate::tools::ToolCallEntry;
 use schemars::JsonSchema;
 use serde::Deserialize;
@@ -78,45 +291,48 @@ pub async fn handle_skill(
 
     match p.action.as_str() {
         "list" => {
-            // Bug 9: use separator variable so empty global yields "[]" not "]".
-            // #67: a JSON quote inside an ObjectScript literal is $CHAR(34), never \" —
-            // backslash escapes nothing, so the old form was not valid ObjectScript and this
-            // tool could only ever answer []. Stored values are stripped of quotes/newlines
-            // so the assembled JSON stays parseable.
-            let code = "set q=$CHAR(34) set key=\"\" set out=\"[\" set sep=\"\" for  { set key=$order(^SKILLS(key)) quit:key=\"\"  set data=$get(^SKILLS(key)) set out=out_sep_\"{\"_q_\"name\"_q_\":\"_q_$translate(key,q_$CHAR(13,10),\"   \")_q_\",\"_q_\"description\"_q_\":\"_q_$translate($piece(data,\"|\",1),q_$CHAR(13,10),\"   \")_q_\",\"_q_\"usage_count\"_q_\":\"_+$piece(data,\"|\",3)_\"}\" set sep=\",\" } set out=out_\"]\" write out";
-            let raw = xecute(iris, client, code, &ns).await.unwrap_or_default();
-            let skills: serde_json::Value =
-                serde_json::from_str(&raw).unwrap_or(serde_json::json!([]));
-            ok_json(serde_json::json!({"success": true, "skills": skills}))
+            // #119: was a hand-built `$translate` embed that emitted `\q` for a name
+            // containing a backslash — invalid JSON, silently swallowed by unwrap_or([]).
+            let code = skills_list_json_code(None, false);
+            match read_skills_json(iris, &code, &ns).await {
+                Ok(skills) => ok_json(serde_json::json!({
+                    "success": true, "skills": skills,
+                    "namespace": ns, "source": "^SKILLS"
+                })),
+                Err(e) => skills_read_fail("skill(action=list)", &ns, e),
+            }
         }
         "describe" => {
             let name = p.name.as_deref().unwrap_or("");
-            let code = format!("set data=$get(^SKILLS({})) write data", os_str_expr(name));
-            let raw = xecute(iris, client, &code, &ns).await.unwrap_or_default();
-            if raw.is_empty() {
-                return err_json("NOT_FOUND", &format!("Skill '{}' not found", name));
+            let code = skills_describe_json_code(name);
+            match read_skills_json(iris, &code, &ns).await {
+                // #119: `found` is the sentinel — an empty payload used to mean BOTH
+                // "no such skill" and "the read failed". `usage_count` is now a number,
+                // matching what action=list already returned.
+                Ok(v) if v.get("found").and_then(|f| f.as_i64()) == Some(1) => {
+                    ok_json(serde_json::json!({
+                        "success": true,
+                        "name": name,
+                        "description": v.get("description").cloned().unwrap_or(serde_json::json!("")),
+                        "body": v.get("body").cloned().unwrap_or(serde_json::json!("")),
+                        "usage_count": v.get("usage_count").cloned().unwrap_or(serde_json::json!(0)),
+                        "created_at": v.get("created_at").cloned().unwrap_or(serde_json::json!("")),
+                    }))
+                }
+                Ok(_) => err_json("NOT_FOUND", &format!("Skill '{}' not found", name)),
+                Err(e) => skills_read_fail("skill(action=describe)", &ns, e),
             }
-            let parts: Vec<&str> = raw.splitn(4, '|').collect();
-            ok_json(serde_json::json!({
-                "success": true,
-                "name": name,
-                "description": parts.first().unwrap_or(&""),
-                "body": parts.get(1).unwrap_or(&""),
-                "usage_count": parts.get(2).unwrap_or(&"0"),
-                "created_at": parts.get(3).unwrap_or(&""),
-            }))
         }
         "search" => {
             let query = p.query.as_deref().unwrap_or("").to_lowercase();
-            // Bug 9: use separator variable so empty results yield "[]" not "]".
-            let code = format!(
-                "set q=$CHAR(34) set key=\"\" set out=\"[\" set sep=\"\" for {{ set key=$order(^SKILLS(key)) quit:key=\"\"  set data=$get(^SKILLS(key)) if $find($zconvert(key_data,\"L\"),{})>0 {{ set out=out_sep_\"{{\"_q_\"name\"_q_\":\"_q_$translate(key,q_$CHAR(13,10),\"   \")_q_\",\"_q_\"description\"_q_\":\"_q_$translate($piece(data,\"|\",1),q_$CHAR(13,10),\"   \")_q_\"}}\" set sep=\",\" }} }} set out=out_\"]\" write out",
-                os_str_expr(&query)
-            );
-            let raw = xecute(iris, client, &code, &ns).await.unwrap_or_default();
-            let results: serde_json::Value =
-                serde_json::from_str(&raw).unwrap_or(serde_json::json!([]));
-            ok_json(serde_json::json!({"success": true, "query": query, "results": results}))
+            let code = skills_list_json_code(Some(&query), false);
+            match read_skills_json(iris, &code, &ns).await {
+                Ok(results) => ok_json(serde_json::json!({
+                    "success": true, "query": query, "results": results,
+                    "namespace": ns, "source": "^SKILLS"
+                })),
+                Err(e) => skills_read_fail("skill(action=search)", &ns, e),
+            }
         }
         "forget" => {
             let name = p.name.as_deref().unwrap_or("");
@@ -433,5 +649,334 @@ mod objectscript_escaping_tests {
             1,
             "generated code stays on one line: {code}"
         );
+    }
+
+    // ── #119: ^SKILLS -> JSON assembly ───────────────────────────────────────
+
+    /// The bug: the value went in, the subscript (the skill NAME) never did.
+    #[test]
+    fn list_code_emits_the_subscript_as_name() {
+        let code = skills_list_json_code(None, false);
+        assert!(code.contains(r#""name":(key)"#), "{code}");
+        assert!(code.contains("$order(^SKILLS(key))"), "{code}");
+        assert!(
+            code.contains(r#""created_at":($piece(data,"|",4))"#),
+            "{code}"
+        );
+    }
+
+    /// The raw value must never be concatenated into the array literal again.
+    #[test]
+    fn list_code_never_concatenates_the_raw_value() {
+        let code = skills_list_json_code(None, false);
+        assert!(!code.contains("_sep_skill"), "{code}");
+        assert!(!code.contains("result_sep"), "{code}");
+        assert!(code.contains("%Push"), "{code}");
+        assert!(code.contains("%ToJSON"), "{code}");
+    }
+
+    /// `do arr.%ToJSON(st)` streams into a temp stream; `write arr.%ToJSON()` (or
+    /// `set j=arr.%ToJSON()`) materialises the whole document as one string and can hit
+    /// <MAXSTRING> on a large registry.
+    #[test]
+    fn list_code_streams_rather_than_materialising() {
+        let code = skills_list_json_code(None, false);
+        assert!(code.contains("do arr.%ToJSON(st)"), "{code}");
+        assert!(code.contains("%Stream.TmpCharacter"), "{code}");
+        assert!(!code.contains("write arr.%ToJSON"), "{code}");
+        assert!(!code.contains("=arr.%ToJSON"), "{code}");
+    }
+
+    /// #67: the search needle is embedded from Rust, so it goes through os_str_expr.
+    #[test]
+    fn search_needle_is_quote_doubled_never_backslashed() {
+        let code = skills_list_json_code(Some(r#"say "hi""#), false);
+        assert!(code.contains(r#""say ""hi""""#), "{code}");
+        assert!(
+            !code.contains(r#"\""#),
+            "no C-style escaping may survive: {code}"
+        );
+    }
+
+    /// A literal cannot span a source line, and build_exec_class splits on '\n'.
+    #[test]
+    fn search_needle_with_a_newline_is_char_spliced_and_stays_one_line() {
+        let code = skills_list_json_code(Some("a\nb"), false);
+        assert!(code.contains("$CHAR(10)"), "{code}");
+        assert!(!code.contains(r#"\n"#), "{code}");
+        assert_eq!(code.lines().count(), 1, "{code}");
+    }
+
+    /// An empty needle must not emit a filter at all: `$find(x,"")` is 1, so a `continue:`
+    /// clause would be dead code, and `None`/`Some("")` must not diverge.
+    #[test]
+    fn an_empty_filter_is_the_same_as_no_filter() {
+        let none = skills_list_json_code(None, false);
+        let empty = skills_list_json_code(Some(""), false);
+        assert_eq!(none, empty);
+        assert!(!none.contains("continue:"), "{none}");
+        assert!(skills_list_json_code(Some("x"), false).contains("continue:'$find("));
+    }
+
+    /// list/search must not ship every skill body; describe must.
+    #[test]
+    fn body_is_opt_in() {
+        assert!(!skills_list_json_code(None, false).contains(r#""body""#));
+        assert!(skills_list_json_code(None, true).contains(r#""body":($piece(data,"|",2))"#));
+        assert!(skills_describe_json_code("x").contains(r#""body":($piece(data,"|",2))"#));
+    }
+
+    /// A skill name is user data and can hold a quote.
+    #[test]
+    fn describe_code_escapes_the_name_and_carries_the_found_sentinel() {
+        let code = skills_describe_json_code(r#"quo"te"#);
+        assert!(code.contains(r#""quo""te""#), "{code}");
+        assert!(!code.contains(r#"\""#), "{code}");
+        assert!(code.contains(r#"{"found":0}"#), "{code}");
+        assert!(code.contains(r#""found":1"#), "{code}");
+        assert!(code.contains("$data(^SKILLS(skname))=0"), "{code}");
+        assert_eq!(code.lines().count(), 1, "{code}");
+    }
+
+    /// The payload must be fenced onto its own line: the docker-exec transport
+    /// interleaves `USER>` prompts and strip_iris_banner only drops BARE prompt lines.
+    #[test]
+    fn every_builder_fences_its_payload_with_newlines() {
+        for code in [
+            skills_list_json_code(None, false),
+            skills_list_json_code(Some("q"), true),
+            skills_describe_json_code("n"),
+        ] {
+            assert!(code.contains("do st.Rewind() write ! while "), "{code}");
+            assert!(code.trim_end().ends_with("write !"), "{code}");
+            assert_eq!(
+                code.lines().count(),
+                1,
+                "generated code stays one line: {code}"
+            );
+        }
+    }
+
+    // ── #119 follow-up: non-ASCII must survive an 8-bit transport ─────────────
+    //
+    // Live repro this pins (IRIS 2026.2, ^SKILLS("unicode-café-中") seeded over the HTTP
+    // path, read back over docker exec): skill_list answered
+    //     {"name":"unicode-caf\u{fffd}-?","description":"caf\u{fffd} \u{fffd} ?? description"}
+    // with isError:false / success:true, and skill_describe answered NOT_FOUND — byte for
+    // byte the same envelope as a skill that really does not exist.
+
+    /// RECEIVE: the payload must leave IRIS as pure ASCII, because the docker-exec
+    /// terminal device replaces a CJK character with `?` and emits `é` as one byte.
+    #[test]
+    fn every_builder_emits_a_pure_ascii_payload() {
+        for code in [
+            skills_list_json_code(None, false),
+            skills_list_json_code(Some("café"), true),
+            skills_describe_json_code("unicode-café-中"),
+        ] {
+            assert!(
+                code.is_ascii(),
+                "generated source must be pure ASCII: {code}"
+            );
+            // every char above 0x7E is re-emitted as \uXXXX before it reaches the device
+            assert!(code.contains(r#"$select(c<128:$char(c),1:"\u""#), "{code}");
+            assert!(code.contains("$extract(\"000\"_$zhex(c),*-3,*)"), "{code}");
+        }
+    }
+
+    /// SEND: the needle and the skill name are embedded from Rust, so a raw non-ASCII
+    /// literal would be re-decoded 8-bit by `iris session` and stop matching the data.
+    /// This is what made skill_describe answer a FALSE NOT_FOUND.
+    #[test]
+    fn a_non_ascii_needle_and_name_are_char_spliced() {
+        let code = skills_list_json_code(Some("café"), false);
+        assert!(code.contains("$CHAR(233)"), "{code}");
+        assert!(
+            !code.contains("café"),
+            "no raw non-ASCII may survive: {code}"
+        );
+
+        let code = skills_describe_json_code("unicode-café-中");
+        assert!(
+            code.contains(r#"set skname="unicode-caf"_$CHAR(233)"#),
+            "{code}"
+        );
+        assert!(code.contains("$CHAR(20013)"), "{code}");
+        assert_eq!(code.lines().count(), 1, "{code}");
+    }
+
+    /// The escaping contract itself, checked against what live IRIS actually emitted for
+    /// the `os_json_ascii_emit` loop — `serde_json` must decode it back to the ORIGINAL
+    /// characters, including an astral character carried as a UTF-16 surrogate pair.
+    #[test]
+    fn ascii_escaped_payloads_decode_back_to_the_original_characters() {
+        // Captured verbatim from IRIS 2026.2 running the emit loop over
+        // {"name":"unicode-"_$char(233)_"-"_$char(20013),"desc":"caf"_$char(233)_" plain"}
+        let live = r#"{"name":"unicode-\u00E9-\u4E2D","desc":"caf\u00E9 plain"}"#;
+        assert!(live.is_ascii(), "the wire payload must be 7-bit");
+        let v: serde_json::Value = serde_json::from_str(live).expect("must parse");
+        assert_eq!(v["name"], "unicode-é-中");
+        assert_eq!(v["desc"], "café plain");
+
+        // Astral: IRIS holds 😀 as the surrogate pair 55357/56832 and escapes each half.
+        // Captured verbatim for {"emoji":$char(55357)_$char(56832)}.
+        let live = r#"{"emoji":"\uD83D\uDE00"}"#;
+        let v: serde_json::Value = serde_json::from_str(live).expect("must parse");
+        assert_eq!(v["emoji"], "😀");
+
+        // And the shape the bug produced must NOT be mistaken for the fixed one.
+        let corrupted = "{\"name\":\"unicode-\u{fffd}-?\"}";
+        let v: serde_json::Value = serde_json::from_str(corrupted).unwrap();
+        assert_ne!(v["name"], "unicode-é-中");
+    }
+
+    /// Pins the exact bytes the transport can wrap the payload in.
+    #[test]
+    fn extract_json_line_survives_an_interleaved_prompt() {
+        assert_eq!(
+            extract_json_line("USER>\n[{\"a\":1}]\nUSER>"),
+            r#"[{"a":1}]"#
+        );
+        assert_eq!(extract_json_line("\n\n{\"found\":0}\n\n"), r#"{"found":0}"#);
+        assert_eq!(extract_json_line(""), "");
+        assert_eq!(extract_json_line("DOCKER_REQUIRED"), "");
+    }
+
+    /// The parse contract: upstream's repro plus the two shapes captured VERBATIM from
+    /// live IRIS 2026.2. This is the test that would have caught #119 with no IRIS at all.
+    #[test]
+    fn the_old_shapes_do_not_parse_and_the_new_one_does() {
+        // 1. mod.rs skill_list — raw pipe-delimited values concatenated into an array literal.
+        let old_modrs = "[desc|body|0|2026-01-01T00:00:00Z,a|b|c|d|e]";
+        assert!(serde_json::from_str::<serde_json::Value>(old_modrs).is_err());
+
+        // 2. handle_skill "list" — $translate neutralises quote/CR/LF but NOT backslash.
+        let old_translate = r#"[{"name":"a\qb","description":"desc\r","usage_count":0}]"#;
+        assert!(
+            serde_json::from_str::<serde_json::Value>(old_translate).is_err(),
+            "`\\q` is not a valid JSON escape — this is why a backslash in a name silently \
+             produced an empty list"
+        );
+
+        // 3. What %ToJSON actually emitted for the same data on live IRIS.
+        let fixed = r#"[{"name":"quo\"te","description":"desc with \" quote","usage_count":1,"created_at":"2026-01-01T00:00:00Z"},{"name":"a\\qb","description":"desc\\r","usage_count":0,"created_at":""}]"#;
+        let v: Vec<serde_json::Value> = serde_json::from_str(fixed).expect("must parse");
+        assert_eq!(v[0]["name"], r#"quo"te"#);
+        assert_eq!(v[0]["usage_count"], 1);
+        assert_eq!(v[1]["name"], r"a\qb");
+
+        // 4. CRLF is escaped, so the payload is still ONE line — this is what keeps
+        //    strip_iris_banner from re-joining a raw newline INSIDE a JSON string.
+        let crlf =
+            r#"[{"name":"nl","description":"desc\r\nline2","usage_count":0,"created_at":""}]"#;
+        assert_eq!(crlf.lines().count(), 1);
+        let v: Vec<serde_json::Value> = serde_json::from_str(crlf).expect("must parse");
+        assert_eq!(v[0]["description"], "desc\r\nline2");
+
+        // 5. Empty registry is `[]`, not `]`. (Regression guard shared with
+        //    tests/unit/test_tools_fixes.rs::test_skill_list_empty_global_json.)
+        assert!(serde_json::from_str::<serde_json::Value>("[]")
+            .unwrap()
+            .as_array()
+            .unwrap()
+            .is_empty());
+    }
+
+    /// A pipe in a description is truncated by $piece — that is the ^SKILLS storage
+    /// format, NOT a JSON bug. Pin it so nobody "fixes" it inside the JSON builder.
+    #[test]
+    fn a_pipe_in_a_description_truncates_but_still_yields_valid_json() {
+        // Live IRIS, value `a|b|c|d|e`:
+        let observed = r#"[{"name":"pipe","description":"a","usage_count":0,"created_at":"d"}]"#;
+        let v: Vec<serde_json::Value> = serde_json::from_str(observed).expect("valid JSON");
+        assert_eq!(v[0]["description"], "a", "pipe is the storage delimiter");
+    }
+
+    /// #119 criterion 3: three states that used to collapse into one empty list.
+    #[test]
+    fn unreachable_and_unparseable_are_different_error_codes() {
+        fn payload(r: &rmcp::model::CallToolResult) -> serde_json::Value {
+            let text = match &r.content[0].raw {
+                rmcp::model::RawContent::Text(t) => &t.text,
+                _ => panic!("expected text content"),
+            };
+            serde_json::from_str(text).unwrap()
+        }
+
+        let r = skills_read_fail(
+            "skill_list",
+            "USER",
+            SkillsReadError::Unreachable("DOCKER_REQUIRED".into()),
+        )
+        .unwrap();
+        assert_eq!(r.is_error, Some(true));
+        let v = payload(&r);
+        assert_eq!(v["error_code"], "DOCKER_REQUIRED");
+
+        let r = skills_read_fail(
+            "skill_list",
+            "USER",
+            SkillsReadError::Unparseable {
+                raw: "<SYNTAX>zRun+3^Foo".into(),
+                parse_error: "expected value at line 1 column 1".into(),
+            },
+        )
+        .unwrap();
+        assert_eq!(r.is_error, Some(true));
+        let v = payload(&r);
+        assert_eq!(v["error_code"], "SKILLS_PARSE_FAILED");
+        assert_eq!(v["raw_excerpt"], "<SYNTAX>zRun+3^Foo");
+        assert!(
+            v["error"]
+                .as_str()
+                .unwrap()
+                .contains("NOT an empty registry"),
+            "the message must say IRIS WAS reached: {v}"
+        );
+    }
+    /// #119 follow-up: an empty payload is an UNREACHABLE transport, not malformed JSON.
+    /// `IrisConnection::execute` drops the exit status, so a failed `docker exec` arrives
+    /// as `Ok("")`; classifying that as a parse failure made the tool state "IRIS WAS
+    /// reachable" about a container that does not exist.
+    #[test]
+    fn an_empty_payload_is_unreachable_not_unparseable() {
+        for raw in ["", "   ", "\n", "\r\n  \n"] {
+            match classify_skills_payload(raw) {
+                Err(SkillsReadError::Unreachable(msg)) => {
+                    assert!(msg.contains("no output"), "{msg}")
+                }
+                other => panic!("empty payload must be Unreachable, got {other:?}"),
+            }
+        }
+        // Output that is present but not JSON is still a genuine parse failure.
+        match classify_skills_payload("<SYNTAX>zRun+3^Foo") {
+            Err(SkillsReadError::Unparseable { .. }) => {}
+            other => panic!("non-empty garbage must stay Unparseable, got {other:?}"),
+        }
+        // A reachable but empty registry writes `[]` — that is success, not an error.
+        assert_eq!(
+            classify_skills_payload("[]").unwrap(),
+            serde_json::json!([])
+        );
+    }
+
+    /// #119 follow-up: the search haystack was `key_"|"_data`, and `data` is the
+    /// pipe-delimited record — so every entry contained a `|` and a search for "|"
+    /// returned the entire registry.
+    #[test]
+    fn the_search_haystack_is_the_fields_not_the_delimited_record() {
+        let code = skills_list_json_code(Some("|"), false);
+        assert!(
+            !code.contains(r#"key_"|"_data"#),
+            "the delimiter must not be spliced into the haystack: {code}"
+        );
+        assert!(
+            code.contains(r#"$piece(data,"|",1)_" "_$piece(data,"|",2)"#),
+            "name + description + body is the haystack: {code}"
+        );
+        // The needle itself still goes through os_str_expr (#67).
+        assert!(code.contains(r#"$find($zconvert("#), "{code}");
+        // No filter at all when no needle was given.
+        assert!(!skills_list_json_code(None, false).contains("continue:"));
     }
 }

--- a/crates/iris-agentic-dev-core/tests/integration/test_e2e_all_tools.rs
+++ b/crates/iris-agentic-dev-core/tests/integration/test_e2e_all_tools.rs
@@ -1,4 +1,4 @@
-//! T079: E2E test — all 20 tools respond without INTERNAL_ERROR.
+//! T079: E2E test — all 23 tools respond without INTERNAL_ERROR.
 //! T080: Steve's web prefix scenario.
 //! Run: IRIS_HOST=localhost IRIS_WEB_PORT=52780 IRIS_USERNAME=SuperUser IRIS_PASSWORD=SYS cargo test --test test_e2e_all_tools
 #![allow(dead_code, clippy::zombie_processes)]

--- a/crates/iris-agentic-dev-core/tests/interop_e2e_tests.rs
+++ b/crates/iris-agentic-dev-core/tests/interop_e2e_tests.rs
@@ -101,11 +101,11 @@ fn tools_list_returns_interop_profile() {
         .expect("no tools array");
     let names: Vec<_> = tools.iter().filter_map(|t| t["name"].as_str()).collect();
 
-    // Interop profile (fork default): 20 tools; 2 (iris_production_item, iris_credential_manage)
-    // may be write-gated off on a read-only connection, so accept 18-20.
+    // Interop profile (fork default): 23 tools; 2 (iris_production_item, iris_credential_manage)
+    // may be write-gated off on a read-only connection, so accept 21-23.
     assert!(
-        (18..=20).contains(&names.len()),
-        "expected the interop profile (18-20 tools), got {}: {:?}",
+        (21..=23).contains(&names.len()),
+        "expected the interop profile (21-23 tools), got {}: {:?}",
         names.len(),
         names
     );

--- a/crates/iris-agentic-dev-core/tests/mcp_handshake.rs
+++ b/crates/iris-agentic-dev-core/tests/mcp_handshake.rs
@@ -144,8 +144,8 @@ fn mcp_server_tools_list_returns_interop_profile() {
 
     let tool_names: Vec<_> = tools.iter().filter_map(|t| t["name"].as_str()).collect();
 
-    // Interop profile (this fork's default toolset) exposes exactly the interop
-    // keep-list: 20 tools, plus the 3 added by the 056 interop-depth port.
+    // Interop profile (this fork's default toolset) exposes exactly the 23-tool
+    // interop keep-list (INTEROP_TOOLS).
     assert_eq!(
         tool_names.len(),
         23,

--- a/crates/iris-agentic-dev-core/tests/unit/test_toolset.rs
+++ b/crates/iris-agentic-dev-core/tests/unit/test_toolset.rs
@@ -213,14 +213,16 @@ fn test_merged_excludes_original_interop_production_tools() {
     }
 }
 
-/// Merged must have exactly 33 tools (added iris_table_info in feat-038-040).
+/// Merged must advertise exactly 46 tools (measured 2026-08-26; 50 - 8 + 4).
+/// Renamed: the old `test_merged_tool_count_is_23` contradicted its own assertion (33),
+/// and both numbers came from a hardcoded list that had drifted away from the router.
 #[test]
-fn test_merged_tool_count_is_23() {
+fn test_merged_tool_count() {
     let tools = IrisTools::new_with_toolset(None, Toolset::Merged).expect("IrisTools::new");
     let count = tools.registered_tool_names().len();
     assert_eq!(
-        count, 33,
-        "Merged toolset must have exactly 33 tools, got {}",
+        count, 46,
+        "Merged toolset must advertise exactly 46 tools, got {}",
         count
     );
     // iris_get_log must be registered in Merged (027-progressive-disclosure)
@@ -330,4 +332,118 @@ fn test_interop_excludes_meta_tools() {
             excluded
         );
     }
+}
+
+// ── Anti-drift: the counts the Toolset doc comments claim ────────────────────
+//
+// Until 2026-08-26 `registered_tool_names()` built the non-Interop tiers from a hardcoded
+// list last audited against v0.4.x. It had drifted 17 tools short and carried one phantom
+// (`iris_admin`, which the router removes for baseline/nostub), and NOTHING caught it:
+// the tests that guarded it compared the hardcoded list against itself, so they were
+// tautological. These tests pin the real, router-derived numbers.
+
+/// Baseline advertises 54 — the 58 the `#[tool_router]` macro registers minus the 4
+/// merged-only ones.
+#[test]
+fn test_baseline_tool_count() {
+    let n = IrisTools::new_with_toolset(None, Toolset::Baseline)
+        .expect("IrisTools::new")
+        .registered_tool_names()
+        .len();
+    assert_eq!(
+        n, 54,
+        "Baseline must advertise exactly 54 tools (Toolset::Baseline doc comment says 54), got {}",
+        n
+    );
+}
+
+/// `test_nostub_tool_count` only asserts baseline-minus-4, so it stayed green through the
+/// whole drift. Pin the absolute number too.
+#[test]
+fn test_nostub_tool_count_absolute() {
+    let n = IrisTools::new_with_toolset(None, Toolset::Nostub)
+        .expect("IrisTools::new")
+        .registered_tool_names()
+        .len();
+    assert_eq!(n, 50, "Nostub must advertise exactly 50 tools, got {}", n);
+}
+
+/// The single regression gate for the four doc-comment numbers. A failure here means the
+/// tool surface moved: update `Toolset`'s doc comments in src/tools/mod.rs, or explain
+/// the change.
+#[test]
+fn test_toolset_counts_match_doc_comments() {
+    for (ts, expected) in [
+        (Toolset::Baseline, 54usize),
+        (Toolset::Nostub, 50),
+        (Toolset::Merged, 46),
+        (Toolset::Interop, 23),
+    ] {
+        let n = IrisTools::new_with_toolset(None, ts)
+            .expect("IrisTools::new")
+            .registered_tool_names()
+            .len();
+        assert_eq!(
+            n, expected,
+            "Toolset::{:?} advertises {} tools but src/tools/mod.rs documents {} — update \
+             the doc comment or explain the change",
+            ts, n, expected
+        );
+    }
+    // Two independent anchors for the interop number: the keep-list and the router.
+    assert_eq!(
+        iris_agentic_dev_core::tools::INTEROP_TOOLS.len(),
+        23,
+        "INTEROP_TOOLS is the interop profile — it must agree with the measured count"
+    );
+}
+
+/// The merged-only tools must not leak into baseline/nostub. `iris_admin` is the one the
+/// stale hardcoded list got wrong: it claimed baseline advertised a tool the router
+/// explicitly removes. `test_iris_get_log_absent_from_baseline_and_nostub` covers one of
+/// the four; this generalises it.
+#[test]
+fn test_baseline_excludes_merged_only_tools() {
+    let baseline = IrisTools::new_with_toolset(None, Toolset::Baseline)
+        .expect("IrisTools::new")
+        .registered_tool_names();
+    let nostub = IrisTools::new_with_toolset(None, Toolset::Nostub)
+        .expect("IrisTools::new")
+        .registered_tool_names();
+    for t in [
+        "iris_debug",
+        "iris_containers",
+        "iris_admin",
+        "iris_get_log",
+    ] {
+        assert!(
+            !baseline.contains(t),
+            "{t} is merged-only and must NOT be in Baseline"
+        );
+        assert!(
+            !nostub.contains(t),
+            "{t} is merged-only and must NOT be in Nostub"
+        );
+    }
+}
+
+/// `IrisTools::new()` stamps `Toolset::Baseline`, so its router must be the pruned
+/// baseline router — it used to assign the raw 58-tool one.
+#[test]
+fn test_new_uses_pruned_baseline_router() {
+    let via_new = IrisTools::new(None)
+        .expect("IrisTools::new")
+        .registered_tool_names();
+    let via_toolset = IrisTools::new_with_toolset(None, Toolset::Baseline)
+        .expect("IrisTools::new")
+        .registered_tool_names();
+    assert_eq!(
+        via_new.len(),
+        54,
+        "new() claims Toolset::Baseline, so it must advertise the baseline surface"
+    );
+    assert_eq!(
+        via_new, via_toolset,
+        "new() and new_with_toolset(_, Baseline) must register the same tools"
+    );
 }

--- a/tools-status.json
+++ b/tools-status.json
@@ -1,6 +1,6 @@
 {
-  "_comment": "Per-tool validation gate for the iris-interop-dev (interop-profile) fork. A tool is 'OK' only when its named unit AND e2e tests exist and pass. scripts/validate-tools.sh checks this. Statuses: OK = unit+e2e green; unit-ok = unit green, e2e pending (needs interop-enabled namespace); profile-only = present in the 20-tool interop profile (verified by mcp_handshake) but no dedicated behaviour test yet. Both execution transports (HTTP/Atelier REST and Docker-exec) are validated by transport_e2e.",
-  "profile": "interop (20 tools, default)",
+  "_comment": "Per-tool validation gate for the iris-interop-dev (interop-profile) fork. A tool is 'OK' only when its named unit AND e2e tests exist and pass. scripts/validate-tools.sh checks this. Statuses: OK = unit+e2e green; unit-ok = unit green, e2e pending (needs interop-enabled namespace); profile-only = present in the 23-tool interop profile (verified by mcp_handshake) but no dedicated behaviour test yet. Both execution transports (HTTP/Atelier REST and Docker-exec) are validated by transport_e2e.",
+  "profile": "interop (23 tools, default)",
   "transports": {
     "http_atelier_rest": {
       "test": "transport_e2e::http_transport_executes_and_captures_output",
@@ -18,7 +18,7 @@
   "profile_surface": {
     "test": "mcp_handshake::mcp_server_tools_list_returns_interop_profile",
     "status": "OK",
-    "note": "asserts exactly the 20 interop tools, meta tools pruned"
+    "note": "asserts exactly the 23 interop tools, meta tools pruned"
   },
   "tools": [
     {
@@ -101,9 +101,9 @@
     },
     {
       "tool": "iris_get_log",
-      "unit": null,
+      "unit": "tools::get_log_params_tests (12) + schema_normalization_tests (2)",
       "e2e": null,
-      "status": "profile-only"
+      "status": "unit-ok"
     },
     {
       "tool": "iris_debug",
@@ -137,6 +137,24 @@
     },
     {
       "tool": "find_subclass_implementations",
+      "unit": null,
+      "e2e": null,
+      "status": "profile-only"
+    },
+    {
+      "tool": "iris_message_body",
+      "unit": "interop_unit_tests::message_body_is_blocked_under_the_default_policy + redact_hl7v2_* (3)",
+      "e2e": null,
+      "status": "unit-ok"
+    },
+    {
+      "tool": "iris_business_rule_info",
+      "unit": "interop_unit_tests::business_rule_info_rejects_an_unknown_action + business_rule_get_requires_a_rule_name",
+      "e2e": null,
+      "status": "unit-ok"
+    },
+    {
+      "tool": "iris_production_diff",
       "unit": null,
       "e2e": null,
       "status": "profile-only"


### PR DESCRIPTION
Three items, each reproduced on the installed build first and re-verified live against the dev IRIS (webgateway `localhost:43080`, namespace `APP`).

## #78 — `iris_get_log(log_id)` returned the index instead of the entry

`GetLogParams` accepted only `id`; serde dropped every other key, so the call landed in the `p.id.is_none()` arm — the *listing* form. Self-inflicted: the description opens *"retrieve a stored result by log_id"* and every truncating tool emits a `log_id` field, so an agent round-tripping our own name got `{"logs":[],"success":true}` and read it as "there is no relevant log".

| call | before | after |
|---|---|---|
| `{"log_id":"1"}` | `{"logs":[],"success":true}` | `LOG_NOT_FOUND`, `isError:true` |
| `{"logid":"1"}` | `{"logs":[],"success":true}` | `INVALID_PARAMS` naming `'logid'`, `did_you_mean:["id"]` |
| `{"namespace":"APP"}` | `{"logs":[]}` | index **+ a note** |
| `{"id":"1"}` | `LOG_NOT_FOUND` | unchanged |

- `#[serde(alias = "log_id")]` on `id`.
- `#[serde(flatten)]` leftover capture so a mistyped addressing key is **named** rather than dropped. `namespace` and `_`-prefixed keys stay ignorable — `namespace` is advertised by 11 of the 23 interop tools and rides along on nearly every call, **including the correct call in the issue's own repro**, and cannot mean anything to a process-global store. A blanket `deny_unknown_fields` would have traded a silent wrong answer for a wave of hard errors on calls that are correct today.
- The empty index now says what the store is and is **not**, pointing at `iris_interop_query` `what='logs'` / `what='trace'`.
- Handler moved to a free fn over the store — all 12 new tests are plain sync `#[test]`, no connection, no runtime.
- `drop_default_additional_properties` keeps the advertised `inputSchema` byte-identical despite the flattened map.

## Upstream #119 — `^SKILLS` entries were invisible to every reader

`skill_list` / `skill_describe` / `skill_search` concatenated the **raw** pipe-delimited `^SKILLS` value straight into a JSON array literal with no quoting, and never emitted the subscript at all — so `from_str` failed on any non-empty registry and the `Err` branch returned an empty list, indistinguishable from "IRIS unreachable".

- Shared builders in `skills_tools.rs` using `%DynamicArray`/`%ToJSON` so **IRIS** does the escaping; the three legacy tools and the merged `skill` dispatcher now share one read path. Needle goes through `os_str_expr` (#67).
- Three states are now distinct: `DOCKER_REQUIRED`, `SKILLS_PARSE_FAILED` (reached but unparseable, carries `raw_excerpt`), and `[]` with `success:true` (genuinely empty).
- **An empty payload is `Unreachable`, not `Unparseable`.** `IrisConnection::execute` discards the child's exit status, so a failed `docker exec` arrives as `Ok("")`; classifying that as a parse failure made the tool assert *"IRIS WAS reachable"* about a container that does not exist. Confirmed with `IRIS_CONTAINER=no-such-container-xyz`.
- The search haystack is name + description + body, **not** `key_"|"_data` — the delimiter was in every haystack, so a search for `|` returned the entire registry (7 of 7 → now 0 of 2).
- `os_str_expr` now splices **all** non-ASCII via `$CHAR`, not just control characters: `docker exec -i … iris session` decodes stdin 8-bit, so the two UTF-8 bytes of `ñ` arrived as two characters and a needle silently stopped matching. Astral code points become UTF-16 surrogate pairs — `$char(128512)` returns `""` on this instance, so splicing the raw code point would drop the character.

Note for reviewers: `skill_*` is pruned from the default **interop** profile, so this is only reachable under `IRIS_TOOLSET=baseline|nostub|merged`. Verifying against the default and concluding the tools are gone would be a false alarm.

## toolset — stale doc comments, and a real bug behind them

`registered_tool_names()` built every non-Interop tier from a hardcoded list last audited against **v0.4.x**: 17 tools short, plus a phantom (`iris_admin`, which the router removes for baseline/nostub) — and the tests guarding it compared the list against itself. Replaced with a router derivation for all toolsets, which also fixes the write-gate asymmetry. `IrisTools::new()` now delegates to `with_registry_and_toolset` so its router is pruned rather than the raw one.

Doc comments and clap `--help` corrected to the **measured** counts — baseline 54, nostub 50, merged 46, interop 23. CI now runs `--test test_toolset`, which is where the anti-drift gate lives (it was in a target no gate command ran). `tools-status.json` listed 20 tools under a 23-tool header; the three interop-depth tools were missing.

## Verification

- `cargo fmt --check`, `cargo clippy --all-targets -D warnings`, and the full CI test list: **441 passed, 0 failed**.
- Every behaviour above driven over stdio against the rebuilt `target/debug/iris-interop-dev`.
- Interop profile unchanged at exactly 23 tools; none of these fixes alters the default surface.
- `^SKILLS` scratch entries killed afterwards (`$data(^SKILLS)=0`); the dev instance is as it was found.

Fixes #78. Ports intersystems-community/iris-agentic-dev#119.

🤖 Generated with [Claude Code](https://claude.com/claude-code)