### PR TITLE
chore(release): 0.8.4

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -945,7 +945,7 @@ dependencies = [
 
 [[package]]
 name = "iris-agentic-dev"
-version = "0.8.3"
+version = "0.8.4"
 dependencies = [
  "anyhow",
  "chrono",
@@ -963,7 +963,7 @@ dependencies = [
 
 [[package]]
 name = "iris-agentic-dev-core"
-version = "0.8.3"
+version = "0.8.4"
 dependencies = [
  "anyhow",
  "bollard",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "0.8.3"
+version = "0.8.4"
 edition = "2021"
 authors = ["Thomas Dyar <thomas.dyar@intersystems.com>"]
 license = "MIT"


### PR DESCRIPTION
Version bump for the #80-#88 sweep merged in #96 (and #78/#119/toolset in #79).

Highlights since 0.8.3:
- `iris_get_log`: `log_id` is a declared schema property, no addressing mistake escapes as a raw `-32602`, the index paginates, and the unknown-parameter guard runs unconditionally.
- `iris_compile`: wildcard expansion works against object-shaped `/docnames` — and is guarded, since making it work made a bare `*` a 10,094-class request. `SCOPE_REQUIRED` / `TOO_BROAD` / `LISTING_UNAVAILABLE`.
- Compile console parsing no longer collapses per-method errors (1 -> 48 on a 12-broken-method class).
- `skill_*` reads the connection namespace instead of defaulting to `USER`.
- Plugin subcommand dispatch executes for the first time.
- CI: GITHUB_TOKEN support, offline wiremock coverage, `--no-fail-fast`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)