### PR TITLE
fix: compile namespace + listing filter (#93 #94), agent_info honesty (#89), and a gate that runs everything (#90-#92, #95)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,47 +21,108 @@ jobs:
       - uses: Swatinem/rust-cache@v2
       - run: cargo fmt --all -- --check
       - run: cargo clippy --all-targets -- -D warnings
-      # Build binary first (required for mcp_handshake test which spawns it)
+      # Build the binary first — mcp_handshake, plugin_dispatch_tests and test_compile_cmd
+      # all spawn it, and cargo test does not build another package's bin for them.
       - run: cargo build -p iris-agentic-dev
-      # Unit + handshake tests — no live IRIS needed.
-      # Integration tests (test_mcp_iris, test_e2e_all_tools, test_scm, discovery_tests,
-      # interop_e2e_tests) require IRIS_HOST/IRIS_WEB_PORT; run them locally.
-      # KNOWN FLAKES — if this gate goes red, check these before calling it a regression:
-      #   * mcp_server_startup_latency_under_100ms — load sensitive; re-run it alone.
-      #   * manifest_tests::test_resolve_github_* — live GitHub API. Unauthenticated GitHub
-      #     allows 60 requests/hour PER IP, shared by every job on the runner, and reports
-      #     exhaustion as HTTP 403 — which reads like a permissions bug, not a flake (#87).
-      #     Those four tests no longer run here: they are opt-in behind IRIS_DEV_LIVE_GITHUB
-      #     and covered offline by the *_offline wiremock tests in the same target. The live
-      #     canary runs in the advisory step below.
-      # --no-fail-fast: without it a failure in an earlier --test target means the later ones
-      # never execute and print nothing, which reads as "passed" (#87). Cargo still exits
-      # non-zero if any target failed.
-      - name: Unit + handshake gate (offline, required)
+      # THE RULE (#95): this gate runs EVERY test target the workspace declares or
+      # auto-discovers, minus an explicit opt-out list. New test targets are covered
+      # automatically — there is no list here to forget to update.
+      #
+      # The opt-out list lives in scripts/ci-test-targets.sh, one entry with one reason.
+      # Today it holds exactly one target (docker_discovery_e2e). That script derives the
+      # target list from `cargo metadata`, so auto-discovered targets like transport_e2e
+      # — which appears in no [[test]] block — are included too.
+      #
+      # ADDING A TEST TARGET THAT NEEDS A LIVE IRIS? It is CI-blocking by default now.
+      # Mark the individual tests `#[ignore = "requires live IRIS"]`, or, if the whole
+      # target is unrunnable here, add it to EXCLUDED in that script with a reason.
+      #
+      # PREFER #[ignore] TO A SELF-SKIP. Two styles are in the tree and they are NOT
+      # equivalent in what this gate reports:
+      #   - `#[ignore]` (admin_e2e_tests, interop_e2e_tests, progressive_disclosure_integration,
+      #     test_iris_test_e2e, test_live_reload_e2e, test_sql_safety_e2e, test_sql_translate_e2e)
+      #     reports 46 results as `ignored` — visibly not run.
+      #   - a `require_iris!`/IRIS_HOST check that prints a note and returns (test_e2e,
+      #     test_scm, test_mcp_iris, test_e2e_all_tools, test_compile_cmd) reports as
+      #     PASSED. About 137 of this gate's passes are green-but-vacuous for that reason.
+      # The pass count therefore overstates what ran, which is the same dishonesty #87(b)
+      # fixed for fail-fast. New live-IRIS tests should use #[ignore] so the count stays
+      # truthful; the master-only e2e-tests job is what actually exercises them.
+      #
+      # Before this change the gate ran 11 hand-listed targets. Three targets that were in
+      # no gate at all were found red or intermittently red (#90 test_search_unit,
+      # #91 admin_unit_tests, test_workspace_config) — nobody saw them because nobody ran
+      # them. The marginal cost of the other 32 targets is ~10s: clippy --all-targets
+      # already pays the compile.
+      #
+      # --lib --bins: --bins is not redundant. crates/iris-agentic-dev-bin/src/cmd/plugin.rs
+      # holds unit tests that no job had ever run.
+      #
+      # --no-fail-fast: without it a failure in an earlier --test target means the later
+      # ones never execute and print nothing, which reads as "passed" (#87). Cargo still
+      # exits non-zero if any target failed.
+      #
+      # KNOWN LOAD-SENSITIVE ASSERTIONS — wall-clock budgets, not logic. If one of these
+      # is the only red, RE-RUN IT ALONE before calling it a regression:
+      #   * mcp_handshake::mcp_server_startup_latency_under_100ms  (p50 < 100ms)
+      #   * symbols_local_tests::sc003_parse_500_lines_under_100ms (tree-sitter budget)
+      #   * discovery_tests::probe_atelier_respects_timeout        (< 500ms vs 10.255.255.1)
+      #
+      # NOT a flake source any more: manifest_tests and skills_tests used to reach GitHub
+      # unauthenticated (60 req/hr per IP, shared by every job on a runner, reported as a
+      # 403 that reads like a permissions bug). Both are now covered offline by wiremock
+      # (#87, #92); their live canaries are opt-in behind IRIS_DEV_LIVE_GITHUB and run in
+      # the advisory step below. This gate makes no outbound request.
+      #
+      # Running it locally: use `env -u IRIS_HOST -u IRIS_CONTAINER cargo test ...`. Do NOT
+      # use `IRIS_HOST= ` — src/iris/discovery.rs:149 treats a set-but-empty host as real
+      # and spends 5s probing it. With IRIS_HOST exported, test_e2e and test_scm will talk
+      # to your live instance and write to it.
+      #
+      # WHY THE TARGET LIST IS BUILT ON ITS OWN LINE, AND MUST STAY THERE:
+      # `cargo test ... $(scripts/ci-test-targets.sh) ...` looks equivalent and is not.
+      # Bash `set -e` — the shell Actions runs `run:` with — does NOT propagate a failed
+      # command substitution sitting in argument position (`-eo pipefail` does not either;
+      # both measured). The step would carry on with EMPTY args and EXIT 0. Measured in
+      # this repo, that degraded command runs 2 targets (lib + bin, 408 tests) instead of
+      # 45 and is fully GREEN: every test target — mcp_handshake, test_toolset,
+      # plugin_dispatch_tests included — drops out of the required gate with no signal.
+      # That is #95's own pathology reproduced one level up, so: keep the assignment
+      # standalone. As a standalone assignment the same failure exits 1 (measured).
+      # Triggers that make this matter: the script's anti-drift guard firing (its whole
+      # job is to exit 1), `cargo metadata` failing, python3 missing, or the file landing
+      # without its exec bit.
+      #
+      # `bash scripts/...` rather than `scripts/...`: the file's mode bit is then not
+      # load-bearing. A checkout that loses +x gets a working gate instead of one that
+      # depends on the guard above to notice `Permission denied`.
+      - name: Full offline test gate (required)
         run: |
-          cargo test --no-fail-fast -p iris-agentic-dev-core --lib \
-            --test test_compile_params \
-            --test test_doc_params \
-            --test test_elicitation \
-            --test interop_unit_tests \
-            --test manifest_tests \
-            --test skills_tests \
-            --test vscode_config_tests \
-            --test mcp_handshake \
-            --test test_toolset
+          TARGETS=$(bash scripts/ci-test-targets.sh)
+          # The script refuses to exit 0 with an empty list; this refuses to trust it.
+          # A $TARGETS carrying no --test flag is precisely the silent degradation above,
+          # and the glob catches empty, whitespace-only and malformed alike.
+          if [[ "$TARGETS" != *--test* ]]; then
+            echo "::error::scripts/ci-test-targets.sh emitted no test targets - refusing to run a degraded gate"
+            exit 1
+          fi
+          # Unquoted on purpose: $TARGETS must word-split into the --test flags.
+          cargo test --workspace --lib --bins $TARGETS --no-fail-fast
         env:
           RUST_LOG: warn
-      # #86: these two tests were red at master and were in no gate, so nobody saw it.
-      - name: Plugin dispatch gate (#86)
-        run: cargo test --no-fail-fast -p iris-agentic-dev --test plugin_dispatch_tests
-        env:
-          RUST_LOG: warn
-      # Advisory: exercises the real api.github.com path with the token Actions injects
-      # (1000 req/hr per repo, not 60 per IP). continue-on-error so a GitHub-side outage
-      # or limit can never redden the required gate above.
-      - name: Live GitHub resolver canary (advisory)
+      # Advisory: exercises the real api.github.com and raw.githubusercontent.com paths
+      # with the token Actions injects (1000 req/hr per repo, not 60 per IP).
+      # continue-on-error so a GitHub-side outage or limit can never redden the gate above.
+      #   * manifest_tests — the version resolver against api.github.com (#87).
+      #   * skills_tests   — the subscription path against raw.githubusercontent.com (#92).
+      #     Retargeted: it pointed at intersystems-community/iris-vector-rag, which
+      #     publishes no manifest (HTTP 404), so it had been failing-when-enabled and
+      #     hidden behind a flag since v0.5.0.
+      - name: Live GitHub canaries — resolver + subscription (advisory)
         continue-on-error: true
-        run: cargo test --no-fail-fast -p iris-agentic-dev-core --test manifest_tests -- --nocapture
+        run: |
+          cargo test --no-fail-fast -p iris-agentic-dev-core \
+            --test manifest_tests --test skills_tests -- --nocapture
         env:
           RUST_LOG: warn
           IRIS_DEV_LIVE_GITHUB: "1"

--- a/crates/iris-agentic-dev-core/Cargo.toml
+++ b/crates/iris-agentic-dev-core/Cargo.toml
@@ -202,3 +202,11 @@ path = "tests/unit/test_sql_translate.rs"
 [[test]]
 name = "test_sql_translate_e2e"
 path = "tests/integration/test_sql_translate_e2e.rs"
+
+# Declared explicitly only so every test target is visible in one file (#95). Cargo
+# auto-discovers tests/*.rs, so this target already existed and already ran — but it
+# appeared in no [[test]] block, which is why the CI gate derives its target list from
+# `cargo metadata` rather than from this file.
+[[test]]
+name = "transport_e2e"
+path = "tests/transport_e2e.rs"

--- a/crates/iris-agentic-dev-core/src/iris/connection.rs
+++ b/crates/iris-agentic-dev-core/src/iris/connection.rs
@@ -190,6 +190,49 @@ impl IrisConnection {
         );
     }
 
+    /// Issue #93: the namespaces these credentials can actually reach, read from the
+    /// Atelier root descriptor (`result.content.namespaces`) — the same URL `probe()`
+    /// already fetches for version/api, so transport, auth and prefix handling are
+    /// pre-validated. 439 bytes and ~6 ms on the dev instance.
+    ///
+    /// An Atelier 404 for a MISSING NAMESPACE comes back with a zero-byte body, which is
+    /// byte-for-byte indistinguishable from a 404 for a missing document — so a tool that
+    /// wants to tell those apart has to ask a second question. This is that question.
+    ///
+    /// Fetched fresh at the moment of the question and never cached: a namespace can be
+    /// created while this server runs, and a stale "does not exist" is precisely the wrong
+    /// answer #93 is about. It only ever runs on a path that has ALREADY failed.
+    ///
+    /// `None` always means *cannot tell* — transport error, non-2xx (a wrong
+    /// `IRIS_WEB_PREFIX` 404s here too), or a body without the array (an old or foreign
+    /// server). Callers must keep their own error in that case and never turn `None` into
+    /// a positive claim about a namespace.
+    ///
+    /// The list reflects ACCESSIBILITY, not raw existence: `%Atelier.v1.Utils.General`
+    /// filters to what the authenticated user can reach, so a namespace that exists but is
+    /// invisible to these credentials is absent from it. Messages built from this must say
+    /// so.
+    pub async fn accessible_namespaces(&self, client: &reqwest::Client) -> Option<Vec<String>> {
+        let resp = client
+            .get(self.atelier_url("/"))
+            .basic_auth(&self.username, Some(&self.password))
+            .send()
+            .await
+            .ok()?;
+        if !resp.status().is_success() {
+            tracing::debug!("Atelier root namespace probe got HTTP {}", resp.status());
+            return None;
+        }
+        let body: serde_json::Value = resp.json().await.ok()?;
+        Some(
+            body["result"]["content"]["namespaces"]
+                .as_array()?
+                .iter()
+                .filter_map(|n| n.as_str().map(str::to_string))
+                .collect(),
+        )
+    }
+
     /// Query `^%SYS("SystemMode")` to detect whether this is a Live instance.
     async fn detect_system_mode(&self, client: &reqwest::Client) -> SystemMode {
         let url = self.versioned_ns_url("%SYS", "/action/query");

--- a/crates/iris-agentic-dev-core/src/skills/mod.rs
+++ b/crates/iris-agentic-dev-core/src/skills/mod.rs
@@ -1,6 +1,10 @@
 use anyhow::{Context, Result};
 use reqwest::Client;
 
+/// Live GitHub raw-content base. Overridable per-call so tests can point at a mock
+/// server (#92, mirroring `manifest::resolve::GITHUB_API` from #87).
+const RAW_GITHUB: &str = "https://raw.githubusercontent.com";
+
 pub struct SkillRegistry {
     skills: Vec<Skill>,
     kb_items: Vec<KbItem>,
@@ -40,7 +44,16 @@ impl SkillRegistry {
         &self.kb_items
     }
 
+    /// Subscribe to a GitHub package, loading its skills and KB items.
     pub async fn load_from_github(&mut self, owner_repo: &str) -> Result<()> {
+        self.load_from_github_at(RAW_GITHUB, owner_repo).await
+    }
+
+    /// Same as [`load_from_github`](Self::load_from_github), against an explicit raw-content
+    /// base URL. The tests drive this with a wiremock server so the subscription path is
+    /// covered offline (#92, same seam as `manifest::resolve::resolve_github_version_at`).
+    pub async fn load_from_github_at(&mut self, raw_base: &str, owner_repo: &str) -> Result<()> {
+        let raw_base = raw_base.trim_end_matches('/');
         let client = Client::builder()
             .user_agent("iris-agentic-dev/0.3.1")
             .build()?;
@@ -49,12 +62,14 @@ impl SkillRegistry {
             .split_once('/')
             .with_context(|| format!("invalid owner/repo: {}", owner_repo))?;
 
-        let manifest = self.fetch_manifest(owner, repo, &client).await?;
+        let manifest = self
+            .fetch_manifest_at(raw_base, owner, repo, &client)
+            .await?;
 
         for skill_path in &manifest.provides_skills {
             let skill_md_url = format!(
-                "https://raw.githubusercontent.com/{}/{}/HEAD/{}/SKILL.md",
-                owner, repo, skill_path
+                "{}/{}/{}/HEAD/{}/SKILL.md",
+                raw_base, owner, repo, skill_path
             );
             if let Ok(content) = fetch_text(&skill_md_url, &client).await {
                 if let Some(name) = extract_frontmatter_field(&content, "name") {
@@ -71,10 +86,7 @@ impl SkillRegistry {
         }
 
         for kb_path in &manifest.provides_kb_items {
-            let kb_url = format!(
-                "https://raw.githubusercontent.com/{}/{}/HEAD/{}",
-                owner, repo, kb_path
-            );
+            let kb_url = format!("{}/{}/{}/HEAD/{}", raw_base, owner, repo, kb_path);
             if let Ok(content) = fetch_text(&kb_url, &client).await {
                 let title = extract_frontmatter_field(&content, "title")
                     .or_else(|| extract_h1_title(&content))
@@ -96,11 +108,14 @@ impl SkillRegistry {
         Ok(())
     }
 
-    async fn fetch_manifest(&self, owner: &str, repo: &str, client: &Client) -> Result<Manifest> {
-        let url = format!(
-            "https://raw.githubusercontent.com/{}/{}/HEAD/iris-agentic-dev.toml",
-            owner, repo
-        );
+    async fn fetch_manifest_at(
+        &self,
+        raw_base: &str,
+        owner: &str,
+        repo: &str,
+        client: &Client,
+    ) -> Result<Manifest> {
+        let url = format!("{}/{}/{}/HEAD/iris-agentic-dev.toml", raw_base, owner, repo);
         let text = fetch_text(&url, client)
             .await
             .with_context(|| format!("no iris-agentic-dev.toml found in {}/{}", owner, repo))?;

--- a/crates/iris-agentic-dev-core/src/tools/interop.rs
+++ b/crates/iris-agentic-dev-core/src/tools/interop.rs
@@ -160,6 +160,62 @@ pub async fn ensure_interop_namespace(
     ))
 }
 
+/// Issue #93: an Atelier 404 for a namespace that does not exist arrives with a ZERO-BYTE
+/// body, so it is indistinguishable from a 404 for a missing document — and every caller
+/// guessed wrong. `iris_compile` reported `IRIS_UNREACHABLE` with "Check IRIS_HOST and
+/// IRIS_WEB_PORT" while IRIS was answering perfectly on that very host and port.
+///
+/// Same `Option<Result<…>>` contract as `ensure_interop_namespace` above: `Some` means "I
+/// have a definitive better error for you", `None` means "keep your own". `None` is
+/// returned whenever the root descriptor cannot be read (`accessible_namespaces` = cannot
+/// tell) or the namespace IS in the list — a wrong `IRIS_WEB_PREFIX` 404s the root GET too,
+/// and that is exactly the case the host/port hint is right for.
+///
+/// Call this ONLY on status 404. A 401/403 is credentials and a 5xx is a sick instance;
+/// reporting either as a missing namespace would ship a new wrong answer for an old one.
+///
+/// The comparison is case-insensitive and trimmed: Atelier serves `/v8/app/docnames/CLS`
+/// happily (verified: 200, identical body) and `resolve_namespace` passes the caller's
+/// string through verbatim, so `eq` would invent a false NAMESPACE_NOT_FOUND for a
+/// namespace that works.
+pub async fn namespace_missing_error(
+    iris: &IrisConnection,
+    client: &reqwest::Client,
+    ns: &str,
+    attempted_url: &str,
+) -> Option<Result<CallToolResult, McpError>> {
+    let available = iris.accessible_namespaces(client).await?;
+    if available
+        .iter()
+        .any(|n| n.trim().eq_ignore_ascii_case(ns.trim()))
+    {
+        return None;
+    }
+    Some(crate::tools::envelope::fail_with(
+        crate::tools::ERR_NAMESPACE_NOT_FOUND,
+        &format!(
+            "Namespace '{ns}' does not exist on this IRIS instance, or is not accessible to \
+             user '{user}' — IRIS answered on {base}, the namespace did not. Available \
+             namespaces: {list}.",
+            user = iris.username,
+            base = iris.base_url,
+            list = available.join(", "),
+        ),
+        serde_json::json!({
+            "namespace": ns,
+            "available_namespaces": available,
+            "attempted_url": attempted_url,
+            // Explicit, so the IRIS_UNREACHABLE host/port hint this replaces can never
+            // reappear through `builtin_hint` (envelope.rs).
+            "hint": format!(
+                "Pass namespace= one of the listed namespaces (omitting it targets the \
+                 connection namespace '{}'). Nothing was compiled.",
+                iris.namespace
+            ),
+        }),
+    ))
+}
+
 #[derive(Debug, Deserialize, JsonSchema)]
 pub struct ProductionStatusParams {
     #[serde(default = "default_ns")]
@@ -3539,5 +3595,135 @@ mod tests {
             production_name_arg(&serde_json::json!({"name": " P.Prod "})).as_deref(),
             Some("P.Prod")
         );
+    }
+}
+
+// ── Issue #93: "that namespace does not exist" vs "I cannot tell" ─────────────
+#[cfg(test)]
+mod namespace_missing_tests {
+    use super::*;
+    use crate::iris::connection::DiscoverySource;
+    use wiremock::matchers::{method, path_regex};
+    use wiremock::{Mock, MockServer, ResponseTemplate};
+
+    fn rt() -> tokio::runtime::Runtime {
+        tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .unwrap()
+    }
+
+    /// Mount an Atelier root descriptor answering with `namespaces`, then ask about `ns`.
+    async fn ask(namespaces: &[&str], ns: &str) -> Option<serde_json::Value> {
+        let server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(path_regex(r"^/api/atelier/$"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                "result": {"content": {"version": "IRIS 2026.1", "api": 8,
+                                       "namespaces": namespaces}}
+            })))
+            .mount(&server)
+            .await;
+        let iris = IrisConnection::new(
+            server.uri(),
+            "APP",
+            "_SYSTEM",
+            "SYS",
+            DiscoverySource::EnvVar,
+        );
+        let client = reqwest::Client::new();
+        let out = namespace_missing_error(&iris, &client, ns, "http://x/attempted").await?;
+        let r = out.unwrap();
+        assert_eq!(r.is_error, Some(true));
+        let text = match &r.content[0].raw {
+            rmcp::model::RawContent::Text(t) => t.text.clone(),
+            _ => panic!("expected text content"),
+        };
+        Some(serde_json::from_str(&text).unwrap())
+    }
+
+    /// A namespace that IS in the list is not missing — whatever else the 404 meant, this
+    /// helper must keep its hands off the caller's error.
+    #[test]
+    fn a_namespace_that_exists_yields_no_error_however_it_is_spelled() {
+        rt().block_on(async {
+            // Case-insensitive and trimmed: `resolve_namespace` passes the caller's string
+            // through verbatim and Atelier serves `/v8/app/...` happily, so `eq` here would
+            // invent a false NAMESPACE_NOT_FOUND for a namespace that works.
+            for spelling in ["APP", "app", "aPp", " APP ", "USER", "user"] {
+                assert!(
+                    ask(&["APP", "USER"], spelling).await.is_none(),
+                    "'{spelling}' is in the list and must not be reported missing"
+                );
+            }
+        });
+    }
+
+    /// The answer #93 asks for: name the namespace, say it may be an ACCESS problem rather
+    /// than a missing namespace, list the ones that ARE reachable, and never let the
+    /// IRIS_UNREACHABLE host/port hint back in.
+    #[test]
+    fn a_missing_namespace_lists_the_ones_that_do_exist() {
+        rt().block_on(async {
+            let v = ask(&["APP", "USER"], "ZZNOSUCHNS")
+                .await
+                .expect("a namespace absent from the list is definitively missing");
+            assert_eq!(v["error_code"], "NAMESPACE_NOT_FOUND", "{v}");
+            assert_eq!(v["namespace"], "ZZNOSUCHNS", "{v}");
+            assert_eq!(
+                v["available_namespaces"],
+                serde_json::json!(["APP", "USER"]),
+                "{v}"
+            );
+            assert_eq!(v["attempted_url"], "http://x/attempted", "{v}");
+            let msg = v["error"].as_str().unwrap();
+            assert!(msg.contains("APP, USER"), "name them in the prose too: {v}");
+            assert!(
+                msg.contains("not accessible to user '_SYSTEM'"),
+                "the list reflects ACCESS, not raw existence: {v}"
+            );
+            assert!(
+                v["hint"].as_str().unwrap().contains("Nothing was compiled"),
+                "{v}"
+            );
+            assert!(!v.to_string().contains("Check IRIS_HOST"), "{v}");
+        });
+    }
+
+    /// `None` means CANNOT TELL and must never become a positive claim. A wrong
+    /// `IRIS_WEB_PREFIX` 404s the root GET as well — the case the host/port hint is
+    /// actually right for — and an old or foreign server answers without the array.
+    #[test]
+    fn an_unreadable_root_descriptor_is_never_a_claim_about_a_namespace() {
+        rt().block_on(async {
+            for body in [
+                ResponseTemplate::new(404),
+                ResponseTemplate::new(500),
+                // 200, but no `namespaces` array (older Atelier).
+                ResponseTemplate::new(200).set_body_json(
+                    serde_json::json!({"result": {"content": {"version": "IRIS 2019.1"}}}),
+                ),
+            ] {
+                let server = MockServer::start().await;
+                Mock::given(method("GET"))
+                    .and(path_regex(r"^/api/atelier/$"))
+                    .respond_with(body)
+                    .mount(&server)
+                    .await;
+                let iris = IrisConnection::new(
+                    server.uri(),
+                    "APP",
+                    "_SYSTEM",
+                    "SYS",
+                    DiscoverySource::EnvVar,
+                );
+                assert!(
+                    namespace_missing_error(&iris, &reqwest::Client::new(), "ZZNOSUCHNS", "u")
+                        .await
+                        .is_none(),
+                    "a blind probe must leave the caller's error alone"
+                );
+            }
+        });
     }
 }

--- a/crates/iris-agentic-dev-core/src/tools/mod.rs
+++ b/crates/iris-agentic-dev-core/src/tools/mod.rs
@@ -2754,6 +2754,18 @@ impl IrisTools {
                     }
                 };
                 if !put_resp.status().is_success() {
+                    // #93: an Atelier 404 for a missing NAMESPACE has a zero-byte body, so
+                    // it is indistinguishable from a missing document — this path reported
+                    // it as UPLOAD_FAILED "PUT X returned HTTP 404 Not Found" and never
+                    // named the namespace. Only on 404: 401/403 and 5xx keep their meaning.
+                    if put_resp.status().as_u16() == 404 {
+                        if let Some(e) =
+                            interop::namespace_missing_error(&iris, client, &namespace, &put_url)
+                                .await
+                        {
+                            return e;
+                        }
+                    }
                     return err_json(
                         "UPLOAD_FAILED",
                         &format!("PUT {} returned HTTP {}", doc_name, put_resp.status()),
@@ -2811,6 +2823,11 @@ impl IrisTools {
         // see `docnames_in_body`. `scanned` is carried so a NOT_FOUND can distinguish "the
         // pattern matched nothing" from "the listing itself came back empty".
         let mut scanned = 0usize;
+        // #94: whether the listing was narrowed server-side, and with what. Hoisted out of
+        // the wildcard arm because the NOT_FOUND message below MUST branch on it: once the
+        // listing is filtered, `scanned` counts CANDIDATES, not the namespace.
+        let mut listing_narrowed = false;
+        let mut listing_filter_used: Option<&str> = None;
         let targets: Vec<String> = if p.target.contains('*') {
             // #88: an unqualified pattern is refused BEFORE the listing is fetched — there
             // is no expansion to inspect, and no reason to pull 10k names to say so.
@@ -2818,12 +2835,44 @@ impl IrisTools {
                 return unqualified_wildcard_error(&p.target, &namespace);
             }
             let list_url = iris.versioned_ns_url(&namespace, "/docnames/CLS");
-            match client
-                .get(&list_url)
+            // #94: narrow the listing SERVER-SIDE. `?filter=X` becomes `Name Like '%X%'`
+            // inside the query GetDocNames already runs, so the response is a SUPERSET of
+            // what the client regex selects — see `wildcard_listing_filter`. 1,696,950
+            // bytes -> ~2,066; a wildcard compile 331 ms -> ~45 ms.
+            //
+            // DELIBERATELY NO CACHE, and do not add one. What is left after narrowing is
+            // ~38 ms of server-side index walk that no filter can avoid; a perfect cache
+            // would buy back ~33 ms. In-process invalidation cannot see another MCP process,
+            // a human saving a class in VS Code / Studio / the Portal, an ImportDir or IPM
+            // install, a mapping change, or generated dependents — and any of those inside
+            // the TTL makes `Pkg.*` skip a class while still reporting success:true. That is
+            // the exact failure mode this issue series exists to eliminate; 33 ms does not
+            // buy it. `e2e_compile_wildcard_package` is the regression test.
+            let listing_filter = wildcard_listing_filter(&p.target);
+            let mut fetch_url = match listing_filter {
+                Some(f) => format!("{list_url}?filter={}", urlencoding::encode(f)),
+                None => list_url.clone(),
+            };
+            listing_filter_used = listing_filter;
+            listing_narrowed = listing_filter.is_some();
+            let mut listing = client
+                .get(&fetch_url)
                 .basic_auth(&iris.username, Some(&iris.password))
                 .send()
-                .await
-            {
+                .await;
+            // An Atelier build that rejects the parameter must degrade to exactly today's
+            // behaviour, not to a new failure: retry once, unfiltered.
+            if listing_narrowed && !matches!(&listing, Ok(r) if r.status().is_success()) {
+                fetch_url = list_url.clone();
+                listing_narrowed = false;
+                listing_filter_used = None;
+                listing = client
+                    .get(&fetch_url)
+                    .basic_auth(&iris.username, Some(&iris.password))
+                    .send()
+                    .await;
+            }
+            match listing {
                 Ok(resp) if resp.status().is_success() => {
                     let body: serde_json::Value = resp.json().await.unwrap_or_default();
                     // One pass over the listing, not two: `scanned` and the expansion read
@@ -2848,6 +2897,20 @@ impl IrisTools {
                 // expansion, no count and no cap — the guard silently off exactly when the
                 // instance is unhealthy. A wildcard therefore fails here instead of guessing.
                 other => {
+                    // #93: a 404 here used to become LISTING_UNAVAILABLE, which never said
+                    // the namespace does not exist and never named the ones that do — the
+                    // 404 body is zero bytes, so only a second question can tell them apart.
+                    if let Ok(resp) = &other {
+                        if resp.status().as_u16() == 404 {
+                            if let Some(e) = interop::namespace_missing_error(
+                                &iris, client, &namespace, &fetch_url,
+                            )
+                            .await
+                            {
+                                return e;
+                            }
+                        }
+                    }
                     let detail = match other {
                         Ok(resp) => format!("HTTP {}", resp.status().as_u16()),
                         Err(e) => e.to_string(),
@@ -2863,7 +2926,9 @@ impl IrisTools {
                         serde_json::json!({
                             "pattern": p.target,
                             "namespace": namespace,
-                            "listing_url": list_url,
+                            // #94: the URL actually requested, so the caller can reproduce it.
+                            "listing_url": fetch_url,
+                            "listing_filter": listing_filter_used,
                             "hint": "Compile a single document by its exact name, which needs \
                                      no listing. If the namespace is wrong, iris_query can \
                                      confirm it exists.",
@@ -2880,14 +2945,38 @@ impl IrisTools {
             // It also has to say what was NOT searched: the listing is /docnames/CLS, so a
             // wildcard can never see a .mac/.int/.inc routine, and a bare NOT_FOUND there
             // reads as "that routine does not exist" when it does and compiles by name.
-            return err_json(
-                "NOT_FOUND",
-                &format!(
+            // #94: `scanned` STOPS meaning "documents in the namespace" the moment the
+            // listing is narrowed server-side — left alone, this sentence would start
+            // saying "scanned 0 CLS document(s) in namespace APP" for a typo'd package,
+            // which reads as "the namespace is empty". A new silent wrong answer
+            // introduced by a performance fix is not an acceptable trade, so the two
+            // cases get two sentences.
+            let msg = match listing_filter_used {
+                Some(f) => format!(
+                    "No documents match pattern '{}' — the CLS listing for namespace {} was \
+                     narrowed server-side to names containing '{}', which returned {} \
+                     candidate document(s). Wildcards expand CLASS documents only: compile a \
+                     .mac/.int/.inc routine by its exact name.",
+                    p.target, namespace, f, scanned
+                ),
+                None => format!(
                     "No documents match pattern '{}' — scanned {} CLS document(s) in \
                      namespace {}. Wildcards expand CLASS documents only: compile a \
                      .mac/.int/.inc routine by its exact name.",
                     p.target, scanned, namespace
                 ),
+            };
+            return crate::tools::envelope::fail_with(
+                "NOT_FOUND",
+                &msg,
+                serde_json::json!({
+                    "pattern": p.target,
+                    "namespace": namespace,
+                    // Machine-readable, so the distinction is not only in the prose.
+                    "listing_narrowed": listing_narrowed,
+                    "listing_filter": listing_filter_used,
+                    "candidates_scanned": scanned,
+                }),
             );
         }
 
@@ -2949,6 +3038,19 @@ impl IrisTools {
         if !resp.status().is_success() {
             let url_str = compile_url.clone();
             let status = resp.status().as_u16();
+            // #93, the verbatim repro: compiling an EXACT target in a namespace that does
+            // not exist answered IRIS_UNREACHABLE + "Check IRIS_HOST and IRIS_WEB_PORT"
+            // while IRIS was answering perfectly on that host and port. The 404 body is
+            // zero bytes, so the transport alone cannot tell a missing namespace from a
+            // missing document; ask the root descriptor. Only on 404 — a 401/403 is
+            // credentials and a 5xx is a sick instance, and both keep their current error.
+            if status == 404 {
+                if let Some(e) =
+                    interop::namespace_missing_error(&iris, client, &namespace, &url_str).await
+                {
+                    return e;
+                }
+            }
             return err_json_with_url("IRIS_UNREACHABLE", &format!("HTTP {}", status), &url_str);
         }
 
@@ -4708,13 +4810,17 @@ Methods:
         };
         let code = skills_tools::skills_list_json_code(None, false);
         match skills_tools::read_skills_json(&iris, &code, &ns).await {
-            Ok(skills) => {
-                let count = skills.as_array().map(|a| a.len()).unwrap_or(0);
-                ok_json(serde_json::json!({
+            // #89 follow-up: count via the shared helper, not `unwrap_or(0)`. This is the
+            // tool agent_info is meant to agree with, and the old shape would have made the
+            // two disagree in the opposite direction — count:0 success:true here against
+            // SKILLS_PARSE_FAILED there — for any payload that parsed to a non-array.
+            Ok(skills) => match skills_tools::skills_count_from_payload(&skills) {
+                Err(e) => skills_tools::skills_read_fail("skill_list", &ns, e),
+                Ok(count) => ok_json(serde_json::json!({
                     "success": true, "skills": skills, "count": count,
                     "namespace": ns, "source": "^SKILLS"
-                }))
-            }
+                })),
+            },
             Err(e) => skills_tools::skills_read_fail("skill_list", &ns, e),
         }
     }
@@ -5003,7 +5109,22 @@ Methods:
                     })
                     .collect()
             })
-            .unwrap_or_default();
+            // #89 follow-up: recover the guard rather than reporting an unreadable
+            // history as an empty one, matching handle_agent_info(what=history).
+            .unwrap_or_else(|e| {
+                let h = e.into_inner();
+                h.iter()
+                    .rev()
+                    .take(p.limit)
+                    .map(|c| {
+                        serde_json::json!({
+                            "tool": c.tool,
+                            "success": c.success,
+                            "ago_secs": c.timestamp.elapsed().as_secs(),
+                        })
+                    })
+                    .collect()
+            });
         ok_json(serde_json::json!({"calls": calls, "limit": p.limit}))
     }
 
@@ -5202,7 +5323,7 @@ Methods:
     }
 
     #[tool(
-        description = "Session and learning agent information. what=stats returns skill count and session call count, what=history returns recent tool call history."
+        description = "Session and learning agent information. what=stats returns the ^SKILLS skill count for the connection's namespace plus the session call count — it FAILS with DOCKER_REQUIRED / SKILLS_PARSE_FAILED if the registry cannot be read, and never reports 0 for a registry it could not read. what=history returns recent tool call history and needs no IRIS connection."
     )]
     async fn agent_info(
         &self,
@@ -6300,6 +6421,41 @@ fn wildcard_target_is_unqualified(pattern: &str) -> bool {
     matches!(pattern.find('*'), Some(0))
 }
 
+/// Issue #94: the literal text before a wildcard's first `*`, when it is safe to hand to
+/// the Atelier `?filter=` query parameter.
+///
+/// Every wildcard compile used to GET the WHOLE `/docnames/CLS` listing: measured on the
+/// dev instance at 1,696,950 bytes / 0.294 s server-side / 12,750 documents, ~98% of the
+/// cost of the call. `%Api.Atelier.v1:GetDocNames` accepts `filter=X` and turns it into
+/// `Name Like '%X%'` inside the same `%Library.RoutineMgr:StudioOpenDialog` query it
+/// already runs — 2,066 bytes / 0.040 s for `filter=Ens.Alerting.`.
+///
+/// The safety argument is the SUPERSET INVARIANT: `LIKE '%X%'` is a *contains* match and
+/// `docname_pattern_regex` is anchored on the same literal prefix, so every name the client
+/// regex would have matched necessarily contains that prefix and survives the server
+/// filter. The server can only over-deliver; the client-side regex still does the real
+/// selection, so `Matched` / `TooBroad` / `NOT_FOUND` are bit-for-bit unchanged. (Measured:
+/// the filter is case-insensitive, matching the regex's `(?i)`.)
+///
+/// `%` and `_` are PERMITTED. In `LIKE` they are wildcards, so they can only broaden the
+/// match, never narrow it — and `%Pkg.*` needs its leading `%` to reach a system package.
+/// A quote must never get through: `GetDocNames` builds that `Name Like` clause by STRING
+/// CONCATENATION, and a probe with `filter=%27` returned 200 with an empty content array —
+/// i.e. an unguarded quote would narrow WRONGLY rather than fail loudly. Hence an allowlist
+/// rather than an escape, and a rejected prefix means "fetch the whole listing" (today's
+/// behaviour), never "narrow it wrongly".
+fn wildcard_listing_filter(pattern: &str) -> Option<&str> {
+    let prefix = &pattern[..pattern.find('*')?];
+    if prefix.is_empty() {
+        // Unqualified — already refused before any fetch by `wildcard_target_is_unqualified`.
+        return None;
+    }
+    prefix
+        .chars()
+        .all(|c| c.is_ascii_alphanumeric() || matches!(c, '.' | '_' | '%' | '-'))
+        .then_some(prefix)
+}
+
 /// Issue #88: the most documents ONE wildcard compile may queue.
 ///
 /// Picked from the shape of a real namespace, not as a round number. The dev instance's APP
@@ -7383,8 +7539,80 @@ mod no_tests_found_guidance_tests {
 mod wildcard_listing_failure_tests {
     use super::*;
     use crate::iris::connection::{DiscoverySource, IrisConnection};
-    use wiremock::matchers::{method, path_regex};
+    use wiremock::matchers::{method, path_regex, query_param, query_param_is_missing};
     use wiremock::{Mock, MockServer, ResponseTemplate};
+
+    /// Drive the real `iris_compile` handler against a mock Atelier and read its envelope.
+    /// `namespace: None` targets the connection namespace, exactly as an omitted parameter
+    /// does in production.
+    async fn compile_against(
+        server: &MockServer,
+        conn_ns: &str,
+        namespace: Option<&str>,
+        target: &str,
+    ) -> (Option<bool>, serde_json::Value) {
+        let conn = IrisConnection::new(
+            server.uri(),
+            conn_ns,
+            "_SYSTEM",
+            "SYS",
+            DiscoverySource::EnvVar,
+        );
+        let tools = IrisTools::new_with_toolset(Some(conn), Toolset::Interop).unwrap();
+        let r = tools
+            .iris_compile(rmcp::handler::server::wrapper::Parameters(CompileParams {
+                target: target.into(),
+                flags: "cuk".into(),
+                namespace: namespace.map(str::to_string),
+                force_writable: false,
+                inline: false,
+            }))
+            .await
+            .expect("the tool must answer, not error out of the transport");
+        let text = match &r.content[0].raw {
+            rmcp::model::RawContent::Text(t) => t.text.clone(),
+            _ => panic!("expected text content"),
+        };
+        (r.is_error, serde_json::from_str(&text).unwrap())
+    }
+
+    /// An Atelier `/docnames/CLS` body over the given document names.
+    fn listing(names: &[&str]) -> serde_json::Value {
+        serde_json::json!({"result": {"content": names.iter()
+            .map(|n| serde_json::json!({"cat":"CLS","db":"APP-CODE","gen":false,"name":n}))
+            .collect::<Vec<_>>()}})
+    }
+
+    /// A compile response with no errors.
+    fn clean_compile() -> serde_json::Value {
+        serde_json::json!({"status":{"errors":[],"summary":""},"console":[],"result":{"content":[]}})
+    }
+
+    /// The Atelier root descriptor — `result.content.namespaces` is what #93 reads.
+    fn root_descriptor(namespaces: &[&str]) -> serde_json::Value {
+        serde_json::json!({"result": {"content": {
+            "version": "IRIS for UNIX 2026.1", "api": 8, "namespaces": namespaces
+        }}})
+    }
+
+    fn rt() -> tokio::runtime::Runtime {
+        tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .unwrap()
+    }
+
+    /// The POST bodies `/action/compile` actually received.
+    async fn compile_payloads(server: &MockServer) -> Vec<serde_json::Value> {
+        server
+            .received_requests()
+            .await
+            .unwrap()
+            .iter()
+            .filter(|r| r.url.path().ends_with("/action/compile"))
+            .map(|r| serde_json::from_slice(&r.body).unwrap())
+            .collect()
+    }
 
     /// #88 follow-up: the guard lives on the expansion, so when the LISTING cannot be read
     /// there is nothing to apply it to. The old `_ => vec![p.target.clone()]` fallback handed
@@ -7451,6 +7679,323 @@ mod wildcard_listing_failure_tests {
             assert_eq!(v["pattern"], "APPPKG.*");
         });
     }
+
+    /// #94: the listing GET must actually carry `?filter=<prefix>` — the whole point is
+    /// that the 1,696,950-byte namespace listing never crosses the wire. The mock only
+    /// answers a request that HAS the parameter, so an unfiltered fetch would fall through
+    /// to LISTING_UNAVAILABLE and fail this test loudly.
+    #[test]
+    fn a_wildcard_narrows_the_listing_server_side_and_compiles_what_it_matched() {
+        rt().block_on(async {
+            let server = MockServer::start().await;
+            Mock::given(method("GET"))
+                .and(path_regex(r".*/docnames/CLS$"))
+                .and(query_param("filter", "APPPKG."))
+                .respond_with(ResponseTemplate::new(200).set_body_json(listing(&[
+                    "APPPKG.FoundationProduction.cls",
+                    "APPPKG.Sub.Helper.cls",
+                ])))
+                .expect(1)
+                .mount(&server)
+                .await;
+            Mock::given(method("POST"))
+                .and(path_regex(r".*/action/compile$"))
+                .respond_with(ResponseTemplate::new(200).set_body_json(clean_compile()))
+                .expect(1)
+                .mount(&server)
+                .await;
+
+            let (is_err, v) = compile_against(&server, "APP", None, "APPPKG.*").await;
+            assert_eq!(is_err, Some(false), "{v}");
+            assert_eq!(v["targets_compiled"], 2, "{v}");
+            assert_eq!(
+                compile_payloads(&server).await,
+                vec![serde_json::json!([
+                    "APPPKG.FoundationProduction.cls",
+                    "APPPKG.Sub.Helper.cls"
+                ])],
+                "the narrowed listing must drive the compile set unchanged"
+            );
+        });
+    }
+
+    /// #94: an Atelier build that rejects `?filter=` must degrade to EXACTLY today's
+    /// behaviour — one unfiltered retry — not to a new failure mode. Without this the
+    /// performance fix would break wildcards on every server that does not know the
+    /// parameter.
+    #[test]
+    fn a_rejected_filter_falls_back_to_the_unfiltered_listing() {
+        rt().block_on(async {
+            let server = MockServer::start().await;
+            Mock::given(method("GET"))
+                .and(path_regex(r".*/docnames/CLS$"))
+                .and(query_param("filter", "APPPKG."))
+                .respond_with(ResponseTemplate::new(400))
+                .expect(1)
+                .mount(&server)
+                .await;
+            Mock::given(method("GET"))
+                .and(path_regex(r".*/docnames/CLS$"))
+                .and(query_param_is_missing("filter"))
+                .respond_with(ResponseTemplate::new(200).set_body_json(listing(&[
+                    "APPPKG.FoundationProduction.cls",
+                    "WebTerminal.Common.cls",
+                ])))
+                .expect(1)
+                .mount(&server)
+                .await;
+            Mock::given(method("POST"))
+                .and(path_regex(r".*/action/compile$"))
+                .respond_with(ResponseTemplate::new(200).set_body_json(clean_compile()))
+                .expect(1)
+                .mount(&server)
+                .await;
+
+            let (is_err, v) = compile_against(&server, "APP", None, "APPPKG.*").await;
+            assert_eq!(is_err, Some(false), "{v}");
+            assert_eq!(v["targets_compiled"], 1, "{v}");
+        });
+    }
+
+    /// #94 B3: once the listing is narrowed, `scanned` counts CANDIDATES, not the
+    /// namespace — so the old sentence would start reporting "scanned 0 CLS document(s) in
+    /// namespace APP" for a typo'd package, which reads as "the namespace is empty". A
+    /// performance fix must not ship a new silent wrong answer.
+    #[test]
+    fn a_narrowed_listing_never_says_it_scanned_zero_documents_in_the_namespace() {
+        rt().block_on(async {
+            let server = MockServer::start().await;
+            Mock::given(method("GET"))
+                .and(path_regex(r".*/docnames/CLS$"))
+                .and(query_param("filter", "ZZNOPKG."))
+                .respond_with(ResponseTemplate::new(200).set_body_json(listing(&[])))
+                .mount(&server)
+                .await;
+            Mock::given(method("POST"))
+                .and(path_regex(r".*/action/compile$"))
+                .respond_with(ResponseTemplate::new(200))
+                .expect(0)
+                .mount(&server)
+                .await;
+
+            let (is_err, v) = compile_against(&server, "APP", None, "ZZNOPKG.*").await;
+            assert_eq!(is_err, Some(true), "{v}");
+            assert_eq!(v["error_code"], "NOT_FOUND", "{v}");
+            let msg = v["error"].as_str().unwrap();
+            assert!(msg.contains("ZZNOPKG."), "the filter must be named: {v}");
+            assert!(
+                !msg.contains("scanned 0 CLS document(s)"),
+                "a narrowed listing must not claim the namespace is empty: {v}"
+            );
+            assert_eq!(v["listing_narrowed"], true, "{v}");
+            assert_eq!(v["listing_filter"], "ZZNOPKG.", "{v}");
+            assert_eq!(v["candidates_scanned"], 0, "{v}");
+        });
+    }
+
+    /// #93, the verbatim repro: an EXACT target in a namespace that does not exist answered
+    /// `IRIS_UNREACHABLE` + "Check IRIS_HOST and IRIS_WEB_PORT" while IRIS was answering
+    /// perfectly on that host and port. The 404 body is zero bytes, so the fix asks the
+    /// root descriptor a second question.
+    #[test]
+    fn a_missing_namespace_is_named_instead_of_blaming_the_host_and_port() {
+        rt().block_on(async {
+            let server = MockServer::start().await;
+            Mock::given(method("POST"))
+                .and(path_regex(r".*/action/compile$"))
+                .respond_with(ResponseTemplate::new(404))
+                .mount(&server)
+                .await;
+            Mock::given(method("GET"))
+                .and(path_regex(r"^/api/atelier/$"))
+                .respond_with(
+                    ResponseTemplate::new(200).set_body_json(root_descriptor(&["APP", "USER"])),
+                )
+                .mount(&server)
+                .await;
+
+            let (is_err, v) = compile_against(&server, "APP", Some("ZZNOSUCHNS"), "Foo.Bar").await;
+            assert_eq!(is_err, Some(true), "{v}");
+            assert_eq!(v["error_code"], "NAMESPACE_NOT_FOUND", "{v}");
+            assert_eq!(v["namespace"], "ZZNOSUCHNS", "{v}");
+            assert_eq!(
+                v["available_namespaces"],
+                serde_json::json!(["APP", "USER"]),
+                "#93 asks for the namespaces that DO exist: {v}"
+            );
+            let text = v.to_string();
+            assert!(
+                !text.contains("Check IRIS_HOST"),
+                "the host/port hint is the wrong advice here and must not survive: {v}"
+            );
+            assert!(
+                v["error"]
+                    .as_str()
+                    .unwrap()
+                    .contains("not accessible to user"),
+                "the list reflects ACCESS, not raw existence — say so: {v}"
+            );
+        });
+    }
+
+    /// #93 false-positive guard: Atelier serves `/v8/app/docnames/CLS` happily and
+    /// `resolve_namespace` passes the caller's string through verbatim, so a case-sensitive
+    /// comparison would invent a NAMESPACE_NOT_FOUND for a namespace that works. Pinned as
+    /// a test, not a comment.
+    #[test]
+    fn a_namespace_that_differs_only_in_case_is_not_reported_as_missing() {
+        rt().block_on(async {
+            let server = MockServer::start().await;
+            Mock::given(method("POST"))
+                .and(path_regex(r".*/action/compile$"))
+                .respond_with(ResponseTemplate::new(404))
+                .mount(&server)
+                .await;
+            Mock::given(method("GET"))
+                .and(path_regex(r"^/api/atelier/$"))
+                .respond_with(ResponseTemplate::new(200).set_body_json(root_descriptor(&["APP"])))
+                .mount(&server)
+                .await;
+
+            let (is_err, v) = compile_against(&server, "APP", Some("app"), "Foo.Bar").await;
+            assert_eq!(is_err, Some(true), "{v}");
+            assert_ne!(
+                v["error_code"], "NAMESPACE_NOT_FOUND",
+                "'app' IS 'APP' — today's error must survive: {v}"
+            );
+            assert_eq!(v["error_code"], "IRIS_UNREACHABLE", "{v}");
+        });
+    }
+
+    /// #93 on the wildcard listing arm: a 404 used to become LISTING_UNAVAILABLE, which
+    /// never said the namespace does not exist and never named the ones that do.
+    #[test]
+    fn a_wildcard_in_a_missing_namespace_names_the_namespace_not_the_listing() {
+        rt().block_on(async {
+            let server = MockServer::start().await;
+            Mock::given(method("GET"))
+                .and(path_regex(r".*/docnames/CLS$"))
+                .respond_with(ResponseTemplate::new(404))
+                .mount(&server)
+                .await;
+            Mock::given(method("GET"))
+                .and(path_regex(r"^/api/atelier/$"))
+                .respond_with(
+                    ResponseTemplate::new(200).set_body_json(root_descriptor(&["APP", "USER"])),
+                )
+                .mount(&server)
+                .await;
+            Mock::given(method("POST"))
+                .and(path_regex(r".*/action/compile$"))
+                .respond_with(ResponseTemplate::new(200))
+                .expect(0)
+                .mount(&server)
+                .await;
+
+            let (is_err, v) = compile_against(&server, "APP", Some("ZZNOSUCHNS"), "APPPKG.*").await;
+            assert_eq!(is_err, Some(true), "{v}");
+            assert_eq!(v["error_code"], "NAMESPACE_NOT_FOUND", "{v}");
+            assert_eq!(
+                v["available_namespaces"],
+                serde_json::json!(["APP", "USER"]),
+                "{v}"
+            );
+        });
+    }
+
+    /// #93 "cannot tell": a wrong IRIS_WEB_PREFIX 404s the listing AND the root descriptor,
+    /// and that is exactly the case the host/port advice is right for. `None` from
+    /// `accessible_namespaces` must never become a positive claim about a namespace —
+    /// today's error survives verbatim, still saying nothing was compiled.
+    #[test]
+    fn a_blind_root_descriptor_keeps_todays_error_instead_of_guessing() {
+        rt().block_on(async {
+            let server = MockServer::start().await;
+            Mock::given(method("GET"))
+                .and(path_regex(r".*/docnames/CLS$"))
+                .respond_with(ResponseTemplate::new(404))
+                .mount(&server)
+                .await;
+            Mock::given(method("GET"))
+                .and(path_regex(r"^/api/atelier/$"))
+                .respond_with(ResponseTemplate::new(500))
+                .mount(&server)
+                .await;
+            Mock::given(method("POST"))
+                .and(path_regex(r".*/action/compile$"))
+                .respond_with(ResponseTemplate::new(200))
+                .expect(0)
+                .mount(&server)
+                .await;
+
+            let (is_err, v) = compile_against(&server, "APP", Some("ZZNOSUCHNS"), "APPPKG.*").await;
+            assert_eq!(is_err, Some(true), "{v}");
+            assert_eq!(v["error_code"], "LISTING_UNAVAILABLE", "{v}");
+            assert!(
+                v["error"]
+                    .as_str()
+                    .unwrap()
+                    .contains("Nothing was compiled"),
+                "{v}"
+            );
+        });
+    }
+}
+
+// ── Issue #94: server-side narrowing of the /docnames listing ─────────────────
+#[cfg(test)]
+mod wildcard_listing_filter_tests {
+    use super::*;
+
+    /// The prefix handed to `?filter=`, per pattern shape.
+    #[test]
+    fn wildcard_listing_filter_takes_the_literal_prefix() {
+        assert_eq!(wildcard_listing_filter("MyApp.*"), Some("MyApp."));
+        assert_eq!(wildcard_listing_filter("MyApp.*.cls"), Some("MyApp."));
+        assert_eq!(wildcard_listing_filter("MyApp.Sub.*"), Some("MyApp.Sub."));
+        assert_eq!(
+            wildcard_listing_filter("WebTerminal.C*"),
+            Some("WebTerminal.C")
+        );
+        // Mid-pattern star: the prefix is still everything before the FIRST `*`.
+        assert_eq!(wildcard_listing_filter("Pkg.*.Foo"), Some("Pkg."));
+        // The leading `%` of a system package must survive — in LIKE it only broadens.
+        assert_eq!(wildcard_listing_filter("%Pkg.*"), Some("%Pkg."));
+        // No wildcard at all: nothing to narrow (this path never fetches a listing).
+        assert_eq!(wildcard_listing_filter("MyApp.Foo"), None);
+    }
+
+    /// Unqualified patterns have no prefix. They are already refused before any fetch;
+    /// the helper must not answer `Some("")`, which would mean `Name Like '%%'`.
+    #[test]
+    fn wildcard_listing_filter_refuses_an_unqualified_pattern() {
+        assert_eq!(wildcard_listing_filter("*"), None);
+        assert_eq!(wildcard_listing_filter("*.cls"), None);
+        assert_eq!(wildcard_listing_filter("*Foo"), None);
+    }
+
+    /// #94 injection guard. `%Api.Atelier.v1:GetDocNames` builds `Name Like '%<filter>%'`
+    /// by STRING CONCATENATION, and a probe with `filter=%27` returned 200 with an EMPTY
+    /// content array — so an unguarded quote narrows WRONGLY rather than failing loudly,
+    /// i.e. a wildcard compile that silently skips classes. Rejection fails SAFE: no
+    /// filter, full listing, exactly today's behaviour.
+    #[test]
+    fn wildcard_listing_filter_rejects_anything_that_could_reach_the_like_clause() {
+        for pattern in [
+            "Foo'.*",
+            "Foo';--.*",
+            "Foo\".*",
+            "Foo /*x*/.*",
+            "Foo\n.*",
+            "Ens\u{00e9}.*",
+        ] {
+            assert_eq!(
+                wildcard_listing_filter(pattern),
+                None,
+                "'{pattern}' must fall back to the unfiltered listing"
+            );
+        }
+    }
 }
 
 #[cfg(test)]
@@ -7485,6 +8030,82 @@ mod docname_expansion_tests {
             {"cat":"CLS","db":"APP-CODE","gen":false,"name":"WebTerminal.Core.cls",
              "ts":"2026-08-01 09:00:00.000","upd":true}
         ]}})
+    }
+
+    /// #94 THE test that matters: the server-side `?filter=` narrowing must be a pure
+    /// SUPERSET of what the client regex selects, so every expansion outcome is unchanged.
+    ///
+    /// `filter=X` is `Name Like '%X%'` — a CONTAINS match — and `docname_pattern_regex` is
+    /// `(?i)^…$` anchored on the same literal prefix, so any name the regex matches begins
+    /// with that prefix, therefore contains it, therefore survives the filter. This test
+    /// simulates the server by keeping only the elements a `LIKE '%prefix%'` would keep,
+    /// then asserts the expansion is identical either way.
+    ///
+    /// `Pkg.*.Foo` is the load-bearing case: its prefix is `Pkg.` while its matches are
+    /// deeper, so it is what breaks FIRST if a future IRIS ever makes `filter` an anchored
+    /// or prefix match — flipping the relation to a subset and making a wildcard compile
+    /// silently skip documents while reporting success. If this test ever goes red, the
+    /// narrowing must be removed, not the assertion.
+    fn filtered_like_the_server_would(body: &serde_json::Value, prefix: &str) -> serde_json::Value {
+        // Case-insensitive, matching the measured behaviour of the Atelier LIKE filter.
+        let needle = prefix.to_lowercase();
+        let kept: Vec<serde_json::Value> = body["result"]["content"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .filter(|d| {
+                let name = d
+                    .as_str()
+                    .or_else(|| d.get("name").and_then(|n| n.as_str()))
+                    .unwrap();
+                name.to_lowercase().contains(&needle)
+            })
+            .cloned()
+            .collect();
+        serde_json::json!({"result": {"content": kept}})
+    }
+
+    /// A listing with enough shape to make narrowing observable: sub-packages, a system
+    /// class, and near-miss names that the filter keeps but the regex must still reject.
+    fn wide_body() -> serde_json::Value {
+        serde_json::json!({"result":{"content":[
+            {"cat":"CLS","name":"%Api.Atelier.v1.cls"},
+            {"cat":"CLS","name":"%Api.DocDB.v1.cls"},
+            {"cat":"CLS","name":"APPPKG.FoundationProduction.cls"},
+            {"cat":"CLS","name":"APPPKG.Sub.Helper.cls"},
+            {"cat":"CLS","name":"APPPKGX.NotMine.cls"},
+            {"cat":"CLS","name":"Pkg.Class.Foo.cls"},
+            {"cat":"CLS","name":"Pkg.Class.Bar.cls"},
+            {"cat":"CLS","name":"Pkg.Other.Foo.cls"},
+            {"cat":"CLS","name":"Pkg.Foo.cls"},
+            {"cat":"CLS","name":"Elsewhere.APPPKG.Shadow.cls"},
+            {"cat":"CLS","name":"WebTerminal.Common.cls"}
+        ]}})
+    }
+
+    #[test]
+    fn a_server_narrowed_listing_expands_to_exactly_the_same_documents() {
+        for body in [object_body(), wide_body()] {
+            for pattern in [
+                "APPPKG.*",
+                "APPPKG.*.cls",
+                "APPPKG.Sub.*",
+                "Pkg.Class.*",
+                "Pkg.*.Foo",
+                "%Api.*",
+                "WebTerminal.C*",
+                "ZZNOPKG.*",
+            ] {
+                let prefix = wildcard_listing_filter(pattern)
+                    .unwrap_or_else(|| panic!("'{pattern}' must yield a filter prefix"));
+                let narrowed = filtered_like_the_server_would(&body, prefix);
+                assert_eq!(
+                    expand_wildcard_target(&docnames_in_body(&body), pattern),
+                    expand_wildcard_target(&docnames_in_body(&narrowed), pattern),
+                    "'{pattern}': server-side narrowing changed the expansion"
+                );
+            }
+        }
     }
 
     /// The shape older builds return — the only one the old code handled. Must keep working.

--- a/crates/iris-agentic-dev-core/src/tools/skills_tools.rs
+++ b/crates/iris-agentic-dev-core/src/tools/skills_tools.rs
@@ -195,6 +195,27 @@ pub(crate) fn classify_skills_payload(raw: &str) -> Result<serde_json::Value, Sk
     })
 }
 
+/// #89: the skill count is the LENGTH of the array `skills_list_json_code` emits — never a
+/// fallback zero. `agent_info(what=stats)` used to run its OWN `write count` loop over
+/// `^SKILLS` and funnel every failure through
+/// `.unwrap_or_default().trim().parse().unwrap_or(0)`, so no IRIS_CONTAINER, a failed
+/// `docker exec` and a `<UNDEFINED>` all printed `skill_count: 0` with `success: true` —
+/// reproduced live against a registry that genuinely held 2 skills, in the same session
+/// where `skill(action=list)` correctly answered DOCKER_REQUIRED.
+///
+/// `[]` is a genuinely empty registry (0). Anything that is not an array means IRIS
+/// answered something we did not ask for: a parse failure, NOT an empty registry.
+/// Deliberately not `map_or(0, …)` — that is the same silent zero, one refactor from
+/// re-opening this issue.
+pub(crate) fn skills_count_from_payload(v: &serde_json::Value) -> Result<usize, SkillsReadError> {
+    v.as_array()
+        .map(Vec::len)
+        .ok_or_else(|| SkillsReadError::Unparseable {
+            raw: v.to_string().chars().take(400).collect(),
+            parse_error: "^SKILLS listing was not a JSON array".into(),
+        })
+}
+
 /// Turn a `SkillsReadError` into the envelope (issue #2 — one failure surface).
 /// `DOCKER_REQUIRED` is the code `skill_forget` already uses for an unreachable IRIS, so
 /// callers that branch on it keep working; `SKILLS_PARSE_FAILED` is new and says
@@ -594,46 +615,60 @@ fn default_limit() -> usize {
 
 pub async fn handle_agent_info(
     iris: &IrisConnection,
-    client: &reqwest::Client,
+    // #89: the ^SKILLS read goes through read_skills_json -> IrisConnection::execute
+    // (docker exec); no HTTP client is used. Kept for signature parity with the siblings.
+    _client: &reqwest::Client,
     p: AgentInfoParams,
     history: &std::sync::Mutex<VecDeque<ToolCallEntry>>,
 ) -> Result<rmcp::model::CallToolResult, rmcp::ErrorData> {
     match p.what.as_str() {
         "stats" => {
             let ns = skills_namespace(Some(iris));
-            let code = "set count=0 set key=\"\" for { set key=$order(^SKILLS(key)) quit:key=\"\"  set count=count+1 } write count";
-            let skill_count: usize = xecute(iris, client, code, &ns)
+            // #89: count what `skill(action=list)` lists — SAME builder, SAME namespace
+            // (#85), SAME classification (#119) — so the two tools can no longer disagree
+            // about the registry. This arm was the last ^SKILLS *reader* in the crate that
+            // bypassed read_skills_json, hardcoded the global instead of SKILLS_GLOBAL, and
+            // pinned every failure to 0 with success:true.
+            let code = skills_list_json_code(None, false);
+            let skill_count = match read_skills_json(iris, &code, &ns)
                 .await
-                .unwrap_or_default()
-                .trim()
-                .parse()
-                .unwrap_or(0);
-            let session_calls = history.lock().map(|h| h.len()).unwrap_or(0);
+                .and_then(|v| skills_count_from_payload(&v))
+            {
+                Ok(n) => n,
+                Err(e) => return skills_read_fail("agent_info(what=stats)", &ns, e),
+            };
+            // A poisoned mutex means another tool panicked holding the history; the deque
+            // itself is intact (record_call cannot leave it structurally invalid), so
+            // recover it rather than reporting "0 calls" — the same false zero again.
+            let session_calls = history.lock().unwrap_or_else(|e| e.into_inner()).len();
             ok_json(serde_json::json!({
                 "success": true,
                 "skill_count": skill_count,
                 "session_calls": session_calls,
                 "learning_enabled": learning_enabled(),
+                // #85: which registry the count came from. Every sibling reports these.
+                "namespace": ns,
+                "source": "^SKILLS",
             }))
         }
         "history" => {
             let limit = p.limit;
-            let calls: Vec<serde_json::Value> = history
-                .lock()
-                .map(|h| {
-                    h.iter()
-                        .rev()
-                        .take(limit)
-                        .map(|c| {
-                            serde_json::json!({
-                                "tool": c.tool,
-                                "success": c.success,
-                                "ago_secs": c.timestamp.elapsed().as_secs(),
-                            })
-                        })
-                        .collect()
+            // #89: same poison recovery — `.unwrap_or_default()` on the lock rendered an
+            // unreadable history as `calls: []` with success:true, i.e. "no history"
+            // instead of "history unreadable". Identical behaviour in every non-panic case.
+            let guard = history.lock().unwrap_or_else(|e| e.into_inner());
+            let calls: Vec<serde_json::Value> = guard
+                .iter()
+                .rev()
+                .take(limit)
+                .map(|c| {
+                    serde_json::json!({
+                        "tool": c.tool,
+                        "success": c.success,
+                        "ago_secs": c.timestamp.elapsed().as_secs(),
+                    })
                 })
-                .unwrap_or_default();
+                .collect();
             ok_json(serde_json::json!({"success": true, "calls": calls}))
         }
         other => err_json(
@@ -985,6 +1020,103 @@ mod objectscript_escaping_tests {
             classify_skills_payload("[]").unwrap(),
             serde_json::json!([])
         );
+    }
+
+    /// #89: a count is the LENGTH of the listing, never a fallback zero. The old stats arm
+    /// ran its own `write count` and funnelled every failure through
+    /// `.unwrap_or_default().trim().parse().unwrap_or(0)` — reproduced live saying
+    /// `skill_count: 0` about a registry that held 2 skills, in the same session where
+    /// `skill(action=list)` correctly answered DOCKER_REQUIRED.
+    #[test]
+    fn a_skill_count_is_the_array_length_never_a_fallback_zero() {
+        assert_eq!(
+            skills_count_from_payload(&serde_json::json!([
+                {"name": "a", "description": "x"},
+                {"name": "b", "description": "y"}
+            ]))
+            .unwrap(),
+            2
+        );
+        // An empty registry IS legitimately zero — that is the one true zero.
+        assert_eq!(
+            skills_count_from_payload(&serde_json::json!([])).unwrap(),
+            0
+        );
+        // Anything that is not an array is IRIS answering something we did not ask for.
+        // Deliberately not `map_or(0, ..)`: that is the same silent zero, one refactor from
+        // re-opening this issue.
+        for not_a_list in [
+            serde_json::json!({"found": 0}),
+            serde_json::json!("[]"),
+            serde_json::json!(0),
+            serde_json::json!(null),
+        ] {
+            match skills_count_from_payload(&not_a_list) {
+                Err(SkillsReadError::Unparseable { parse_error, .. }) => {
+                    assert!(parse_error.contains("not a JSON array"), "{parse_error}")
+                }
+                other => panic!("{not_a_list} must not be a count, got {other:?}"),
+            }
+        }
+    }
+
+    /// #89: the three states the old arm collapsed into `{"skill_count":0,"success":true}`.
+    /// No IRIS_CONTAINER and a failed `docker exec` (which reaches this crate as `Ok("")`)
+    /// are DOCKER_REQUIRED; garbage on the wire is SKILLS_PARSE_FAILED. In every case the
+    /// envelope must carry NO count at all — a caller that sees `skill_count` must be able
+    /// to trust it.
+    #[test]
+    fn an_unreadable_registry_is_never_a_count_of_zero() {
+        fn payload(r: &rmcp::model::CallToolResult) -> serde_json::Value {
+            let text = match &r.content[0].raw {
+                rmcp::model::RawContent::Text(t) => &t.text,
+                _ => panic!("expected text content"),
+            };
+            serde_json::from_str(text).unwrap()
+        }
+
+        for (raw, expected_code) in [
+            ("", "DOCKER_REQUIRED"),
+            ("   ", "DOCKER_REQUIRED"),
+            ("<SYNTAX>zRun+3^Foo", "SKILLS_PARSE_FAILED"),
+        ] {
+            let e = classify_skills_payload(raw)
+                .and_then(|v| skills_count_from_payload(&v).map(|_| ()))
+                .expect_err("none of these payloads is a readable registry");
+            let r = skills_read_fail("agent_info(what=stats)", "APP", e).unwrap();
+            assert_eq!(r.is_error, Some(true), "{raw:?}");
+            let v = payload(&r);
+            assert_eq!(v["error_code"], expected_code, "{v}");
+            assert!(v.get("skill_count").is_none(), "no count may survive: {v}");
+            let msg = v["error"].as_str().unwrap();
+            assert!(msg.contains("agent_info(what=stats)"), "{v}");
+            assert!(msg.contains("'APP'"), "#85: name the registry read: {v}");
+            assert_eq!(v["namespace"], "APP", "{v}");
+            assert_eq!(v["source"], "^SKILLS", "{v}");
+        }
+
+        // A payload that parses but is not a list is a parse failure, not a count: this is
+        // the leg `skills_count_from_payload` adds on top of #119's classification.
+        let e = classify_skills_payload("{\"found\":0}")
+            .and_then(|v| skills_count_from_payload(&v).map(|_| ()))
+            .expect_err("an object is not a listing");
+        let v = payload(&skills_read_fail("agent_info(what=stats)", "APP", e).unwrap());
+        assert_eq!(v["error_code"], "SKILLS_PARSE_FAILED", "{v}");
+    }
+
+    /// #89: stats must count what `skill(action=list)` lists — the SAME builder, so the two
+    /// tools can no longer disagree about the registry. The old arm had its own hand-rolled
+    /// `^SKILLS` reader, the last one in the crate to bypass `read_skills_json`.
+    #[test]
+    fn stats_and_skill_list_read_the_registry_the_same_way() {
+        let code = skills_list_json_code(None, false);
+        assert!(code.contains(SKILLS_GLOBAL), "{code}");
+        assert!(
+            !code.contains("write count"),
+            "the private `write count` reader is gone for good: {code}"
+        );
+        // Bodies stay out of a count.
+        assert!(!code.contains(r#""body":"#), "{code}");
     }
 
     /// #119 follow-up: the search haystack was `key_"|"_data`, and `data` is the

--- a/crates/iris-agentic-dev-core/tests/admin_unit_tests.rs
+++ b/crates/iris-agentic-dev-core/tests/admin_unit_tests.rs
@@ -15,9 +15,31 @@ fn result_text(r: &rmcp::model::CallToolResult) -> serde_json::Value {
 
 // ── T004/T030: ADMIN_WRITE_DISABLED without IRIS_ADMIN_TOOLS ─────────────────
 
+// #91: this was THREE `#[test]`s — `write_actions_disabled_without_env`,
+// `write_allowed_with_env_set` and `write_not_allowed_without_env` — and they RACED.
+// `IRIS_ADMIN_TOOLS` is process-global, cargo runs all three on parallel threads in this
+// one binary, and each one's `set_var`/`remove_var` lands inside another's window.
+// Measured before the merge: 7 of 12 `cargo test` runs red, and 10 of 25 raw-binary runs,
+// with BOTH directions observed — `write_allowed_with_env_set` (was :197) failing because
+// a sibling removed the var, and `write_not_allowed_without_env` (was :204) failing
+// because a sibling set it. The action loop is the third participant, not a bystander:
+// every `*_impl` consults the same variable through `admin_write_allowed`
+// (src/tools/admin.rs:422) before it looks at the connection.
+//
+// Merging them into one sequential function gives the binary exactly ONE env-var
+// timeline. Same fix and same rationale as #85 (tests/unit/test_skills_unit.rs:112).
+// No assertion is lost; each phase is labelled so a future red says which one failed.
 #[test]
-fn write_actions_disabled_without_env() {
+fn admin_write_env_gate() {
+    // ── phase 1: unset -> the helper itself says no ──────────────────────────
     std::env::remove_var("IRIS_ADMIN_TOOLS");
+    assert!(
+        !admin_write_allowed(),
+        "phase 1 (was write_not_allowed_without_env): admin_write_allowed() must be false \
+         with IRIS_ADMIN_TOOLS unset"
+    );
+
+    // ── phase 2: unset -> every write action refuses ─────────────────────────
     let rt = rt();
 
     let actions: &[&str] = &[
@@ -47,10 +69,22 @@ fn write_actions_disabled_without_env() {
         let v = result_text(&r);
         assert_eq!(
             v["error_code"], "ADMIN_WRITE_DISABLED",
-            "action '{}' should return ADMIN_WRITE_DISABLED without IRIS_ADMIN_TOOLS",
+            "phase 2 (was write_actions_disabled_without_env): action '{}' should return \
+             ADMIN_WRITE_DISABLED without IRIS_ADMIN_TOOLS",
             action
         );
     }
+
+    // ── phase 3: set -> the helper says yes ──────────────────────────────────
+    std::env::set_var("IRIS_ADMIN_TOOLS", "1");
+    assert!(
+        admin_write_allowed(),
+        "phase 3 (was write_allowed_with_env_set): admin_write_allowed() must be true with \
+         IRIS_ADMIN_TOOLS=1"
+    );
+
+    // Leave the process as we found it for anything that runs after us.
+    std::env::remove_var("IRIS_ADMIN_TOOLS");
 }
 
 // ── T005: list_users never contains password ──────────────────────────────────
@@ -191,15 +225,7 @@ fn webapp_type_inference() {
 
 // ── admin_write_allowed helper ────────────────────────────────────────────────
 
-#[test]
-fn write_allowed_with_env_set() {
-    std::env::set_var("IRIS_ADMIN_TOOLS", "1");
-    assert!(admin_write_allowed());
-    std::env::remove_var("IRIS_ADMIN_TOOLS");
-}
-
-#[test]
-fn write_not_allowed_without_env() {
-    std::env::remove_var("IRIS_ADMIN_TOOLS");
-    assert!(!admin_write_allowed());
-}
+// #91: `write_allowed_with_env_set` and `write_not_allowed_without_env` used to live here.
+// Both assertions survive, as phases 3 and 1 of `admin_write_env_gate` at the top of this
+// file — they cannot be separate `#[test]`s because they share one process-global variable
+// with each other and with the write-action loop. See the comment there.

--- a/crates/iris-agentic-dev-core/tests/integration/test_e2e.rs
+++ b/crates/iris-agentic-dev-core/tests/integration/test_e2e.rs
@@ -815,6 +815,37 @@ fn e2e_compile_wildcard_package() {
         compiled
     );
 
+    // Issue #94 — the ANTI-STALENESS regression. #94 narrows the /docnames listing
+    // server-side (`?filter=Test022.Wild.`) and DELIBERATELY does not cache it; this is the
+    // test that fails the day someone "optimises" a cache back in. Seed a THIRD class
+    // AFTER the wildcard compile above has already run, then compile the same wildcard
+    // again: a cached listing would answer from the previous expansion, silently skip
+    // Gamma, and still report success:true with a count that looks plausible.
+    let name_c = "Test022.Wild.Gamma.cls";
+    call_tool(
+        "iris_doc",
+        serde_json::json!({"mode":"put","name":name_c,
+            "content":"Class Test022.Wild.Gamma { ClassMethod Run() As %String { Return \"c\" } }",
+            "namespace":"USER"}),
+    );
+    let again = call_tool(
+        "iris_compile",
+        serde_json::json!({"target":"Test022.Wild.*.cls","namespace":"USER","flags":"ck"}),
+    );
+    assert!(
+        again["success"] == true,
+        "re-running the wildcard must succeed: {}",
+        again
+    );
+    assert_eq!(
+        again["targets_compiled"].as_u64().unwrap_or(0),
+        compiled + 1,
+        "the wildcard must expand to EXACTLY one more document than before — a class \
+         written AFTER the previous wildcard compile has to be seen immediately, and a \
+         stale listing here is a silent wrong answer reported as success: {}",
+        again
+    );
+
     // Cleanup
     call_tool(
         "iris_doc",
@@ -823,6 +854,10 @@ fn e2e_compile_wildcard_package() {
     call_tool(
         "iris_doc",
         serde_json::json!({"mode":"delete","name":name_b,"namespace":"USER"}),
+    );
+    call_tool(
+        "iris_doc",
+        serde_json::json!({"mode":"delete","name":name_c,"namespace":"USER"}),
     );
 }
 

--- a/crates/iris-agentic-dev-core/tests/skills_tests.rs
+++ b/crates/iris-agentic-dev-core/tests/skills_tests.rs
@@ -10,61 +10,196 @@ fn registry_starts_empty() {
     assert_eq!(registry.list_skills().len(), 0);
 }
 
-/// load_from_github with invalid repo gracefully fails.
+// ── #92: the subscription path, offline ───────────────────────────────────────
+//
+// These two tests used to reach raw.githubusercontent.com unconditionally on every
+// required-gate run — 3 live GETs — and, worse, asserted NOTHING: both ended in
+// `let _ = result;`, so a GitHub outage, a 429 or a DNS hijack passed them just as
+// happily as a correct answer. That is the same fake-coverage pathology #87 removed
+// from manifest_tests. They now drive `load_from_github_at` against a wiremock server
+// on localhost and assert on the actual outcome.
+use wiremock::matchers::{method, path};
+use wiremock::{Mock, MockServer, ResponseTemplate};
+
+/// A 404 manifest must surface WHY it failed, naming the repo.
 #[tokio::test]
-async fn load_invalid_repo_returns_error() {
-    let mut registry = SkillRegistry::new();
-    // nonexistent repo should return Ok (graceful) or Err — never panic
-    let result = registry
-        .load_from_github("nonexistent/repo-that-does-not-exist-xyzzy")
+async fn load_invalid_repo_returns_error_offline() {
+    let server = MockServer::start().await;
+    // Every path 404s — the shape of a repo with no manifest at its root.
+    Mock::given(method("GET"))
+        .respond_with(ResponseTemplate::new(404))
+        .mount(&server)
         .await;
-    // Accept either outcome — the important thing is no panic
-    let _ = result;
-}
 
-/// Multiple subscriptions accumulate independently.
-#[tokio::test]
-async fn multiple_subscriptions_accumulate() {
     let mut registry = SkillRegistry::new();
-    // Both loads fail gracefully on nonexistent repos
-    let _ = registry.load_from_github("owner1/repo1").await;
-    let _ = registry.load_from_github("owner2/repo2").await;
-    // Registry should not have grown (both failed) — just verify no panic
-    let _ = registry.list_skills().len();
+    let err = registry
+        .load_from_github_at(&server.uri(), "nonexistent/repo-that-does-not-exist-xyzzy")
+        .await
+        .expect_err("a repo with no iris-agentic-dev.toml must be an Err");
+
+    let msg = format!("{:#}", err);
+    assert!(
+        msg.contains("no iris-agentic-dev.toml found"),
+        "error must say what was missing, got: {msg}"
+    );
+    assert!(
+        msg.contains("nonexistent") && msg.contains("repo-that-does-not-exist-xyzzy"),
+        "error must name the owner/repo, got: {msg}"
+    );
+    assert_eq!(
+        registry.list_skills().len(),
+        0,
+        "a failed load must not leave partial skills behind"
+    );
 }
 
-/// E2e test: subscribe to the real intersystems-community/vscode-objectscript-mcp package.
-/// Requires network access. Skipped in CI unless IRIS_DEV_NETWORK_TESTS=1.
+/// Two successful subscriptions accumulate, and each skill remembers its own source repo.
 #[tokio::test]
-async fn e2e_subscribe_to_iris_vector_rag() {
-    if std::env::var("IRIS_DEV_NETWORK_TESTS").as_deref() != Ok("1") {
+async fn multiple_subscriptions_accumulate_offline() {
+    let server = MockServer::start().await;
+
+    for (owner, repo, skill) in [
+        ("owner1", "repo1", "alpha-skill"),
+        ("owner2", "repo2", "beta-skill"),
+    ] {
+        Mock::given(method("GET"))
+            .and(path(format!("/{owner}/{repo}/HEAD/iris-agentic-dev.toml")))
+            .respond_with(ResponseTemplate::new(200).set_body_string(format!(
+                r#"
+[package]
+name = "{repo}"
+version = "1.0.0"
+[provides]
+skills = ["skills/{skill}"]
+kb_items = ["kb/{skill}-notes.md"]
+"#
+            )))
+            .mount(&server)
+            .await;
+        Mock::given(method("GET"))
+            .and(path(format!(
+                "/{owner}/{repo}/HEAD/skills/{skill}/SKILL.md"
+            )))
+            .respond_with(ResponseTemplate::new(200).set_body_string(format!(
+                "---\nname: {skill}\ndescription: a mocked skill\n---\n\n# {skill}\n"
+            )))
+            .mount(&server)
+            .await;
+        Mock::given(method("GET"))
+            .and(path(format!("/{owner}/{repo}/HEAD/kb/{skill}-notes.md")))
+            .respond_with(ResponseTemplate::new(200).set_body_string(format!(
+                "---\ntitle: {skill} notes\n---\n\nmocked kb body\n"
+            )))
+            .mount(&server)
+            .await;
+    }
+
+    let mut registry = SkillRegistry::new();
+    registry
+        .load_from_github_at(&server.uri(), "owner1/repo1")
+        .await
+        .expect("first subscription should load");
+    registry
+        .load_from_github_at(&server.uri(), "owner2/repo2")
+        .await
+        .expect("second subscription should load");
+
+    // The point of the test: the second load ADDS to the first, it does not replace it.
+    assert_eq!(
+        registry.list_skills().len(),
+        2,
+        "two subscriptions must accumulate"
+    );
+    let names: Vec<&str> = registry.list_skills().iter().map(|s| &*s.name).collect();
+    assert!(names.contains(&"alpha-skill"), "got: {names:?}");
+    assert!(names.contains(&"beta-skill"), "got: {names:?}");
+
+    let repos: Vec<&str> = registry
+        .list_skills()
+        .iter()
+        .map(|s| &*s.source_repo)
+        .collect();
+    assert!(repos.contains(&"owner1/repo1"), "got: {repos:?}");
+    assert!(repos.contains(&"owner2/repo2"), "got: {repos:?}");
+
+    // #92 follow-up: retargeting the live canary dropped the only assertion covering the
+    // kb-item fetch/registration path (the new target publishes no kb_items), and the
+    // offline replacement did not pick it up — leaving load_from_github -> list_kb_items
+    // asserted nowhere. Only kb_items TOML *parsing* was still covered.
+    let kb_titles: Vec<&str> = registry.list_kb_items().iter().map(|k| &*k.title).collect();
+    assert_eq!(
+        kb_titles.len(),
+        2,
+        "kb items must accumulate too: {kb_titles:?}"
+    );
+    assert!(
+        kb_titles.contains(&"alpha-skill notes"),
+        "the frontmatter title must be used: {kb_titles:?}"
+    );
+}
+
+// ── #92: the live canary ──────────────────────────────────────────────────────
+
+// Copy of `live_github_enabled` from tests/manifest_tests.rs:209 — integration-test
+// binaries are separate crates and cannot share a helper without a tests/common/mod.rs.
+// Keep the two in step if either changes.
+//
+// Reuses #87's IRIS_DEV_LIVE_GITHUB rather than keeping a second flag name
+// (IRIS_DEV_NETWORK_TESTS, now retired) for the same concept.
+fn live_github_enabled() -> bool {
+    let on = std::env::var("IRIS_DEV_LIVE_GITHUB")
+        .map(|v| {
+            let v = v.trim().to_ascii_lowercase();
+            !v.is_empty() && v != "0" && v != "false"
+        })
+        .unwrap_or(false);
+    if !on {
+        eprintln!(
+            "SKIP: live GitHub subscription canary — set IRIS_DEV_LIVE_GITHUB=1 to run it. \
+             Offline coverage of the same logic runs unconditionally in the *_offline tests."
+        );
+    }
+    on
+}
+
+/// Live canary: subscribe to a real package over the real network. Advisory only.
+///
+/// RETARGETED (#92). This was `e2e_subscribe_to_iris_vector_rag`, pointed at
+/// intersystems-community/iris-vector-rag — which publishes no manifest: the URL returns
+/// HTTP 404, so the test FAILED whenever it was actually enabled, and its
+/// `IRIS_DEV_NETWORK_TESTS` guard meant nobody saw that between v0.5.0 (7eb8b96) and now.
+/// Upstream's own iris-agentic-dev.toml records the cause — iris-vector-graph and
+/// iris-vector-rag "moved to their own repos (commit 1fb7a8c) — do not re-add here, the
+/// paths 404 on install."
+///
+/// It now points at intersystems-community/iris-agentic-dev, whose root manifest returns
+/// 200 and lists ~35 skills. Assertions are deliberately LOOSE — two long-standing skill
+/// names and a lower bound, not an exact count — because this depends on an upstream
+/// repo's file staying put, and a brittle assertion here would rot the same way.
+#[tokio::test]
+async fn live_subscribe_canary() {
+    if !live_github_enabled() {
         return;
     }
     let mut registry = SkillRegistry::new();
     registry
-        .load_from_github("intersystems-community/iris-vector-rag")
+        .load_from_github("intersystems-community/iris-agentic-dev")
         .await
-        .expect("should load iris-vector-rag package");
+        .expect("should load the iris-agentic-dev skill pack");
+
+    let names: Vec<&str> = registry.list_skills().iter().map(|s| &*s.name).collect();
     assert!(
-        registry.list_skills().len() >= 2,
-        "should have at least 2 skills"
+        names.len() >= 10,
+        "expected the published skill pack, got {} skills: {names:?}",
+        names.len()
     );
     assert!(
-        !registry.list_kb_items().is_empty(),
-        "should have at least 1 KB item"
-    );
-    let names: Vec<_> = registry
-        .list_skills()
-        .iter()
-        .map(|s| s.name.as_str())
-        .collect();
-    assert!(
-        names.contains(&"iris-rag-pipeline"),
-        "iris-rag-pipeline skill must be present"
+        names.contains(&"objectscript-review"),
+        "objectscript-review must be present, got: {names:?}"
     );
     assert!(
-        names.contains(&"iris-vector-search"),
-        "iris-vector-search skill must be present"
+        names.contains(&"iris-sql"),
+        "iris-sql must be present, got: {names:?}"
     );
 }
 
@@ -94,4 +229,104 @@ kb_items = ["kb/iris-vector-patterns.md"]
     let provides = manifest.provides.unwrap();
     assert_eq!(provides.skills.len(), 2);
     assert_eq!(provides.kb_items.len(), 1);
+}
+
+// ── Issue #89: agent_info(what=stats) must never invent a count ───────────────
+
+/// #89 regression test, exactly as filed: `agent_info(what=stats)` reported
+/// `{"skill_count":0,"success":true}` while `skill(action=list)` in the SAME session
+/// answered `DOCKER_REQUIRED` — reproduced live against a registry that genuinely held 2
+/// skills. `IrisConnection::execute` is docker-exec ONLY, so with no `IRIS_CONTAINER` the
+/// read fails before anything is dialled or spawned: this test touches neither the network
+/// nor docker.
+///
+/// ONE `#[test]` on purpose — `IRIS_CONTAINER` is process-global and cargo runs tests in
+/// parallel threads, so splitting the sub-cases would race (same rule as
+/// `skills_namespace_fallback_chain`).
+#[test]
+fn agent_info_stats_reports_unreachable_not_a_count_of_zero() {
+    use iris_agentic_dev_core::iris::connection::{DiscoverySource, IrisConnection};
+    use iris_agentic_dev_core::tools::skills_tools::{handle_agent_info, AgentInfoParams};
+
+    fn payload(r: &rmcp::model::CallToolResult) -> serde_json::Value {
+        let text = match &r.content[0].raw {
+            rmcp::model::RawContent::Text(t) => &t.text,
+            _ => panic!("expected text content"),
+        };
+        serde_json::from_str(text).unwrap()
+    }
+
+    std::env::remove_var("IRIS_CONTAINER");
+    std::env::remove_var("OBJECTSCRIPT_SKILLMCP_NAMESPACE");
+
+    let rt = tokio::runtime::Builder::new_current_thread()
+        .enable_all()
+        .build()
+        .unwrap();
+    // RFC 2606 `.invalid` host so a future edit cannot accidentally point this at the
+    // maintainer's live dev IRIS.
+    let iris = IrisConnection::new(
+        "http://never-dialled.invalid",
+        "APP",
+        "_SYSTEM",
+        "SYS",
+        DiscoverySource::EnvVar,
+    );
+    let client = reqwest::Client::new();
+    let history = std::sync::Mutex::new(std::collections::VecDeque::new());
+
+    rt.block_on(async {
+        // 1. The issue itself: an unreadable registry is an ERROR, not a count of zero.
+        let r = handle_agent_info(
+            &iris,
+            &client,
+            AgentInfoParams {
+                what: "stats".into(),
+                limit: 20,
+            },
+            &history,
+        )
+        .await
+        .unwrap();
+        assert_eq!(r.is_error, Some(true), "a false zero is not success");
+        let v = payload(&r);
+        assert_eq!(v["error_code"], "DOCKER_REQUIRED", "{v}");
+        assert!(v.get("skill_count").is_none(), "no count may survive: {v}");
+        // #85: say WHICH registry — the count resolves from the connection (APP, not USER).
+        assert_eq!(v["namespace"], "APP", "{v}");
+        assert_eq!(v["source"], "^SKILLS", "{v}");
+
+        // 2. what=history touches no connection and must NOT be dragged into the failure.
+        let r = handle_agent_info(
+            &iris,
+            &client,
+            AgentInfoParams {
+                what: "history".into(),
+                limit: 20,
+            },
+            &history,
+        )
+        .await
+        .unwrap();
+        assert_eq!(r.is_error, Some(false), "history needs no IRIS");
+        let v = payload(&r);
+        assert_eq!(v["success"], true, "{v}");
+        assert_eq!(v["calls"], serde_json::json!([]), "{v}");
+
+        // 3. An unknown `what` is still a parameter error, not a registry error.
+        let r = handle_agent_info(
+            &iris,
+            &client,
+            AgentInfoParams {
+                what: "bogus".into(),
+                limit: 20,
+            },
+            &history,
+        )
+        .await
+        .unwrap();
+        assert_eq!(payload(&r)["error_code"], "INVALID_PARAM");
+    });
+
+    std::env::remove_var("IRIS_CONTAINER");
 }

--- a/crates/iris-agentic-dev-core/tests/unit/test_generate_unit.rs
+++ b/crates/iris-agentic-dev-core/tests/unit/test_generate_unit.rs
@@ -231,59 +231,66 @@ fn test_retry_template_contains_errors_placeholder() {
 
 // ── LlmClient::from_env ──────────────────────────────────────────────────────
 
+// #95: this was FOUR `#[test]`s — `test_llm_client_from_env_none_when_model_unset`,
+// `..._none_when_api_key_unset`, `..._some_when_both_set` and
+// `..._anthropic_key_accepted` — and they RACED, the same defect as #91.
+// `IRIS_GENERATE_CLASS_MODEL`, `OPENAI_API_KEY` and `ANTHROPIC_API_KEY` are
+// process-global; cargo runs all four on parallel threads in this one binary.
+//
+// Found by running the widened gate three times rather than once — the first two runs
+// were green. Reproduced afterwards at 2 of 40 raw-binary runs, failing at what was
+// :283 with "should return Some when model and ANTHROPIC_API_KEY are set": the
+// `remove_var("IRIS_GENERATE_CLASS_MODEL")` in the model-unset test lands between the
+// anthropic test's `set_var` and its `LlmClient::from_env()` read, so `from_env` sees no
+// model and correctly returns None. Every ordering of the four has a losing interleaving.
+//
+// The low rate is the point: at 5% this would have read as an unrelated infrastructure
+// blip for months. Merging into one sequential function gives the binary exactly ONE
+// env-var timeline. No assertion is lost; each phase is labelled so a future red says
+// which one failed.
 #[test]
-fn test_llm_client_from_env_none_when_model_unset() {
+fn llm_client_from_env_gate() {
     use iris_agentic_dev_core::generate::LlmClient;
-    std::env::remove_var("IRIS_GENERATE_CLASS_MODEL");
-    // OPENAI_API_KEY may or may not be set — without the model var, must return None
-    let client = LlmClient::from_env();
-    assert!(
-        client.is_none(),
-        "should be None when IRIS_GENERATE_CLASS_MODEL is unset"
-    );
-}
 
-#[test]
-fn test_llm_client_from_env_none_when_api_key_unset() {
-    use iris_agentic_dev_core::generate::LlmClient;
+    // ── phase 1: no model -> None, whatever the keys say ─────────────────────
+    std::env::remove_var("IRIS_GENERATE_CLASS_MODEL");
+    std::env::set_var("OPENAI_API_KEY", "sk-test-key");
+    assert!(
+        LlmClient::from_env().is_none(),
+        "phase 1 (was test_llm_client_from_env_none_when_model_unset): should be None when \
+         IRIS_GENERATE_CLASS_MODEL is unset, even with a key present"
+    );
+
+    // ── phase 2: model but no key -> None ────────────────────────────────────
     std::env::set_var("IRIS_GENERATE_CLASS_MODEL", "gpt-4o");
     std::env::remove_var("OPENAI_API_KEY");
     std::env::remove_var("ANTHROPIC_API_KEY");
-    let client = LlmClient::from_env();
-    // If no API key is available, should return None
-    // (model is set but key is missing)
     assert!(
-        client.is_none(),
-        "should be None when both OPENAI_API_KEY and ANTHROPIC_API_KEY are unset"
+        LlmClient::from_env().is_none(),
+        "phase 2 (was test_llm_client_from_env_none_when_api_key_unset): should be None when \
+         both OPENAI_API_KEY and ANTHROPIC_API_KEY are unset"
     );
-    std::env::remove_var("IRIS_GENERATE_CLASS_MODEL");
-}
 
-#[test]
-fn test_llm_client_from_env_some_when_both_set() {
-    use iris_agentic_dev_core::generate::LlmClient;
-    std::env::set_var("IRIS_GENERATE_CLASS_MODEL", "gpt-4o");
+    // ── phase 3: model + OpenAI key -> Some ──────────────────────────────────
     std::env::set_var("OPENAI_API_KEY", "sk-test-key");
-    let client = LlmClient::from_env();
     assert!(
-        client.is_some(),
-        "should return Some when model and API key are set"
+        LlmClient::from_env().is_some(),
+        "phase 3 (was test_llm_client_from_env_some_when_both_set): should return Some when \
+         model and OPENAI_API_KEY are set"
     );
-    std::env::remove_var("IRIS_GENERATE_CLASS_MODEL");
-    std::env::remove_var("OPENAI_API_KEY");
-}
 
-#[test]
-fn test_llm_client_from_env_anthropic_key_accepted() {
-    use iris_agentic_dev_core::generate::LlmClient;
+    // ── phase 4: model + Anthropic key, no OpenAI key -> Some ────────────────
     std::env::set_var("IRIS_GENERATE_CLASS_MODEL", "claude-3-5-sonnet-20241022");
     std::env::remove_var("OPENAI_API_KEY");
     std::env::set_var("ANTHROPIC_API_KEY", "sk-ant-test-key");
-    let client = LlmClient::from_env();
     assert!(
-        client.is_some(),
-        "should return Some when model and ANTHROPIC_API_KEY are set"
+        LlmClient::from_env().is_some(),
+        "phase 4 (was test_llm_client_from_env_anthropic_key_accepted): should return Some \
+         when model and ANTHROPIC_API_KEY are set"
     );
+
+    // Leave the process as we found it for anything that runs after us.
     std::env::remove_var("IRIS_GENERATE_CLASS_MODEL");
+    std::env::remove_var("OPENAI_API_KEY");
     std::env::remove_var("ANTHROPIC_API_KEY");
 }

--- a/crates/iris-agentic-dev-core/tests/unit/test_search_unit.rs
+++ b/crates/iris-agentic-dev-core/tests/unit/test_search_unit.rs
@@ -30,7 +30,12 @@ fn test_search_params_full() {
     )
     .unwrap();
     assert_eq!(p.query, "Director");
-    assert_eq!(p.namespace, None); // omitted -> resolved to the connection namespace at call time
+    // #90: the literal above SETS this field, so it must survive as Some. "USER" is
+    // deliberately `resolve_namespace`'s own fallback string (src/tools/interop.rs): this
+    // pins that serde does not special-case it, i.e. an explicitly requested USER still
+    // overrides a connection sitting on another namespace. Omitted -> None is covered by
+    // test_search_params_minimal; a non-default value by test_search_params_custom_namespace.
+    assert_eq!(p.namespace.as_deref(), Some("USER"));
     assert!(p.regex);
     assert!(!p.case_sensitive);
     assert_eq!(p.category.as_deref(), Some("CLS"));

--- a/crates/iris-agentic-dev-core/tests/unit/test_workspace_config.rs
+++ b/crates/iris-agentic-dev-core/tests/unit/test_workspace_config.rs
@@ -11,10 +11,54 @@ fn write_toml(dir: &tempfile::TempDir, contents: &str) {
     f.write_all(contents.as_bytes()).unwrap();
 }
 
+// ── Env serialisation (#95) ───────────────────────────────────────────────────
+//
+// This file was red on 7 of 15 `cargo test` runs before this guard, the same defect as
+// #91: process-global env vars read and written by tests that cargo runs on parallel
+// threads in one binary. The observed failure was a CROSS-VARIABLE leak —
+// `test_https_scheme_in_base_url` saw `https://iris.example.com:443/myprefix`, i.e. an
+// `IRIS_WEB_PREFIX` set by a web-prefix test bled into a scheme test.
+//
+// The treatment differs from #91's merge-into-one-function on purpose: #91 had three
+// tests on one variable, which merge cleanly. Here there are five variables across 23
+// tests and the leaks cross variable boundaries, so merging would mean one unreadable
+// mega-test. A serialising guard that also resets every key keeps the test names.
+//
+// The guard clears SEVEN keys, not the five the tests mention directly:
+// `workspace_config_to_connection` (src/iris/workspace_config.rs:247-253) SETS
+// `IRIS_NAMESPACE`, `IRIS_USERNAME` and `IRIS_PASSWORD` as a side effect of merely being
+// called, so a test that never names them still leaves them behind for the next one.
+//
+// Every test that calls `workspace_config_to_connection`, `load_workspace_config` or
+// `workspace_root` takes the guard — including the `load_*` tests that pass an explicit
+// directory, because `workspace_root` (:39-44) consults `OBJECTSCRIPT_WORKSPACE` BEFORE
+// the path argument: a racing `set_var` makes them read the wrong directory entirely.
+// The `generate_toml_*` and `score_*` tests touch no env and are deliberately unguarded.
+static ENV_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
+
+fn env_guard() -> std::sync::MutexGuard<'static, ()> {
+    // `into_inner`: a panicking test must not poison the mutex and turn one real failure
+    // into twenty-two misleading ones.
+    let g = ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+    for k in [
+        "OBJECTSCRIPT_WORKSPACE",
+        "IRIS_NAMESPACE",
+        "IRIS_CONTAINER",
+        "IRIS_WEB_PREFIX",
+        "IRIS_SCHEME",
+        "IRIS_USERNAME",
+        "IRIS_PASSWORD",
+    ] {
+        std::env::remove_var(k);
+    }
+    g
+}
+
 // ── T004: Core loading tests ──────────────────────────────────────────────────
 
 #[test]
 fn test_load_returns_none_when_no_file() {
+    let _g = env_guard();
     let result = load_workspace_config(Some("/nonexistent/path/that/cannot/exist"));
     assert!(
         result.is_none(),
@@ -24,6 +68,7 @@ fn test_load_returns_none_when_no_file() {
 
 #[test]
 fn test_load_parses_container_field() {
+    let _g = env_guard();
     let dir = tempfile::TempDir::new().unwrap();
     write_toml(&dir, r#"container = "test-iris""#);
     let cfg = load_workspace_config(Some(dir.path().to_str().unwrap())).unwrap();
@@ -32,6 +77,7 @@ fn test_load_parses_container_field() {
 
 #[test]
 fn test_load_parses_all_fields() {
+    let _g = env_guard();
     let dir = tempfile::TempDir::new().unwrap();
     write_toml(
         &dir,
@@ -55,6 +101,7 @@ password = "mypass"
 
 #[test]
 fn test_load_returns_none_on_syntax_error() {
+    let _g = env_guard();
     let dir = tempfile::TempDir::new().unwrap();
     write_toml(&dir, "this is not valid toml = = = !!!");
     let result = load_workspace_config(Some(dir.path().to_str().unwrap()));
@@ -66,6 +113,7 @@ fn test_load_returns_none_on_syntax_error() {
 
 #[test]
 fn test_load_uses_cwd_when_workspace_none() {
+    let _g = env_guard();
     // Call with None from a temp dir that has no .iris-dev.toml
     let dir = tempfile::TempDir::new().unwrap();
     let result = load_workspace_config(Some(dir.path().to_str().unwrap()));
@@ -74,6 +122,7 @@ fn test_load_uses_cwd_when_workspace_none() {
 
 #[test]
 fn test_workspace_root_uses_env_var() {
+    let _g = env_guard();
     // Note: env var tests can be flaky if run in parallel; use a unique key.
     // We only test the logic — the env var takes precedence over the path arg.
     let tmp = tempfile::TempDir::new().unwrap();
@@ -90,6 +139,7 @@ fn test_workspace_root_uses_env_var() {
 
 #[test]
 fn test_workspace_root_uses_path_when_no_env_var() {
+    let _g = env_guard();
     std::env::remove_var("OBJECTSCRIPT_WORKSPACE");
     let root = workspace_root(Some("/explicit/path"));
     assert_eq!(root.to_str().unwrap(), "/explicit/path");
@@ -99,6 +149,7 @@ fn test_workspace_root_uses_path_when_no_env_var() {
 
 #[test]
 fn test_workspace_config_host_returns_connection() {
+    let _g = env_guard();
     let dir = tempfile::TempDir::new().unwrap();
     write_toml(&dir, r#"host = "remotehost"\nweb_port = 9999"#);
     // Parse manually since \n in raw string literal doesn't give newline
@@ -127,6 +178,7 @@ fn test_workspace_config_host_returns_connection() {
 
 #[test]
 fn test_workspace_config_namespace_applied() {
+    let _g = env_guard();
     // Container config sets IRIS_NAMESPACE env var
     std::env::remove_var("IRIS_NAMESPACE");
     let cfg = iris_agentic_dev_core::iris::workspace_config::WorkspaceConfig {
@@ -146,6 +198,7 @@ fn test_workspace_config_namespace_applied() {
 
 #[test]
 fn test_workspace_config_sets_iris_container_env() {
+    let _g = env_guard();
     std::env::remove_var("IRIS_CONTAINER");
     let cfg = iris_agentic_dev_core::iris::workspace_config::WorkspaceConfig {
         container: Some("mytest-iris".to_string()),
@@ -164,6 +217,7 @@ fn test_workspace_config_sets_iris_container_env() {
 
 #[test]
 fn test_compile_workspace_config_overrides_env() {
+    let _g = env_guard();
     // Set IRIS_CONTAINER to an "old" value via env
     std::env::set_var("IRIS_CONTAINER", "old-container");
 
@@ -258,6 +312,7 @@ fn test_workspace_config_field_shape() {
 
 #[test]
 fn test_load_parses_web_prefix_field() {
+    let _g = env_guard();
     let dir = tempfile::TempDir::new().unwrap();
     write_toml(
         &dir,
@@ -273,6 +328,7 @@ web_prefix = "irisaicore"
 
 #[test]
 fn test_web_prefix_included_in_base_url() {
+    let _g = env_guard();
     let cfg = iris_agentic_dev_core::iris::workspace_config::WorkspaceConfig {
         host: Some("localhost".to_string()),
         web_port: Some(80),
@@ -289,6 +345,7 @@ fn test_web_prefix_included_in_base_url() {
 
 #[test]
 fn test_web_prefix_strips_leading_trailing_slashes() {
+    let _g = env_guard();
     let cfg = iris_agentic_dev_core::iris::workspace_config::WorkspaceConfig {
         host: Some("localhost".to_string()),
         web_port: Some(52773),
@@ -305,6 +362,7 @@ fn test_web_prefix_strips_leading_trailing_slashes() {
 
 #[test]
 fn test_no_web_prefix_gives_clean_base_url() {
+    let _g = env_guard();
     std::env::remove_var("IRIS_WEB_PREFIX");
     let cfg = iris_agentic_dev_core::iris::workspace_config::WorkspaceConfig {
         host: Some("localhost".to_string()),
@@ -322,6 +380,7 @@ fn test_no_web_prefix_gives_clean_base_url() {
 
 #[test]
 fn test_iris_web_prefix_env_var_used_when_no_toml_prefix() {
+    let _g = env_guard();
     std::env::set_var("IRIS_WEB_PREFIX", "myprefix");
     let cfg = iris_agentic_dev_core::iris::workspace_config::WorkspaceConfig {
         host: Some("localhost".to_string()),
@@ -340,6 +399,7 @@ fn test_iris_web_prefix_env_var_used_when_no_toml_prefix() {
 
 #[test]
 fn test_toml_web_prefix_overrides_env_var() {
+    let _g = env_guard();
     std::env::set_var("IRIS_WEB_PREFIX", "envprefix");
     let cfg = iris_agentic_dev_core::iris::workspace_config::WorkspaceConfig {
         host: Some("localhost".to_string()),
@@ -370,6 +430,7 @@ fn test_generate_toml_contains_web_prefix_comment() {
 
 #[test]
 fn test_load_parses_scheme_field() {
+    let _g = env_guard();
     let dir = tempfile::TempDir::new().unwrap();
     write_toml(
         &dir,
@@ -385,6 +446,7 @@ scheme = "https"
 
 #[test]
 fn test_https_scheme_in_base_url() {
+    let _g = env_guard();
     std::env::remove_var("IRIS_SCHEME");
     let cfg = iris_agentic_dev_core::iris::workspace_config::WorkspaceConfig {
         host: Some("iris.example.com".to_string()),
@@ -403,6 +465,7 @@ fn test_https_scheme_in_base_url() {
 
 #[test]
 fn test_https_scheme_with_prefix() {
+    let _g = env_guard();
     std::env::remove_var("IRIS_SCHEME");
     let cfg = iris_agentic_dev_core::iris::workspace_config::WorkspaceConfig {
         host: Some("dem".to_string()),
@@ -421,6 +484,7 @@ fn test_https_scheme_with_prefix() {
 
 #[test]
 fn test_default_scheme_is_http() {
+    let _g = env_guard();
     std::env::remove_var("IRIS_SCHEME");
     let cfg = iris_agentic_dev_core::iris::workspace_config::WorkspaceConfig {
         host: Some("localhost".to_string()),
@@ -438,6 +502,7 @@ fn test_default_scheme_is_http() {
 
 #[test]
 fn test_iris_scheme_env_var() {
+    let _g = env_guard();
     std::env::set_var("IRIS_SCHEME", "https");
     let cfg = iris_agentic_dev_core::iris::workspace_config::WorkspaceConfig {
         host: Some("localhost".to_string()),
@@ -456,6 +521,7 @@ fn test_iris_scheme_env_var() {
 
 #[test]
 fn test_toml_scheme_overrides_env_var() {
+    let _g = env_guard();
     std::env::set_var("IRIS_SCHEME", "http");
     let cfg = iris_agentic_dev_core::iris::workspace_config::WorkspaceConfig {
         host: Some("localhost".to_string()),

--- a/scripts/ci-test-targets.sh
+++ b/scripts/ci-test-targets.sh
@@ -1,0 +1,88 @@
+#!/usr/bin/env bash
+#
+# Emit the `--test <name>` flags for the required CI gate (#95).
+#
+# THE RULE: the gate runs EVERY test target the workspace declares or auto-discovers,
+# minus the explicit opt-outs below. A newly added test target is therefore covered by
+# default — you do not have to remember to add it anywhere.
+#
+# If you are adding a test target that CANNOT run in CI (needs a live IRIS, a container,
+# or the network), you have two options, in order of preference:
+#   1. Mark the individual tests `#[ignore = "requires <what>"]`. This is what the live
+#      IRIS e2e targets do; they stay in the gate, cost ~0s, and self-document.
+#   2. If the whole target is unrunnable, add it to EXCLUDED below WITH A REASON.
+#
+# Targets are read from `cargo metadata`, not from Cargo.toml, on purpose: transport_e2e
+# is auto-discovered from tests/*.rs and appears in no [[test]] block, so a hand-kept list
+# could never see it. That is exactly the blind spot #95 exists to close.
+
+set -euo pipefail
+
+# Run from the workspace root whatever the caller's cwd is: `cargo metadata` below
+# resolves Cargo.toml from the cwd, and from a subdirectory it dies with a JSON decode
+# traceback rather than anything readable. Actions runs steps from the root; humans do not.
+cd "$(dirname "${BASH_SOURCE[0]}")/.."
+
+# ── THE OPT-OUT LIST — the single readable place. One entry, one reason. ──────────
+#
+# docker_discovery_e2e: `docker run`s real intersystemsdc/iris-community images, sleeps
+#   25s per container, and then `docker exec ... iris session iris -U %SYS
+#   ##class(Security.Users).Create(...)` to make a user. Multi-GB image pulls, minutes of
+#   runtime, and 2 of its 6 tests fail outright with no docker daemon. It also uses the
+#   `iris session` path this repo's house rules forbid everywhere else — worth fixing, but
+#   rewriting an excluded e2e target was out of scope for #95. Run it by hand when
+#   touching container discovery.
+EXCLUDED=( docker_discovery_e2e )
+
+# python3 rather than jq: both are on ubuntu-latest, but contributors run this locally too
+# and python3 is the harder dependency to lose (notably on a stock macOS box).
+ALL=$(cargo metadata --no-deps --format-version 1 | python3 -c '
+import json, sys
+d = json.load(sys.stdin)
+names = {t["name"] for p in d["packages"] for t in p["targets"] if "test" in t["kind"]}
+print("\n".join(sorted(names)))
+')
+
+# ── ANTI-DRIFT GUARD ──────────────────────────────────────────────────────────────
+# A renamed or deleted target must not sit in EXCLUDED unnoticed, silently opting a
+# target that no longer exists out of a gate it was never in. Same role test_toolset
+# plays for the 54/50/46/23 tool counts.
+#
+# `${EXCLUDED[@]+"${EXCLUDED[@]}"}` rather than plain `"${EXCLUDED[@]}"`: under `set -u`,
+# bash 3.2 — stock /bin/bash on macOS, the box this script deliberately caters to — treats
+# an EMPTY array expansion as an unbound variable and aborts. Retiring the last opt-out
+# (`EXCLUDED=()`) is the goal state, and it must not break the script that measures it.
+for x in ${EXCLUDED[@]+"${EXCLUDED[@]}"}; do
+  grep -qx "$x" <<<"$ALL" || {
+    echo "stale exclusion: no test target named $x" >&2
+    exit 1
+  }
+done
+
+# Collect first, print last. The previous form ended on `[[ $skip -eq 0 ]] && printf ...`,
+# whose status becomes the script's when the LAST target in sorted order is the excluded
+# one: a correct, complete list on stdout, nothing on stderr, and exit 1. Verified with
+# EXCLUDED=( vscode_config_tests ) — 43 correct flags, exit 1. Invisible while the caller
+# swallowed the exit code; a mystery red gate the moment it stopped doing that. Use `if`.
+FLAGS=()
+for n in $ALL; do
+  skip=0
+  for x in ${EXCLUDED[@]+"${EXCLUDED[@]}"}; do
+    if [[ "$n" == "$x" ]]; then skip=1; fi
+  done
+  if [[ $skip -eq 0 ]]; then
+    FLAGS+=( --test "$n" )
+  fi
+done
+
+# ── NON-EMPTY GUARD ───────────────────────────────────────────────────────────────
+# Never exit 0 with nothing to say. An empty list turns the caller's
+# `cargo test --workspace --lib --bins <flags> --no-fail-fast` into `--lib --bins`:
+# 2 targets, 408 tests, green, every test target gone. That is the exact silent
+# degradation #95 exists to prevent, so refuse loudly instead.
+if [[ ${#FLAGS[@]} -eq 0 ]]; then
+  echo "no test targets emitted: cargo metadata reported none, or EXCLUDED covers them all" >&2
+  exit 1
+fi
+
+printf -- '%s ' "${FLAGS[@]}"


### PR DESCRIPTION
Closes #89, closes #90, closes #91, closes #92, closes #93, closes #94, closes #95.

All seven were filed from adversarial verification of the #78–#88 work. Every behaviour below was reproduced first and re-verified live against the dev IRIS.

## #94 — solved by server-side filtering, **not** a cache

The obvious fix was a cache, and it would have been worse than the problem: an agent writes a class, compiles `Pkg.*`, and the brand-new class is invisible because the listing was cached before it existed. That is a silent wrong answer — the exact failure mode this whole issue series has been about — traded for 0.29s.

Instead the listing GET now sends `?filter=<literal prefix before the first *>`, with **one unfiltered retry** on any non-success, so an Atelier build that rejects the parameter degrades to precisely today's behaviour.

The prefix is allowlisted (alphanumerics plus `. _ % -`) and a quote is **rejected, not escaped** — `GetDocNames` concatenates it into `Name Like '%X%'`, so a rejected prefix fails *safe* to the full listing rather than into an injection.

Measured on the same instance, same session, 5 reps each:

| call | before | after |
|---|---|---|
| `Ens.Alerting.*` | 338.0 ms | **42.2 ms** |
| `Ens.Alerting.Ac*` | — | 45.4 ms |
| exact name | 5.6 ms | 5.6 ms |

Anti-staleness proven live in one process: `ZZTMP94.*` → 0 candidates; put Alpha → compiles 1; put Beta → compiles 2. A brand-new class is seen immediately, which a cache could not have promised.

## #93 — a missing namespace is not a transport failure

`iris_compile` against a nonexistent namespace returned `IRIS_UNREACHABLE` with *"Check IRIS_HOST and IRIS_WEB_PORT"* while IRIS was perfectly reachable. New read-only `accessible_namespaces()` reads the same Atelier root descriptor `probe()` already uses; `namespace_missing_error()` returns `NAMESPACE_NOT_FOUND` — the code `iris_test` already had — with the list attached.

Deliberately narrow: gated on **404 only**, at the three call sites (compile POST, wildcard listing GET, local-file PUT). 401/403/5xx keep their errors verbatim, because swallowing those into a namespace error is just a different wrong answer. `None` strictly means "cannot tell", so a wrong `IRIS_WEB_PREFIX` never invents one. Comparison is trimmed and case-insensitive: `namespace: "app"` against a list holding `APP` still compiles.

## #89 — agent_info stops reporting a failed read as an empty registry

Two chained `unwrap_or` turned an unreachable IRIS into `{"skill_count": 0, "success": true}`. It now shares the read path #119 built and the namespace resolution #85 added; the last hand-rolled `^SKILLS` reader is gone. `[]` is still a real `0` — the fix must not turn "empty" into an error, and that distinction is verified separately.

**Two more of the same shape, found while verifying:** `skill_list` — the tool `agent_info` is supposed to agree with — still carried `unwrap_or(0)`, so a non-array payload would have made the two disagree in the *opposite* direction. And `agent_history` still reported a poisoned lock as `{"calls": []}`. Both fixed here.

## #90 / #91 / #92 / #95

**#90** — `test_search_params_full` asserted `namespace == None` while its own JSON literal set `"namespace":"USER"`. Red since `010a625` (#16), in no gate, so nobody saw it. Fixed the assertion, not the literal.

**#91** — the process-global env race (red in 2 of 3 parallel runs) merged into one gate test, following the precedent #85 set in `test_skills_unit`. Each phase keeps the name it had, so a future red still says which one failed.

**#92** — off the network, mirroring #87: a `load_from_github_at` seam, wiremock on localhost, live canary behind `IRIS_DEV_LIVE_GITHUB`. Worth noting the two network reachers previously ended in `let _ = result;` and **could not fail** on an outage, a 429, or a DNS hijack. The retarget silently dropped the only assertion covering kb-item fetch/registration; restored here against the mock.

**#95 — the gate runs everything now.** Every test target the workspace declares *or auto-discovers*, minus one documented opt-out (`docker_discovery_e2e`, which `docker run`s real multi-GB images). **11 targets → 43.**

Targets come from `cargo metadata`, not `Cargo.toml`, on purpose: `transport_e2e` is auto-discovered from `tests/*.rs` and appears in no `[[test]]` block, so a hand-kept list could never have seen it — exactly the blind spot #95 exists to close. It is an **opt-out** list, so a newly added target is covered by default. `--bins` is not redundant: `plugin.rs` holds unit tests no job had ever run.

The gate comment also now records something the verification turned up: five live-IRIS targets *self-skip via `require_iris!` and report `PASSED`* rather than `ignored`, so roughly **137 of the 1028 passes are green-but-vacuous**. Overstating a pass count is the same dishonesty #87(b) fixed for fail-fast, so the two styles and their consequences are documented, with `#[ignore]` named as the preferred one.

## Verification

- Widened gate run **three times consecutively: 1028 passed, 0 failed, 46 ignored**, no variance — #91's race would have shown up.
- `cargo fmt --check` and `clippy --all-targets -D warnings` clean.
- Interop profile unchanged at 23 tools.
- Dev IRIS left as found; the local eval battery runs on a different instance (42101/EVALNS) and was not touched.

Follow-ups filed rather than folded in — see the issues referencing this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)