### PR TITLE
fix: auth error surface (#101) and non-2xx blind spots across the tool surface (#102, #99, #100)

### DIFF
--- a/crates/iris-agentic-dev-core/src/iris/connection.rs
+++ b/crates/iris-agentic-dev-core/src/iris/connection.rs
@@ -2,6 +2,65 @@
 
 use std::fmt;
 
+/// Issues #101 / #102: an Atelier call that came back with a non-2xx status, carried as a
+/// TYPED error instead of an opaque `anyhow` string.
+///
+/// Before this, every consumer re-guessed what "PUT doc failed: HTTP 401 Unauthorized" meant
+/// and they disagreed — `iris_production` said INTEROP_ERROR, `iris_table_info` said
+/// IRIS_EXECUTE_ERROR, `iris_test` said TEST_EXECUTION_ERROR. Three tools, three codes, one
+/// cause. `query_once` was worse: it never looked at the status at all, so a 401 (whose body
+/// is not JSON) and a 404 (whose body is ZERO bytes) both surfaced as "error decoding
+/// response body" with the status destroyed.
+///
+/// `message` is the human text — deliberately byte-identical to the string each site used to
+/// `bail!`, so nothing that reads these messages moves. `status` and `url` are the new part:
+/// the tool layer downcasts (see [`atelier_status`]) and can finally ask "is the NAMESPACE
+/// why this 404 happened" without re-parsing prose.
+#[derive(Debug, Clone)]
+pub struct AtelierHttpError {
+    pub status: u16,
+    pub url: String,
+    /// Response body, trimmed and truncated — Atelier puts real diagnostics here on a 400.
+    pub body: String,
+    message: String,
+}
+
+impl AtelierHttpError {
+    pub fn new(
+        status: reqwest::StatusCode,
+        url: impl Into<String>,
+        body: impl Into<String>,
+        message: impl Into<String>,
+    ) -> Self {
+        Self {
+            status: status.as_u16(),
+            url: url.into(),
+            body: body.into(),
+            message: message.into(),
+        }
+    }
+}
+
+impl fmt::Display for AtelierHttpError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(&self.message)
+    }
+}
+
+impl std::error::Error for AtelierHttpError {}
+
+/// `Some` when this `anyhow::Error` is an Atelier non-2xx response, `None` for a transport
+/// failure, a SQL error, or anything else. The tool layer's one entry point to the status.
+pub fn atelier_status(err: &anyhow::Error) -> Option<&AtelierHttpError> {
+    err.downcast_ref::<AtelierHttpError>()
+}
+
+/// Trim and cut a response body to `max` CHARACTERS (not bytes — a cut inside a UTF-8
+/// sequence would panic).
+pub(crate) fn truncate_body(body: &str, max: usize) -> String {
+    body.trim().chars().take(max).collect()
+}
+
 /// Whether the connected IRIS instance is a production (Live) system.
 /// Detected at probe time via `^%SYS("SystemMode")` SQL query.
 #[derive(Debug, Clone, PartialEq, Default)]
@@ -46,6 +105,19 @@ pub struct IrisConnection {
     pub port_superserver: Option<u16>,
     /// Detected at probe time — controls write-tool availability (issue #26).
     pub system_mode: SystemMode,
+    /// Issue #101: the HTTP status the Atelier root probe got, or `None` if the probe never
+    /// ran or never got a response. The server already KNEW a wrong password had been
+    /// rejected — `probe()` logged it to `tracing::debug!` and threw it away, while
+    /// `check_config`, the tool whose own description says to call it to diagnose exactly
+    /// this, went on reporting `connected: true`.
+    pub probe_status: Option<u16>,
+    /// Issue #101: `Some(true)` when the root probe got an HTTP *response* of any status,
+    /// `Some(false)` when it ran and the request never completed (closed port, unroutable
+    /// host), `None` when the probe never ran. `probe_status` alone cannot express the
+    /// middle case — it is `None` for "never ran" AND for "ran, got nothing", and
+    /// `check_config` needs those apart to answer `connected` honestly without turning
+    /// "never asked" into a claim.
+    pub probe_reached: Option<bool>,
 }
 
 /// T011: Manual Debug implementation — never prints the password.
@@ -61,8 +133,30 @@ impl fmt::Debug for IrisConnection {
             .field("source", &self.source)
             .field("port_superserver", &self.port_superserver)
             .field("system_mode", &self.system_mode)
+            .field("probe_status", &self.probe_status)
+            .field("probe_reached", &self.probe_reached)
             .finish()
     }
+}
+
+/// Issue #101/#102: what a GET of the Atelier ROOT descriptor actually established.
+///
+/// See [`IrisConnection::root_probe`]. The `Option<Vec<String>>` this replaces answered
+/// "cannot tell" to a question it could in fact answer, and every caller read "cannot tell"
+/// as licence to keep its own guess.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum RootProbe {
+    /// The root descriptor was read: these namespaces are visible to these credentials.
+    Namespaces(Vec<String>),
+    /// IRIS answered `/api/atelier/` with **404**. Every IRIS with the Atelier REST
+    /// application enabled serves that URL, so this is a positive finding, not an absence
+    /// of one: the application is not published where this server is looking. The usual
+    /// cause is a wrong (or missing) `IRIS_WEB_PREFIX`; the other is the web application
+    /// being disabled.
+    NoAtelierHere { url: String },
+    /// Nothing was established: the request never completed, or IRIS answered with a status
+    /// or a body this probe cannot read anything into. Never a claim.
+    Unknown,
 }
 
 #[derive(Debug, Clone)]
@@ -105,6 +199,8 @@ impl IrisConnection {
             source,
             port_superserver: None,
             system_mode: SystemMode::Unknown,
+            probe_status: None,
+            probe_reached: None,
         }
     }
 
@@ -154,13 +250,19 @@ impl IrisConnection {
         };
 
         let url = self.atelier_url("/");
-        if let Ok(resp) = client
+        let probe = client
             .get(&url)
             .basic_auth(&self.username, Some(&self.password))
             .send()
-            .await
-        {
+            .await;
+        // #101: record REACHED separately from the status. A closed port and a probe that
+        // never ran both leave `probe_status` at None, and `check_config` must not report
+        // them the same way — one is a definite "IRIS did not answer", the other is
+        // "nobody asked", and only the first may become `connected: false`.
+        self.probe_reached = Some(probe.is_ok());
+        if let Ok(resp) = probe {
             let status = resp.status();
+            self.probe_status = Some(status.as_u16());
             if status.is_success() {
                 if let Ok(body) = resp.json::<serde_json::Value>().await {
                     tracing::debug!("Atelier root response: {}", body);
@@ -203,34 +305,70 @@ impl IrisConnection {
     /// created while this server runs, and a stale "does not exist" is precisely the wrong
     /// answer #93 is about. It only ever runs on a path that has ALREADY failed.
     ///
-    /// `None` always means *cannot tell* — transport error, non-2xx (a wrong
-    /// `IRIS_WEB_PREFIX` 404s here too), or a body without the array (an old or foreign
-    /// server). Callers must keep their own error in that case and never turn `None` into
-    /// a positive claim about a namespace.
+    /// `None` always means *cannot tell*. Callers must keep their own error in that case and
+    /// never turn `None` into a positive claim about a namespace. Callers that need to tell
+    /// the two *reasons* for `None` apart — "the Atelier app is not at this URL at all" vs
+    /// "the probe established nothing" — use [`IrisConnection::root_probe`] instead.
     ///
     /// The list reflects ACCESSIBILITY, not raw existence: `%Atelier.v1.Utils.General`
     /// filters to what the authenticated user can reach, so a namespace that exists but is
     /// invisible to these credentials is absent from it. Messages built from this must say
     /// so.
     pub async fn accessible_namespaces(&self, client: &reqwest::Client) -> Option<Vec<String>> {
-        let resp = client
-            .get(self.atelier_url("/"))
+        match self.root_probe(client).await {
+            RootProbe::Namespaces(list) => Some(list),
+            _ => None,
+        }
+    }
+
+    /// Issue #101/#102: the same GET as [`IrisConnection::accessible_namespaces`], keeping the
+    /// finding it used to throw away.
+    ///
+    /// `Option<Vec<String>>` collapsed three different outcomes into one `None`, and the
+    /// difference between them is the whole answer. A **404 on `/api/atelier/`** is not
+    /// "cannot tell": a working Atelier always serves its own root descriptor, so a 404 there
+    /// says positively that the REST application is not published at this URL — the signature
+    /// of a wrong `IRIS_WEB_PREFIX`. Treating that as "cannot tell" is what let `iris_doc`
+    /// mode=head answer `{"success":true,"exists":false}` for a class that provably exists,
+    /// and what stripped the `IRIS_WEB_PREFIX` diagnosis off `iris_query`'s bare 404.
+    ///
+    /// Everything else — transport failure, 5xx, 401/403, or a 2xx body with no `namespaces`
+    /// array (an older or foreign server) — stays [`RootProbe::Unknown`]. Those are genuinely
+    /// unknowable and must never become a claim.
+    pub async fn root_probe(&self, client: &reqwest::Client) -> RootProbe {
+        let url = self.atelier_url("/");
+        let resp = match client
+            .get(&url)
             .basic_auth(&self.username, Some(&self.password))
             .send()
             .await
-            .ok()?;
-        if !resp.status().is_success() {
-            tracing::debug!("Atelier root namespace probe got HTTP {}", resp.status());
-            return None;
+        {
+            Ok(r) => r,
+            Err(e) => {
+                tracing::debug!("Atelier root probe did not complete: {e}");
+                return RootProbe::Unknown;
+            }
+        };
+        let status = resp.status();
+        if status.as_u16() == 404 {
+            tracing::debug!("Atelier root descriptor 404 at {url} — no Atelier application here");
+            return RootProbe::NoAtelierHere { url };
         }
-        let body: serde_json::Value = resp.json().await.ok()?;
-        Some(
-            body["result"]["content"]["namespaces"]
-                .as_array()?
-                .iter()
-                .filter_map(|n| n.as_str().map(str::to_string))
-                .collect(),
-        )
+        if !status.is_success() {
+            tracing::debug!("Atelier root namespace probe got HTTP {status}");
+            return RootProbe::Unknown;
+        }
+        let Ok(body) = resp.json::<serde_json::Value>().await else {
+            return RootProbe::Unknown;
+        };
+        match body["result"]["content"]["namespaces"].as_array() {
+            Some(arr) => RootProbe::Namespaces(
+                arr.iter()
+                    .filter_map(|n| n.as_str().map(str::to_string))
+                    .collect(),
+            ),
+            None => RootProbe::Unknown,
+        }
     }
 
     /// Query `^%SYS("SystemMode")` to detect whether this is a Live instance.
@@ -358,7 +496,15 @@ impl IrisConnection {
             .send()
             .await?;
         if !put_resp.status().is_success() {
-            anyhow::bail!("PUT doc failed: HTTP {}", put_resp.status());
+            // #101/#102: typed, with the SAME text it has always emitted — the caller can now
+            // ask whether the 404 is a missing NAMESPACE rather than reporting Docker.
+            let status = put_resp.status();
+            return Err(anyhow::Error::new(AtelierHttpError::new(
+                status,
+                put_url,
+                "",
+                format!("PUT doc failed: HTTP {}", status),
+            )));
         }
 
         // 2. Compile
@@ -370,8 +516,14 @@ impl IrisConnection {
             .send()
             .await?;
         if !compile_resp.status().is_success() {
+            let status = compile_resp.status();
             let _ = self.delete_doc(&doc_name, namespace, client).await;
-            anyhow::bail!("compile HTTP {}", compile_resp.status());
+            return Err(anyhow::Error::new(AtelierHttpError::new(
+                status,
+                compile_url,
+                "",
+                format!("compile HTTP {}", status),
+            )));
         }
         let compile_body: serde_json::Value = compile_resp.json().await.unwrap_or_default();
         let has_errors = compile_body["result"]["log"]
@@ -578,11 +730,22 @@ impl IrisConnection {
                 Err(e) => {
                     let msg = e.to_string();
                     // Only transport-level failures are retryable; a SQL error is deterministic.
-                    let is_retryable = msg.contains("error sending request")
-                        || msg.contains("connection refused")
-                        || msg.contains("connection reset")
-                        || msg.contains("timed out")
-                        || msg.contains("HTTP 5");
+                    // #102: the 5xx arm is STRUCTURAL now. Before the typed error below, a 500
+                    // made `resp.json()` fail with "error decoding response body", which matches
+                    // none of these substrings — so a 5xx was never actually retried, despite the
+                    // doc comment above promising it. Relying on the Display text happening to
+                    // contain "HTTP 5" would keep that accidental; asking the status makes it
+                    // deliberate.
+                    let is_retryable = match atelier_status(&e) {
+                        Some(http) => http.status >= 500,
+                        None => {
+                            msg.contains("error sending request")
+                                || msg.contains("connection refused")
+                                || msg.contains("connection reset")
+                                || msg.contains("timed out")
+                                || msg.contains("HTTP 5")
+                        }
+                    };
                     if !is_retryable || attempt == delays.len() - 1 {
                         return Err(e);
                     }
@@ -615,15 +778,47 @@ impl IrisConnection {
             .json(&serde_json::json!({"query": sql, "parameters": params}))
             .send()
             .await?;
-        let body: serde_json::Value = resp.json().await?;
-        // Surface Atelier-level errors returned as 200 OK with status.errors in body.
-        if let Some(errs) = body["status"]["errors"].as_array() {
-            if !errs.is_empty() {
-                let msg = errs[0]["error"].as_str().unwrap_or("Atelier query error");
-                anyhow::bail!("{}", msg);
+        // #101/#102: BODY FIRST, then the status. `resp.json()` alone destroyed the status —
+        // a 401 body is not JSON and a missing-namespace 404 body is ZERO bytes, so every
+        // caller saw "error decoding response body" and IRIS's actual answer was gone.
+        //
+        // The ordering is mandatory, not stylistic. Atelier puts REAL diagnostics in the body
+        // of some non-2xx responses: a malformed query POST returns HTTP 400 carrying
+        // `{"status":{"errors":[{"error":"ERROR #16002: Invalid JSON Content",...}]}}`. A
+        // status-first `if !status.is_success() { bail!("HTTP {}") }` would swap one
+        // uninformative error for another. `status.errors` therefore wins over the HTTP status
+        // whatever that status is, so SQL_ERROR and the #16002 text keep coming through
+        // byte-for-byte. (A bad SELECT is not even this case — it returns 200 with
+        // status.errors.)
+        let status = resp.status();
+        let text = resp.text().await?;
+        let parsed = serde_json::from_str::<serde_json::Value>(&text).ok();
+        if let Some(body) = &parsed {
+            if let Some(errs) = body["status"]["errors"].as_array() {
+                if !errs.is_empty() {
+                    let msg = errs[0]["error"].as_str().unwrap_or("Atelier query error");
+                    anyhow::bail!("{}", msg);
+                }
             }
         }
-        Ok(body)
+        if !status.is_success() {
+            let snippet = truncate_body(&text, 500);
+            let message = if snippet.is_empty() {
+                format!("HTTP {status} from {url}")
+            } else {
+                format!("HTTP {status} from {url}: {snippet}")
+            };
+            return Err(anyhow::Error::new(AtelierHttpError::new(
+                status, &url, snippet, message,
+            )));
+        }
+        match parsed {
+            Some(body) => Ok(body),
+            None => anyhow::bail!(
+                "non-JSON response from {url}: {}",
+                truncate_body(&text, 200)
+            ),
+        }
     }
 
     /// Compile a document via POST /action/compile. Returns structured errors and console output.
@@ -646,7 +841,13 @@ impl IrisConnection {
             .send()
             .await?;
         if !resp.status().is_success() {
-            anyhow::bail!("compile HTTP {}", resp.status());
+            let status = resp.status();
+            return Err(anyhow::Error::new(AtelierHttpError::new(
+                status,
+                compile_url,
+                "",
+                format!("compile HTTP {}", status),
+            )));
         }
         let body: serde_json::Value = resp.json().await.unwrap_or_default();
         let console: Vec<String> = body["console"]
@@ -985,5 +1186,178 @@ mod system_mode_tests {
         assert!(!is_production_namespace("USER"));
         assert!(!is_production_namespace("DEV"));
         assert!(!is_production_namespace("MYAPP"));
+    }
+}
+
+// ── Issues #101 / #102: `query_once` must not destroy what IRIS said ──────────
+#[cfg(test)]
+mod atelier_http_error_tests {
+    use super::*;
+    use wiremock::matchers::{method, path_regex};
+    use wiremock::{Mock, MockServer, ResponseTemplate};
+
+    fn rt() -> tokio::runtime::Runtime {
+        tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .unwrap()
+    }
+
+    async fn mount(server: &MockServer, tpl: ResponseTemplate) -> IrisConnection {
+        Mock::given(method("POST"))
+            .and(path_regex(r".*/action/query$"))
+            .respond_with(tpl)
+            .mount(server)
+            .await;
+        IrisConnection::new(
+            server.uri(),
+            "APP",
+            "_SYSTEM",
+            "SYS",
+            DiscoverySource::EnvVar,
+        )
+    }
+
+    async fn ask(tpl: ResponseTemplate) -> anyhow::Result<serde_json::Value> {
+        let server = MockServer::start().await;
+        let iris = mount(&server, tpl).await;
+        iris.query_once("SELECT 1", vec![], "APP", &reqwest::Client::new())
+            .await
+    }
+
+    /// The happy path is untouched.
+    #[test]
+    fn a_200_with_json_is_returned_verbatim() {
+        rt().block_on(async {
+            let body = serde_json::json!({"result": {"content": [{"n": 1}]}});
+            let out = ask(ResponseTemplate::new(200).set_body_json(body.clone()))
+                .await
+                .expect("a 200 with a JSON body is a success");
+            assert_eq!(out, body);
+        });
+    }
+
+    /// Atelier reports SQL errors as 200 + `status.errors`. That message is the useful one
+    /// and it still wins.
+    #[test]
+    fn a_200_carrying_status_errors_still_bails_with_the_atelier_message() {
+        rt().block_on(async {
+            let e = ask(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                "status": {"errors": [{"error": "ERROR #5540: SQLCODE: -51"}]}
+            })))
+            .await
+            .expect_err("status.errors is a failure");
+            assert_eq!(e.to_string(), "ERROR #5540: SQLCODE: -51");
+            assert!(
+                atelier_status(&e).is_none(),
+                "a SQL error is not an HTTP-status error"
+            );
+        });
+    }
+
+    /// THE TRAP this rewrite exists to avoid. A malformed query POST returns HTTP 400 with a
+    /// REAL diagnostic in the body (verified live: `ERROR #16002: Invalid JSON Content`). A
+    /// status-first `if !status.is_success() { bail!("HTTP {}") }` would swap one
+    /// uninformative error for another — so the body is parsed FIRST and `status.errors` wins
+    /// whatever the status is.
+    #[test]
+    fn a_400_carrying_a_diagnostic_reports_the_diagnostic_not_the_status() {
+        rt().block_on(async {
+            let e = ask(ResponseTemplate::new(400).set_body_json(serde_json::json!({
+                "status": {"errors": [{"error": "ERROR #16002: Invalid JSON Content", "code": 16002}]}
+            })))
+            .await
+            .expect_err("a 400 is a failure");
+            assert_eq!(e.to_string(), "ERROR #16002: Invalid JSON Content");
+            assert!(!e.to_string().contains("HTTP 400"), "{e}");
+        });
+    }
+
+    /// The #102 P2 root cause: a missing-namespace 404 has a ZERO-BYTE body, so `resp.json()`
+    /// reported EOF ("error decoding response body") and the status was destroyed. Every
+    /// caller then said IRIS_UNREACHABLE about an instance that had just answered.
+    #[test]
+    fn a_404_with_an_empty_body_keeps_its_status_and_url() {
+        rt().block_on(async {
+            let server = MockServer::start().await;
+            let iris = mount(&server, ResponseTemplate::new(404)).await;
+            let e = iris
+                .query_once("SELECT 1", vec![], "ZZNOSUCHNS", &reqwest::Client::new())
+                .await
+                .expect_err("a 404 is a failure");
+            let http = atelier_status(&e).expect("the status must survive as a typed error");
+            assert_eq!(http.status, 404);
+            assert!(http.url.contains("ZZNOSUCHNS"), "{}", http.url);
+            assert!(e.to_string().contains("HTTP 404"), "{e}");
+            assert!(
+                !e.to_string().contains("error decoding response body"),
+                "{e}"
+            );
+            assert_eq!(
+                server.received_requests().await.unwrap().len(),
+                1,
+                "a 404 is deterministic — it must not be retried"
+            );
+        });
+    }
+
+    /// The #101 repro one layer down: a 401 body is not JSON, so this was the other way the
+    /// status got destroyed.
+    #[test]
+    fn a_401_keeps_its_status_instead_of_becoming_a_decode_failure() {
+        rt().block_on(async {
+            let e = ask(ResponseTemplate::new(401).set_body_string("Unauthorized"))
+                .await
+                .expect_err("a 401 is a failure");
+            let http = atelier_status(&e).expect("typed");
+            assert_eq!(http.status, 401);
+            assert_eq!(http.body, "Unauthorized");
+            assert_eq!(
+                crate::tools::envelope::auth_error_code(&e.to_string()),
+                Some("IRIS_AUTH_FAILED"),
+                "the message must stay classifiable: {e}"
+            );
+        });
+    }
+
+    /// The deliberate retry change. Before the typed error a 5xx surfaced as "error decoding
+    /// response body", which matches none of `query()`'s retry substrings — so a 5xx was
+    /// never retried despite the doc comment promising it. The predicate is structural now.
+    #[test]
+    fn a_5xx_is_retried_and_a_404_is_not() {
+        rt().block_on(async {
+            let server = MockServer::start().await;
+            let iris = mount(&server, ResponseTemplate::new(503)).await;
+            let e = iris
+                .query("SELECT 1", vec![], "APP", &reqwest::Client::new())
+                .await
+                .expect_err("a 503 is a failure");
+            assert_eq!(atelier_status(&e).map(|h| h.status), Some(503));
+            assert_eq!(
+                server.received_requests().await.unwrap().len(),
+                3,
+                "three attempts: the delay table has three entries"
+            );
+        });
+    }
+
+    /// A 2xx whose body is not JSON at all names the URL and shows what came back, instead of
+    /// reqwest's opaque "error decoding response body".
+    #[test]
+    fn a_200_that_is_not_json_says_so() {
+        rt().block_on(async {
+            let e = ask(ResponseTemplate::new(200).set_body_string("<html>login</html>"))
+                .await
+                .expect_err("a non-JSON 200 cannot be a query result");
+            assert!(e.to_string().contains("non-JSON response"), "{e}");
+            assert!(e.to_string().contains("<html>login</html>"), "{e}");
+        });
+    }
+
+    #[test]
+    fn truncate_body_cuts_on_char_boundaries() {
+        // A byte-wise cut inside a multi-byte sequence would panic.
+        assert_eq!(truncate_body("  héllo  ", 3), "hél");
+        assert_eq!(truncate_body("", 500), "");
     }
 }

--- a/crates/iris-agentic-dev-core/src/tools/admin.rs
+++ b/crates/iris-agentic-dev-core/src/tools/admin.rs
@@ -16,6 +16,18 @@ fn iris_unreachable() -> McpError {
     McpError::invalid_request("IRIS_UNREACHABLE", None)
 }
 
+/// Issue #101: every failing admin call reported `IRIS_UNREACHABLE` and inherited the
+/// "check IRIS_HOST / IRIS_WEB_PORT" hint — including a wrong password, which IRIS had
+/// answered with a 401 from that very host and port. `IRIS_UNREACHABLE` now comes only from
+/// the network arm; a 401/403 names the credentials, and everything else says the request
+/// failed without claiming to know why.
+///
+/// `err_json("IRIS_UNREACHABLE", "No IRIS connection")` is deliberately NOT routed here:
+/// that guard fires before any request, and there genuinely is no connection.
+fn admin_error_code(msg: &str) -> &'static str {
+    crate::tools::interop::classify_iris_error_or(msg, "IRIS_REQUEST_FAILED")
+}
+
 /// Returns true if write operations are permitted (IRIS_ADMIN_TOOLS=1 or true).
 pub fn admin_write_allowed() -> bool {
     std::env::var("IRIS_ADMIN_TOOLS")
@@ -67,7 +79,7 @@ pub async fn admin_list_namespaces_impl(
             let count = namespaces.len();
             ok_json(serde_json::json!({"success":true,"namespaces":namespaces,"count":count}))
         }
-        Err(e) => err_json("IRIS_UNREACHABLE", &e.to_string()),
+        Err(e) => err_json(admin_error_code(&e.to_string()), &e.to_string()),
     }
 }
 
@@ -110,7 +122,7 @@ While tRS.Next() {
             let count = databases.len();
             ok_json(serde_json::json!({"success":true,"databases":databases,"count":count}))
         }
-        Err(e) => err_json("IRIS_UNREACHABLE", &e.to_string()),
+        Err(e) => err_json(admin_error_code(&e.to_string()), &e.to_string()),
     }
 }
 
@@ -162,7 +174,7 @@ pub async fn admin_list_users_impl(
                 "total_count": total,
             }))
         }
-        Err(e) => err_json("IRIS_UNREACHABLE", &e.to_string()),
+        Err(e) => err_json(admin_error_code(&e.to_string()), &e.to_string()),
     }
 }
 
@@ -206,7 +218,7 @@ pub async fn admin_list_roles_impl(
                 "total_count": total,
             }))
         }
-        Err(e) => err_json("IRIS_UNREACHABLE", &e.to_string()),
+        Err(e) => err_json(admin_error_code(&e.to_string()), &e.to_string()),
     }
 }
 
@@ -235,7 +247,7 @@ pub async fn admin_list_webapps_impl(
             .as_array()
             .cloned()
             .unwrap_or_default(),
-        Err(e) => return err_json("IRIS_UNREACHABLE", &e.to_string()),
+        Err(e) => return err_json(admin_error_code(&e.to_string()), &e.to_string()),
     };
 
     let mut webapps: Vec<serde_json::Value> = rows
@@ -316,7 +328,7 @@ Write $GET(props("Roles"))"#
             };
             ok_json(serde_json::json!({"success":true,"username":username,"roles":roles}))
         }
-        Err(e) => err_json("IRIS_UNREACHABLE", &e.to_string()),
+        Err(e) => err_json(admin_error_code(&e.to_string()), &e.to_string()),
     }
 }
 
@@ -360,7 +372,7 @@ Write ns_"|"_dc_"|"_en_"|"_tp"#
                 "type": parts[3],
             }))
         }
-        Err(e) => err_json("IRIS_UNREACHABLE", &e.to_string()),
+        Err(e) => err_json(admin_error_code(&e.to_string()), &e.to_string()),
     }
 }
 
@@ -406,7 +418,7 @@ pub async fn admin_check_permission_impl(
                 "user": current_user,
             }))
         }
-        Err(e) => err_json("IRIS_UNREACHABLE", &e.to_string()),
+        Err(e) => err_json(admin_error_code(&e.to_string()), &e.to_string()),
     }
 }
 
@@ -451,7 +463,7 @@ If $$$ISERR(tSC) {{ Write "ERROR:USER_EXISTS:"_$System.Status.GetErrorText(tSC) 
                 err_json("INTEROP_ERROR", out)
             }
         }
-        Err(e) => err_json("IRIS_UNREACHABLE", &e.to_string()),
+        Err(e) => err_json(admin_error_code(&e.to_string()), &e.to_string()),
     }
 }
 
@@ -505,7 +517,7 @@ If $$$ISERR(tSC2) {{ Write "ERROR:INTEROP_ERROR:"_$System.Status.GetErrorText(tS
                 err_json("INTEROP_ERROR", out)
             }
         }
-        Err(e) => err_json("IRIS_UNREACHABLE", &e.to_string()),
+        Err(e) => err_json(admin_error_code(&e.to_string()), &e.to_string()),
     }
 }
 
@@ -542,7 +554,7 @@ If $$$ISERR(tSC) {{ Write "ERROR:INTEROP_ERROR:"_$System.Status.GetErrorText(tSC
                 err_json("INTEROP_ERROR", out)
             }
         }
-        Err(e) => err_json("IRIS_UNREACHABLE", &e.to_string()),
+        Err(e) => err_json(admin_error_code(&e.to_string()), &e.to_string()),
     }
 }
 
@@ -583,7 +595,7 @@ If $$$ISERR(tSC) {{ Write "ERROR:NAMESPACE_EXISTS:"_$System.Status.GetErrorText(
                 err_json("INTEROP_ERROR", out)
             }
         }
-        Err(e) => err_json("IRIS_UNREACHABLE", &e.to_string()),
+        Err(e) => err_json(admin_error_code(&e.to_string()), &e.to_string()),
     }
 }
 
@@ -619,7 +631,7 @@ If $$$ISERR(tSC) {{ Write "ERROR:INTEROP_ERROR:"_$System.Status.GetErrorText(tSC
                 err_json("INTEROP_ERROR", out)
             }
         }
-        Err(e) => err_json("IRIS_UNREACHABLE", &e.to_string()),
+        Err(e) => err_json(admin_error_code(&e.to_string()), &e.to_string()),
     }
 }
 
@@ -663,7 +675,7 @@ If $$$ISERR(tSC) {{ Write "ERROR:WEBAPP_EXISTS:"_$System.Status.GetErrorText(tSC
                 err_json("INTEROP_ERROR", out)
             }
         }
-        Err(e) => err_json("IRIS_UNREACHABLE", &e.to_string()),
+        Err(e) => err_json(admin_error_code(&e.to_string()), &e.to_string()),
     }
 }
 
@@ -699,6 +711,6 @@ If $$$ISERR(tSC2) {{ Write "ERROR:INTEROP_ERROR:"_$System.Status.GetErrorText(tS
                 err_json("INTEROP_ERROR", out)
             }
         }
-        Err(e) => err_json("IRIS_UNREACHABLE", &e.to_string()),
+        Err(e) => err_json(admin_error_code(&e.to_string()), &e.to_string()),
     }
 }

--- a/crates/iris-agentic-dev-core/src/tools/dict.rs
+++ b/crates/iris-agentic-dev-core/src/tools/dict.rs
@@ -6,6 +6,19 @@ use schemars::JsonSchema;
 use serde::Deserialize;
 use std::collections::HashMap;
 
+/// Issue #101: `dict.rs` was the file the "one shared helper, so every tool inherits it at
+/// once" claim did not reach — it had zero lines of diff. Every failure here became
+/// `IRIS_EXECUTE_ERROR` with **no hint**, so `extract_message_map_routing` answered a wrong
+/// password with `"dict::output: PUT doc failed: HTTP 401 Unauthorized"` and never mentioned
+/// a credential. The message keeps its `dict::output:` provenance; only the classification
+/// (and therefore the hint) changes.
+fn dict_exec_fail(msg: &str) -> Result<rmcp::model::CallToolResult, rmcp::ErrorData> {
+    crate::tools::envelope::fail(
+        crate::tools::interop::classify_iris_error_or(msg, "IRIS_EXECUTE_ERROR"),
+        &format!("dict::output: {msg}"),
+    )
+}
+
 pub const METADATA_CACHE_TTL: std::time::Duration = std::time::Duration::from_secs(60);
 pub type MetadataCache = std::sync::Mutex<HashMap<String, (serde_json::Value, std::time::Instant)>>;
 
@@ -118,12 +131,7 @@ pub async fn handle_resolve_dynamic_dispatch(
 
     let output = match iris.execute_via_generator(&code, &namespace, client).await {
         Ok(v) => v,
-        Err(e) => {
-            return crate::tools::envelope::fail(
-                "IRIS_EXECUTE_ERROR",
-                &format!("dict::output: {e}"),
-            )
-        }
+        Err(e) => return dict_exec_fail(&e.to_string()),
     };
     let trimmed = output.trim();
 
@@ -211,12 +219,7 @@ pub async fn handle_extract_message_map_routing(
     let code = build_message_map_code(&p.class_name);
     let output = match iris.execute_via_generator(&code, &namespace, client).await {
         Ok(v) => v,
-        Err(e) => {
-            return crate::tools::envelope::fail(
-                "IRIS_EXECUTE_ERROR",
-                &format!("dict::output: {e}"),
-            )
-        }
+        Err(e) => return dict_exec_fail(&e.to_string()),
     };
     let trimmed = output.trim();
 
@@ -224,9 +227,21 @@ pub async fn handle_extract_message_map_routing(
         return err_json("NOT_FOUND", &format!("Class '{}' not found", p.class_name));
     }
 
-    let inner: serde_json::Value = serde_json::from_str(trimmed).map_err(|e| {
-        rmcp::ErrorData::internal_error(format!("parse failed: {e} raw={trimmed}"), None)
-    })?;
+    // Same #57 escape one layer on: an unparseable body left the envelope as a -32603 too.
+    let inner: serde_json::Value = match serde_json::from_str(trimmed) {
+        Ok(v) => v,
+        Err(e) => {
+            return crate::tools::envelope::fail_with(
+                "PARSE_ERROR",
+                &format!("extract_message_map_routing could not parse the IRIS response: {e}"),
+                serde_json::json!({
+                    "class_name": p.class_name,
+                    "namespace": namespace,
+                    "raw_excerpt": trimmed.chars().take(400).collect::<String>(),
+                }),
+            )
+        }
+    };
     if let Some(err) = inner.get("error") {
         return err_json("PARSE_ERROR", err.as_str().unwrap_or("xml parse failed"));
     }
@@ -305,12 +320,18 @@ pub async fn handle_find_subclass_implementations(
 
     let limit = p.limit.unwrap_or(100);
     let expand_code = build_expand_hierarchy_code(&p.base_classes);
-    let desc_raw = iris
+    // #101/#57: this `?`-ed an rmcp `internal_error` straight out of the handler, so a wrong
+    // password left the tool surface entirely — raw JSON-RPC -32603 "hierarchy expansion
+    // failed: PUT doc failed: HTTP 401 Unauthorized", with no `error_code`, no `hint` and no
+    // `isError` for anything downstream to branch on. A failure to reach or read IRIS is a
+    // TOOL failure and belongs in the envelope.
+    let desc_raw = match iris
         .execute_via_generator(&expand_code, &namespace, client)
         .await
-        .map_err(|e| {
-            rmcp::ErrorData::internal_error(format!("hierarchy expansion failed: {e}"), None)
-        })?;
+    {
+        Ok(v) => v,
+        Err(e) => return dict_exec_fail(&format!("hierarchy expansion failed: {e}")),
+    };
 
     let descendants: Vec<String> = desc_raw
         .trim()
@@ -347,12 +368,7 @@ pub async fn handle_find_subclass_implementations(
 
     let output = match iris.execute_via_generator(&code, &namespace, client).await {
         Ok(v) => v,
-        Err(e) => {
-            return crate::tools::envelope::fail(
-                "IRIS_EXECUTE_ERROR",
-                &format!("dict::output: {e}"),
-            )
-        }
+        Err(e) => return dict_exec_fail(&e.to_string()),
     };
     let trimmed = output.trim();
 

--- a/crates/iris-agentic-dev-core/src/tools/doc.rs
+++ b/crates/iris-agentic-dev-core/src/tools/doc.rs
@@ -108,16 +108,13 @@ fn err_json(code: &str, msg: &str) -> Result<rmcp::model::CallToolResult, rmcp::
 /// Map a non-success Atelier HTTP status to an accurate error_code. `IRIS_UNREACHABLE` is reserved for
 /// real transport failures (reqwest `send()` errors) and the no-connection guard — an HTTP *response*
 /// means IRIS is reachable, so a 4xx/5xx must never be reported as "unreachable".
-fn http_error_code(status: reqwest::StatusCode) -> &'static str {
-    match status.as_u16() {
-        400 => "IRIS_BAD_REQUEST",
-        401 | 403 => "IRIS_AUTH",
-        404 => "NOT_FOUND",
-        409 => "IRIS_CONFLICT",
-        423 => "IRIS_LOCKED",
-        s if s >= 500 => "IRIS_SERVER_ERROR",
-        _ => "IRIS_HTTP_ERROR",
-    }
+/// #101: iris_doc was the ONLY site in the tree that got this approximately right, and even
+/// here `401 | 403 => "IRIS_AUTH"` collapsed two disjoint remedies into one code and attached
+/// no hint at all. The map now lives in `envelope::http_status_code` so the whole surface
+/// shares one scheme instead of each file re-deciding — and 401/403 split into
+/// IRIS_AUTH_FAILED / IRIS_FORBIDDEN, both of which carry a `builtin_hint`.
+pub(crate) fn http_error_code(status: reqwest::StatusCode) -> &'static str {
+    crate::tools::envelope::http_status_code(status.as_u16())
 }
 
 /// Build an error result from a non-success Atelier response: accurate `error_code`, the response body
@@ -298,24 +295,106 @@ async fn handle_get(
         // Collect results, preserving insertion order via a map then re-order.
         let mut map: std::collections::HashMap<String, serde_json::Value> =
             std::collections::HashMap::new();
+        // #102 P1: this arm was byte-identical to the baseline while the single-name path
+        // below it was fixed, so the BATCH form still answered
+        // {"documents":[{"error":"HTTP 404 Not Found"},…],"success":true} — isError:false —
+        // for a namespace that does not exist, never naming the namespace. The envelope
+        // claiming success made it worse than the single-name bug the issue described.
+        // Track the statuses so the summary below is a reading of what happened, not a
+        // constant.
+        let mut first_404_url: Option<String> = None;
+        let mut worst_status: Option<u16> = None;
+        let mut ok_count = 0usize;
         while let Some(res) = set.join_next().await {
             if let Ok((name, fetch_result)) = res {
                 let entry = match fetch_result {
                     Ok(resp) if resp.status().is_success() => {
+                        ok_count += 1;
                         let body: serde_json::Value = resp.json().await.unwrap_or_default();
                         let content = doc_content_to_string(&body);
                         serde_json::json!({"name": name, "content": content})
                     }
                     Ok(resp) => {
-                        serde_json::json!({"name": name, "error": format!("HTTP {}", resp.status())})
+                        let status = resp.status();
+                        if status.as_u16() == 404 && first_404_url.is_none() {
+                            first_404_url = Some(iris.versioned_ns_url(
+                                &namespace,
+                                &format!("/doc/{}", urlencoding::encode(&name)),
+                            ));
+                        }
+                        // A per-document `error_code` so a caller branches on the code here
+                        // exactly as it does on the envelope's — a 401 in this array used to
+                        // be indistinguishable from a missing document.
+                        //
+                        // The status that speaks for the whole batch is the most ACTIONABLE
+                        // one, not the numerically largest: in a mixed 401/404 batch the
+                        // credentials are the reason to act, and "some of these documents do
+                        // not exist" is a detail of a call that was never allowed to run.
+                        worst_status = Some(match (worst_status, status.as_u16()) {
+                            (Some(w), _)
+                                if crate::tools::envelope::auth_status_code(w).is_some() =>
+                            {
+                                w
+                            }
+                            (_, s) if crate::tools::envelope::auth_status_code(s).is_some() => s,
+                            (Some(w), s) => w.max(s),
+                            (None, s) => s,
+                        });
+                        serde_json::json!({
+                            "name": name,
+                            "error": format!("HTTP {status}"),
+                            "error_code": crate::tools::envelope::http_status_code(status.as_u16()),
+                        })
                     }
-                    Err(e) => serde_json::json!({"name": name, "error": e.to_string()}),
+                    Err(e) => serde_json::json!({
+                        "name": name,
+                        "error": e.to_string(),
+                        "error_code": crate::tools::envelope::transport_error_code(&e.to_string()),
+                    }),
                 };
                 map.insert(name, entry);
             }
         }
         let results: Vec<_> = p.names.iter().filter_map(|n| map.remove(n)).collect();
-        return ok_json(serde_json::json!({"success": true, "documents": results}));
+        // `!p.names.is_empty()`, not `!results.is_empty()`: a join that never produced an
+        // entry at all is still a document that was not read, and the empty-`documents`
+        // envelope must not come back claiming success either.
+        if ok_count == 0 && !p.names.is_empty() {
+            // Nothing was read. `success: true` here is the #102 shape verbatim — an envelope
+            // claiming the call worked while every document in it failed.
+            if let Some(url) = &first_404_url {
+                if let Some(explained) = crate::tools::interop::namespace_missing_error(
+                    iris,
+                    client,
+                    &namespace,
+                    url,
+                    "Nothing was read.",
+                )
+                .await
+                {
+                    return explained;
+                }
+            }
+            let code = worst_status.map_or("IRIS_REQUEST_FAILED", |s| {
+                crate::tools::envelope::http_status_code(s)
+            });
+            return crate::tools::envelope::fail_with(
+                code,
+                &format!(
+                    "None of the {} requested documents could be read from namespace \
+                     '{namespace}' — see `documents` for the per-document status.",
+                    p.names.len()
+                ),
+                serde_json::json!({"documents": results, "namespace": namespace}),
+            );
+        }
+        // A partial failure keeps success:true — some documents WERE read — but names the
+        // namespace it read them from, which the baseline never did either.
+        return ok_json(serde_json::json!({
+            "success": true,
+            "documents": results,
+            "namespace": namespace,
+        }));
     }
 
     let name = match require_name(&p, "get") {
@@ -335,6 +414,21 @@ async fn handle_get(
     };
 
     if resp.status().as_u16() == 404 {
+        // #102 P1: the 404 body is ZERO bytes, so "no such document" and "no such namespace"
+        // are the same wire response — and this named the DOCUMENT for both. `None` from the
+        // helper means the namespace is confirmed present (or cannot be checked), and then
+        // NOT_FOUND naming the document is right and survives.
+        if let Some(missing) = crate::tools::interop::namespace_missing_error(
+            iris,
+            client,
+            &namespace,
+            &url,
+            "Nothing was read.",
+        )
+        .await
+        {
+            return missing;
+        }
         return err_json("NOT_FOUND", &format!("Document not found: {name}"));
     }
     if !resp.status().is_success() {
@@ -856,6 +950,19 @@ async fn handle_delete(
     };
 
     if resp.status().as_u16() == 404 {
+        // #102 P1: same zero-byte 404 as handle_get — a missing namespace was reported as a
+        // missing document, and the caller had no way to tell.
+        if let Some(missing) = crate::tools::interop::namespace_missing_error(
+            iris,
+            client,
+            &namespace,
+            &url,
+            "Nothing was deleted.",
+        )
+        .await
+        {
+            return missing;
+        }
         return err_json("NOT_FOUND", &format!("Document not found: {name}"));
     }
     if !resp.status().is_success() {
@@ -899,7 +1006,52 @@ async fn handle_head(
         Err(e) => return crate::tools::envelope::transport_fail("handle_head", &e.to_string()),
     };
 
-    let exists = resp.status().is_success();
+    // #102 P0: this was `let exists = resp.status().is_success();` — so EVERY non-2xx became
+    // a confident `{"success":true,"exists":false}`. Verified live twice: a document that
+    // provably exists was reported absent both for a namespace that does not exist (404) and,
+    // separately, for a wrong password against a namespace that does (401). A failed call must
+    // become an ERROR, never a negative answer. Only a 404 is a legitimate "not there".
+    let status = resp.status();
+    if !status.is_success() && status.as_u16() != 404 {
+        return http_err(resp, Some(name)).await;
+    }
+    if status.as_u16() == 404 {
+        // ...and even a 404 has two meanings on a zero-byte body: no such document, or no
+        // such namespace. This asked `namespace_missing_error`, whose `None` merges "the
+        // namespace is confirmed present" with "nothing could be established" — and then fell
+        // through to `exists = status.is_success()` for BOTH. Under a wrong IRIS_WEB_PREFIX
+        // that produced `{"success":true,"exists":false}` for %Library.String.cls, a class
+        // that answers exists:true one call earlier on the right prefix (reproduced live, and
+        // again against an all-404 stub). `exists:false` is a FACT claim; it may only be
+        // emitted on the arm where the namespace was actually confirmed.
+        use crate::tools::interop::FourOhFour;
+        match crate::tools::interop::classify_404(
+            iris,
+            client,
+            &namespace,
+            &url,
+            "Nothing was read.",
+        )
+        .await
+        {
+            FourOhFour::Explained(e) => return e,
+            // The namespace is there, so the document really is not: the true negative, and
+            // the overwhelmingly common case, is preserved exactly.
+            FourOhFour::TargetMissing => {}
+            FourOhFour::Undetermined => {
+                return crate::tools::interop::indeterminate_404_error(
+                    iris,
+                    &namespace,
+                    &url,
+                    &format!(
+                        "Whether '{name}' exists is therefore unknown — reporting exists:false \
+                         here would be a guess dressed as a reading."
+                    ),
+                )
+            }
+        }
+    }
+    let exists = status.is_success();
     let ts = resp
         .headers()
         .get("ETag")
@@ -1047,8 +1199,20 @@ mod tests {
         assert_eq!(http_error_code(StatusCode::BAD_REQUEST), "IRIS_BAD_REQUEST");
         assert_eq!(http_error_code(StatusCode::LOCKED), "IRIS_LOCKED");
         assert_eq!(http_error_code(StatusCode::CONFLICT), "IRIS_CONFLICT");
-        assert_eq!(http_error_code(StatusCode::UNAUTHORIZED), "IRIS_AUTH");
-        assert_eq!(http_error_code(StatusCode::FORBIDDEN), "IRIS_AUTH");
+        // #101: 401 and 403 are two problems with two disjoint remedies — a 401 caller edits
+        // IRIS_PASSWORD, a 403 caller cannot (IRIS validated the password before it could
+        // evaluate %Development). One code would have left English prose in `hint` as the
+        // only thing separating them.
+        assert_eq!(
+            http_error_code(StatusCode::UNAUTHORIZED),
+            "IRIS_AUTH_FAILED"
+        );
+        assert_eq!(http_error_code(StatusCode::FORBIDDEN), "IRIS_FORBIDDEN");
+        assert_ne!(
+            http_error_code(StatusCode::UNAUTHORIZED),
+            http_error_code(StatusCode::FORBIDDEN),
+            "a 401 and a 403 must not share an error_code"
+        );
         assert_eq!(http_error_code(StatusCode::NOT_FOUND), "NOT_FOUND");
         assert_eq!(
             http_error_code(StatusCode::INTERNAL_SERVER_ERROR),
@@ -1174,5 +1338,477 @@ mod doc_name_suffix_tests {
         assert!(hint.contains("type suffix"), "{hint}");
         assert!(hint.contains("MyApp.Thing.cls"), "{hint}");
         assert!(doc_suffix_hint("MyApp.Thing.cls").is_none());
+    }
+}
+
+// ── Issue #102: a failed call may never become a negative ANSWER ─────────────
+//
+// The matrix is the same for every site, because the defect was NOT 404-blindness — it was
+// non-2xx blindness. Case (d) is the one the issue text missed and the one written first: a
+// wrong password against a namespace that EXISTS produced the identical lie.
+#[cfg(test)]
+mod head_get_delete_status_tests {
+    use super::*;
+    use crate::iris::connection::DiscoverySource;
+    use wiremock::matchers::{method, path_regex};
+    use wiremock::{Mock, MockServer, ResponseTemplate};
+
+    fn rt() -> tokio::runtime::Runtime {
+        tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .unwrap()
+    }
+
+    fn root_descriptor(namespaces: &[&str]) -> serde_json::Value {
+        serde_json::json!({"result": {"content": {
+            "version": "IRIS for UNIX 2026.1", "api": 8, "namespaces": namespaces
+        }}})
+    }
+
+    fn params(mode: &str, namespace: &str) -> IrisDocParams {
+        serde_json::from_value(serde_json::json!({
+            "mode": mode, "name": "Ens.Director.cls", "namespace": namespace
+        }))
+        .unwrap()
+    }
+
+    fn payload(r: &rmcp::model::CallToolResult) -> serde_json::Value {
+        match &r.content[0].raw {
+            rmcp::model::RawContent::Text(t) => serde_json::from_str(&t.text).unwrap(),
+            _ => panic!("expected text content"),
+        }
+    }
+
+    /// Mount a `/doc/...` response for `verb` plus a root descriptor, then run the handler.
+    async fn run(
+        verb: &str,
+        doc: ResponseTemplate,
+        root: Option<ResponseTemplate>,
+        ns: &str,
+    ) -> (Option<bool>, serde_json::Value) {
+        let server = MockServer::start().await;
+        Mock::given(method(verb))
+            .and(path_regex(r".*/doc/.*"))
+            .respond_with(doc)
+            .mount(&server)
+            .await;
+        if let Some(root) = root {
+            Mock::given(method("GET"))
+                .and(path_regex(r"^/api/atelier/$"))
+                .respond_with(root)
+                .mount(&server)
+                .await;
+        }
+        let iris = IrisConnection::new(
+            server.uri(),
+            "APP",
+            "_SYSTEM",
+            "SYS",
+            DiscoverySource::EnvVar,
+        );
+        let client = reqwest::Client::new();
+        let mode = match verb {
+            "HEAD" => "head",
+            "DELETE" => "delete",
+            _ => "get",
+        };
+        let p = params(mode, ns);
+        let r = match mode {
+            "head" => handle_head(&iris, &client, p).await,
+            "delete" => handle_delete(&iris, &client, p).await,
+            _ => handle_get(&iris, &client, p).await,
+        }
+        .expect("the tool must answer, not error out of the transport");
+        (r.is_error, payload(&r))
+    }
+
+    fn ok_root() -> ResponseTemplate {
+        ResponseTemplate::new(200).set_body_json(root_descriptor(&["APP", "USER"]))
+    }
+
+    /// (a) A document that is there is still reported as there.
+    #[test]
+    fn head_still_answers_exists_true_for_a_document_that_exists() {
+        rt().block_on(async {
+            let (is_err, v) = run("HEAD", ResponseTemplate::new(200), None, "APP").await;
+            assert_ne!(is_err, Some(true), "{v}");
+            assert_eq!(v["success"], true, "{v}");
+            assert_eq!(v["exists"], true, "{v}");
+        });
+    }
+
+    /// (b) The legitimate negative — the namespace IS there, the document is not. The guard
+    /// against over-firing: this must NOT become NAMESPACE_NOT_FOUND.
+    #[test]
+    fn head_keeps_exists_false_when_the_namespace_is_confirmed_present() {
+        rt().block_on(async {
+            let (is_err, v) = run("HEAD", ResponseTemplate::new(404), Some(ok_root()), "APP").await;
+            assert_ne!(is_err, Some(true), "{v}");
+            assert_eq!(v["success"], true, "{v}");
+            assert_eq!(v["exists"], false, "{v}");
+        });
+    }
+
+    /// (c) #93 applied to iris_doc: a 404 body is ZERO bytes, so only a second question can
+    /// tell "no such document" from "no such namespace".
+    #[test]
+    fn head_names_the_namespace_when_the_namespace_is_the_reason() {
+        rt().block_on(async {
+            let (is_err, v) = run(
+                "HEAD",
+                ResponseTemplate::new(404),
+                Some(ok_root()),
+                "ZZNOSUCHNS",
+            )
+            .await;
+            assert_eq!(is_err, Some(true), "{v}");
+            assert_eq!(v["error_code"], "NAMESPACE_NOT_FOUND", "{v}");
+            assert_eq!(
+                v["available_namespaces"],
+                serde_json::json!(["APP", "USER"]),
+                "{v}"
+            );
+            assert!(
+                v["attempted_url"].as_str().unwrap().contains("ZZNOSUCHNS"),
+                "{v}"
+            );
+            assert!(!v.to_string().contains("Check IRIS_HOST"), "{v}");
+            assert!(
+                v["hint"].as_str().unwrap().contains("Nothing was read"),
+                "{v}"
+            );
+        });
+    }
+
+    /// (d) THE ASSERTION THAT ENCODES THE ISSUE. Live, with a wrong password against APP — a
+    /// namespace that exists, on an instance that answers — `iris_doc(head)` said the document
+    /// did not exist. It provably did. A 401 is not an answer about a document.
+    #[test]
+    fn head_reports_a_401_instead_of_claiming_the_document_is_absent() {
+        rt().block_on(async {
+            let (is_err, v) = run(
+                "HEAD",
+                ResponseTemplate::new(401).set_body_string("Unauthorized"),
+                Some(ok_root()),
+                "APP",
+            )
+            .await;
+            assert_eq!(is_err, Some(true), "{v}");
+            assert_eq!(v["error_code"], "IRIS_AUTH_FAILED", "{v}");
+            assert_eq!(
+                v["exists"],
+                serde_json::Value::Null,
+                "no negative FACT: {v}"
+            );
+            assert_eq!(v["success"], false, "{v}");
+            assert!(v["hint"].as_str().unwrap().contains("IRIS_PASSWORD"), "{v}");
+        });
+    }
+
+    /// (d, continued) 403 and 5xx are failures too, and each says which kind.
+    #[test]
+    fn head_codes_a_403_and_a_500_from_the_status() {
+        rt().block_on(async {
+            for (status, code) in [(403u16, "IRIS_FORBIDDEN"), (500, "IRIS_SERVER_ERROR")] {
+                let (is_err, v) = run(
+                    "HEAD",
+                    ResponseTemplate::new(status),
+                    Some(ok_root()),
+                    "APP",
+                )
+                .await;
+                assert_eq!(is_err, Some(true), "{v}");
+                assert_eq!(v["error_code"], code, "{v}");
+                assert_eq!(v["exists"], serde_json::Value::Null, "{v}");
+            }
+        });
+    }
+
+    /// (e) The cannot-tell contract, corrected. It used to read "leave the caller's own
+    /// ANSWER alone" and was pinned as `..._leaves_exists_false_alone` — which made a test
+    /// out of the P0 itself. `exists:false` is not the caller's error being preserved; it is
+    /// a FACT claim, `success:true`, `isError:false`, indistinguishable from the true
+    /// negative, and it was emitted precisely when the server had established nothing.
+    ///
+    /// Reproduced live against IRIS 2026.1 with `IRIS_WEB_PREFIX=/zznoprefix`:
+    /// `head(%Library.String.cls)` answered `{"exists":false,"success":true}` for a class
+    /// that answered `exists:true` on the correct prefix seconds earlier.
+    ///
+    /// Cannot-tell means the tool says so. Nothing here may read as a reading.
+    #[test]
+    fn an_unreadable_root_descriptor_never_becomes_exists_false() {
+        rt().block_on(async {
+            for root in [
+                // A sick instance, and an older Atelier that does not list namespaces.
+                ResponseTemplate::new(500),
+                ResponseTemplate::new(200).set_body_json(
+                    serde_json::json!({"result": {"content": {"version": "IRIS 2019.1"}}}),
+                ),
+            ] {
+                let (is_err, v) =
+                    run("HEAD", ResponseTemplate::new(404), Some(root), "ZZNOSUCHNS").await;
+                assert_eq!(is_err, Some(true), "an absent answer is an error: {v}");
+                assert_eq!(v["error_code"], "INDETERMINATE", "{v}");
+                assert_eq!(
+                    v["exists"],
+                    serde_json::Value::Null,
+                    "no negative FACT may survive: {v}"
+                );
+                assert_eq!(v["success"], false, "{v}");
+            }
+        });
+    }
+
+    /// ...and the case that IS knowable is answered, not shrugged at. A 404 root descriptor
+    /// means the Atelier application is not at this URL at all — the wrong-IRIS_WEB_PREFIX
+    /// signature — so head names that instead of either guessing or giving up.
+    #[test]
+    fn a_404_root_descriptor_makes_head_name_the_prefix() {
+        rt().block_on(async {
+            let (is_err, v) = run(
+                "HEAD",
+                ResponseTemplate::new(404),
+                Some(ResponseTemplate::new(404)),
+                "APP",
+            )
+            .await;
+            assert_eq!(is_err, Some(true), "{v}");
+            assert_eq!(v["error_code"], "ATELIER_NOT_FOUND", "{v}");
+            assert_eq!(v["exists"], serde_json::Value::Null, "{v}");
+            assert!(
+                v["hint"].as_str().unwrap().contains("IRIS_WEB_PREFIX"),
+                "{v}"
+            );
+        });
+    }
+
+    // The guard that keeps (e) from swallowing the common case — a confirmed namespace still
+    // answers `exists:false` — is `head_keeps_exists_false_when_the_namespace_is_confirmed_present`
+    // above, unchanged by any of this. That is the point: only the arm with no evidence moved.
+
+    /// #102 P1 for get: a missing NAMESPACE was reported as a missing DOCUMENT.
+    #[test]
+    fn get_names_the_namespace_but_keeps_not_found_for_a_real_document_miss() {
+        rt().block_on(async {
+            let (_, v) = run("GET", ResponseTemplate::new(404), Some(ok_root()), "APP").await;
+            assert_eq!(v["error_code"], "NOT_FOUND", "the namespace is there: {v}");
+            assert!(
+                v["error"].as_str().unwrap().contains("Ens.Director.cls"),
+                "{v}"
+            );
+
+            let (_, v) = run(
+                "GET",
+                ResponseTemplate::new(404),
+                Some(ok_root()),
+                "ZZNOSUCHNS",
+            )
+            .await;
+            assert_eq!(v["error_code"], "NAMESPACE_NOT_FOUND", "{v}");
+            assert!(
+                v["hint"].as_str().unwrap().contains("Nothing was read"),
+                "{v}"
+            );
+        });
+    }
+
+    /// The same for delete — and its effect line says nothing was DELETED, not compiled.
+    #[test]
+    fn delete_names_the_namespace_but_keeps_not_found_for_a_real_document_miss() {
+        rt().block_on(async {
+            let (_, v) = run("DELETE", ResponseTemplate::new(404), Some(ok_root()), "APP").await;
+            assert_eq!(v["error_code"], "NOT_FOUND", "{v}");
+
+            let (_, v) = run(
+                "DELETE",
+                ResponseTemplate::new(404),
+                Some(ok_root()),
+                "ZZNOSUCHNS",
+            )
+            .await;
+            assert_eq!(v["error_code"], "NAMESPACE_NOT_FOUND", "{v}");
+            assert!(
+                v["hint"].as_str().unwrap().contains("Nothing was deleted"),
+                "the hint must not claim a compile that never happened: {v}"
+            );
+        });
+    }
+
+    // ── #102 P1, the BATCH arm of get ────────────────────────────────────────
+    //
+    // The single-name path above was fixed while `names: [...]`, twenty lines higher in the
+    // same function, stayed byte-identical to the baseline. It answered
+    // {"documents":[{"error":"HTTP 404 Not Found"},…],"success":true} — isError:false — for a
+    // namespace that does not exist, which is worse than the bug the issue described: the
+    // envelope claimed the call worked.
+
+    /// Run batch get for `names` against a `/doc/...` mock and the given root descriptor.
+    async fn run_batch(
+        doc: ResponseTemplate,
+        root: Option<ResponseTemplate>,
+        ns: &str,
+        names: &[&str],
+    ) -> (Option<bool>, serde_json::Value) {
+        let server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(path_regex(r".*/doc/.*"))
+            .respond_with(doc)
+            .mount(&server)
+            .await;
+        if let Some(root) = root {
+            Mock::given(method("GET"))
+                .and(path_regex(r"^/api/atelier/$"))
+                .respond_with(root)
+                .mount(&server)
+                .await;
+        }
+        let iris = IrisConnection::new(
+            server.uri(),
+            "APP",
+            "_SYSTEM",
+            "SYS",
+            DiscoverySource::EnvVar,
+        );
+        let p: IrisDocParams = serde_json::from_value(serde_json::json!({
+            "mode": "get", "names": names, "namespace": ns
+        }))
+        .unwrap();
+        let r = handle_get(&iris, &reqwest::Client::new(), p)
+            .await
+            .expect("the tool must answer, not error out of the transport");
+        (r.is_error, payload(&r))
+    }
+
+    /// The filed shape: every document 404s because the NAMESPACE is missing, and the
+    /// envelope said success while never mentioning the namespace.
+    #[test]
+    fn a_batch_get_in_a_missing_namespace_names_the_namespace_and_fails() {
+        rt().block_on(async {
+            let (is_err, v) = run_batch(
+                ResponseTemplate::new(404),
+                Some(ok_root()),
+                "ZZNOSUCHNS",
+                &["%Library.String.cls", "%Library.Integer.cls"],
+            )
+            .await;
+            assert_eq!(
+                is_err,
+                Some(true),
+                "nothing was read — that is a failure: {v}"
+            );
+            assert_eq!(v["error_code"], "NAMESPACE_NOT_FOUND", "{v}");
+            assert_eq!(v["success"], false, "{v}");
+            assert!(
+                v["available_namespaces"]
+                    .as_array()
+                    .is_some_and(|a| !a.is_empty()),
+                "#93 asks for the namespaces that DO exist: {v}"
+            );
+        });
+    }
+
+    /// A 401 across the batch is credentials, not a pile of missing documents — and it must
+    /// carry the same code and hint the single-name path gives (#101).
+    #[test]
+    fn a_batch_get_rejected_by_credentials_says_so() {
+        rt().block_on(async {
+            let (is_err, v) = run_batch(
+                ResponseTemplate::new(401),
+                Some(ok_root()),
+                "APP",
+                &["A.cls", "B.cls"],
+            )
+            .await;
+            assert_eq!(is_err, Some(true), "{v}");
+            assert_eq!(v["error_code"], "IRIS_AUTH_FAILED", "{v}");
+            assert!(v["hint"].as_str().unwrap().contains("IRIS_PASSWORD"), "{v}");
+            // The per-document detail survives, and each entry is coded too.
+            assert_eq!(v["documents"][0]["error_code"], "IRIS_AUTH_FAILED", "{v}");
+        });
+    }
+
+    /// A batch where nothing was read but the statuses disagree speaks with the most
+    /// ACTIONABLE one. A 401 mixed with a 404 is a call that was never allowed to run — a
+    /// numerically-largest rule would have summarised it as NOT_FOUND and sent the caller
+    /// looking for documents instead of at the password.
+    #[test]
+    fn a_mixed_status_batch_leads_with_the_credentials() {
+        rt().block_on(async {
+            let server = MockServer::start().await;
+            Mock::given(method("GET"))
+                .and(path_regex(r".*/doc/LOCKED\.cls$"))
+                .respond_with(ResponseTemplate::new(401))
+                .mount(&server)
+                .await;
+            Mock::given(method("GET"))
+                .and(path_regex(r".*/doc/.*"))
+                .respond_with(ResponseTemplate::new(404))
+                .mount(&server)
+                .await;
+            Mock::given(method("GET"))
+                .and(path_regex(r"^/api/atelier/$"))
+                .respond_with(ResponseTemplate::new(200).set_body_json(root_descriptor(&["APP"])))
+                .mount(&server)
+                .await;
+            let iris = IrisConnection::new(
+                server.uri(),
+                "APP",
+                "_SYSTEM",
+                "SYS",
+                DiscoverySource::EnvVar,
+            );
+            let p: IrisDocParams = serde_json::from_value(serde_json::json!({
+                "mode": "get", "names": ["GONE.cls", "LOCKED.cls"], "namespace": "APP"
+            }))
+            .unwrap();
+            let r = handle_get(&iris, &reqwest::Client::new(), p).await.unwrap();
+            let v = payload(&r);
+            assert_eq!(r.is_error, Some(true), "{v}");
+            assert_eq!(v["error_code"], "IRIS_AUTH_FAILED", "{v}");
+            // Both per-document verdicts still survive intact.
+            assert_eq!(v["documents"][0]["error_code"], "NOT_FOUND", "{v}");
+            assert_eq!(v["documents"][1]["error_code"], "IRIS_AUTH_FAILED", "{v}");
+        });
+    }
+
+    /// The guard: a batch where SOMETHING was read is still a success, and the per-document
+    /// errors ride along exactly as before — only now they are coded and the namespace is
+    /// named.
+    #[test]
+    fn a_batch_get_that_read_something_is_still_a_success() {
+        rt().block_on(async {
+            let server = MockServer::start().await;
+            Mock::given(method("GET"))
+                .and(path_regex(r".*/doc/GOOD\.cls$"))
+                .respond_with(ResponseTemplate::new(200).set_body_json(
+                    serde_json::json!({"result": {"content": ["Class GOOD {", "}"]}}),
+                ))
+                .mount(&server)
+                .await;
+            Mock::given(method("GET"))
+                .and(path_regex(r".*/doc/.*"))
+                .respond_with(ResponseTemplate::new(404))
+                .mount(&server)
+                .await;
+            let iris = IrisConnection::new(
+                server.uri(),
+                "APP",
+                "_SYSTEM",
+                "SYS",
+                DiscoverySource::EnvVar,
+            );
+            let p: IrisDocParams = serde_json::from_value(serde_json::json!({
+                "mode": "get", "names": ["GOOD.cls", "MISSING.cls"], "namespace": "APP"
+            }))
+            .unwrap();
+            let r = handle_get(&iris, &reqwest::Client::new(), p).await.unwrap();
+            let v = payload(&r);
+            assert_ne!(r.is_error, Some(true), "{v}");
+            assert_eq!(v["success"], true, "{v}");
+            assert_eq!(v["namespace"], "APP", "{v}");
+            assert!(v["documents"][0]["content"].is_string(), "{v}");
+            assert_eq!(v["documents"][1]["error_code"], "NOT_FOUND", "{v}");
+        });
     }
 }

--- a/crates/iris-agentic-dev-core/src/tools/envelope.rs
+++ b/crates/iris-agentic-dev-core/src/tools/envelope.rs
@@ -58,19 +58,107 @@ pub fn fail_with(
 /// most common workshop failure (wrong port, container not running).
 ///
 /// `context` names the operation for the message; `err` is the underlying error.
+/// The `error_code` [`transport_fail`] would use, for the call sites that need the code
+/// without the envelope — per-item codes inside a batch result, for instance.
+pub fn transport_error_code(err: &str) -> &'static str {
+    if crate::tools::interop::is_network_error(err) {
+        "IRIS_UNREACHABLE"
+    } else {
+        "IRIS_REQUEST_FAILED"
+    }
+}
+
 pub fn transport_fail(context: &str, err: &str) -> Result<CallToolResult, McpError> {
     // #58: record it server-side too. Before #57 this condition surfaced as an rmcp
     // "response error" WARN; routing it through the envelope removed that line, so
     // without this the server would go quiet about the failure it just reported.
     tracing::warn!(context, error = err, "IRIS request failed");
-    if crate::tools::interop::is_network_error(err) {
-        fail(
+    match transport_error_code(err) {
+        "IRIS_UNREACHABLE" => fail(
             "IRIS_UNREACHABLE",
             &format!("{context} could not reach IRIS: {err}"),
-        )
-    } else {
-        fail("IRIS_REQUEST_FAILED", &format!("{context} failed: {err}"))
+        ),
+        code => fail(code, &format!("{context} failed: {err}")),
     }
+}
+
+/// Issue #101: the classifier for a response that DID arrive. `transport_fail` above covers
+/// `send()` returning `Err` — no response ever came back, so IRIS really is unreachable.
+/// This covers the other half: IRIS answered, with a status that is not 2xx. An HTTP
+/// *response* is proof of reachability, so **no status may map to `IRIS_UNREACHABLE`** —
+/// `doc.rs` has pinned that rule for itself since #57 (`test_http_error_code_is_accurate_not_unreachable`);
+/// this makes it the one rule for the whole surface instead of one file's private discipline.
+pub fn http_status_code(status: u16) -> &'static str {
+    match status {
+        400 => "IRIS_BAD_REQUEST",
+        // #101: 401 and 403 are two different problems with two disjoint remedies, so they
+        // get two codes. A 401 caller edits IRIS_USERNAME / IRIS_PASSWORD. A 403 caller
+        // cannot: IRIS validated the password BEFORE it could evaluate the `%Development`
+        // resource on `/api/atelier`, so on a 403 the password is provably correct and the
+        // fix is a granted role. `error_code` exists precisely so a consumer does not have
+        // to parse prose to pick a branch; one shared code would leave English text in
+        // `hint` as the only thing separating them.
+        401 => "IRIS_AUTH_FAILED",
+        403 => "IRIS_FORBIDDEN",
+        404 => "NOT_FOUND",
+        409 => "IRIS_CONFLICT",
+        423 => "IRIS_LOCKED",
+        s if s >= 500 => "IRIS_SERVER_ERROR",
+        _ => "IRIS_HTTP_ERROR",
+    }
+}
+
+/// `Some(code)` when the status is an authentication/authorization refusal, `None` otherwise.
+/// Lets a call site adopt the #101 codes without adopting a remap of every other status —
+/// which is how `iris_compile` keeps its #93 behaviour for 404 verbatim.
+pub fn auth_status_code(status: u16) -> Option<&'static str> {
+    match status {
+        401 => Some("IRIS_AUTH_FAILED"),
+        403 => Some("IRIS_FORBIDDEN"),
+        _ => None,
+    }
+}
+
+/// The string-level sibling of `interop::is_network_error`, for the many call sites that
+/// hold only an `anyhow` message by the time they classify.
+///
+/// Deliberately narrow, per the Bug-18 lesson recorded at `interop.rs:16` (a loose
+/// `contains("connection")` swallowed "No Interoperability connection configured"): a bare
+/// `contains("401")` would match an IRIS message ID, a line number or a byte count and would
+/// ship a NEW wrong answer to fix an old one. Require the token pair.
+pub fn auth_error_code(msg: &str) -> Option<&'static str> {
+    if msg.contains("HTTP 401") || msg.contains("401 Unauthorized") {
+        return Some("IRIS_AUTH_FAILED");
+    }
+    if msg.contains("HTTP 403") || msg.contains("403 Forbidden") {
+        return Some("IRIS_FORBIDDEN");
+    }
+    None
+}
+
+/// Issue #101: the `transport_fail` slot one layer up — a failure envelope for a response
+/// that arrived. `attempted_url` rides along because it is genuinely useful (unlike the
+/// "Check IRIS_HOST and IRIS_WEB_PORT" hint this replaces, which was wrong for every status).
+pub fn http_status_fail(
+    context: &str,
+    status: reqwest::StatusCode,
+    attempted_url: &str,
+) -> Result<CallToolResult, McpError> {
+    let code = http_status_code(status.as_u16());
+    // #58: record it server-side too, exactly as `transport_fail` does — the server must not
+    // go quiet about the failure it just reported.
+    tracing::warn!(
+        context,
+        status = status.as_u16(),
+        url = attempted_url,
+        code,
+        "IRIS answered with a non-success status"
+    );
+    fail_with(
+        code,
+        &format!("HTTP {status}"),
+        serde_json::json!({ "attempted_url": attempted_url }),
+    )
 }
 
 /// Mechanical recoveries for failures the workshop data showed carry no hint
@@ -90,6 +178,33 @@ fn builtin_hint(code: &str, msg: &str) -> Option<String> {
             "IRIS did not answer on the configured host/port. Check the instance is running \
              (for Docker: `docker ps`), and check IRIS_HOST / IRIS_WEB_PORT — call check_config \
              to see which host, port and namespace this server is actually using."
+                .into(),
+        );
+    }
+    // #101: one wrong environment variable used to produce six different error codes and
+    // not one of them contained the word "password". These two say which variable, and the
+    // 403 one says out loud that the password is NOT the problem — the sentence that stops a
+    // caller burning a session on the wrong knob.
+    if code == "IRIS_AUTH_FAILED" {
+        return Some(
+            "IRIS answered on the configured host and port and rejected the credentials \
+             (HTTP 401) — the host and port are fine. Check IRIS_USERNAME / IRIS_PASSWORD; \
+             call check_config to see which host, port, namespace and user this server is \
+             actually using. On a community container started without IRIS_PASSWORD, basic \
+             auth is disabled entirely — restart it with -e IRIS_PASSWORD=... . A user \
+             lacking the %Development resource on /api/atelier can also surface here on some \
+             web-application configurations."
+                .into(),
+        );
+    }
+    if code == "IRIS_FORBIDDEN" {
+        return Some(
+            "IRIS accepted these credentials and refused the operation (HTTP 403) — the \
+             password is not the problem. This user lacks a required privilege: the \
+             /api/atelier web application requires the %Development resource, and the target \
+             namespace requires its %DB_* resource. Grant the role in the Management Portal \
+             (System Administration > Security > Users), or target a namespace this user can \
+             reach. Do not change IRIS_USERNAME / IRIS_PASSWORD."
                 .into(),
         );
     }
@@ -154,6 +269,98 @@ mod tests {
         )
         .unwrap();
         assert_eq!(payload(&r)["hint"], "custom recovery");
+    }
+
+    // ── Issue #101: an HTTP response is proof of reachability ────────────────
+    //
+    /// The durable guard for this whole issue class. `doc.rs` has asserted this for its own
+    /// private map since #57; the map now lives here, so the rule is enforced for every tool
+    /// that classifies a status — including the two files that violated it from outside
+    /// doc.rs (`iris_query`, `iris_symbols`).
+    #[test]
+    fn no_http_status_is_ever_reported_as_unreachable() {
+        for status in [400u16, 401, 403, 404, 409, 418, 423, 500, 502, 503] {
+            assert_ne!(
+                http_status_code(status),
+                "IRIS_UNREACHABLE",
+                "HTTP {status} arrived, so IRIS is reachable"
+            );
+            let r = http_status_fail(
+                "t",
+                reqwest::StatusCode::from_u16(status).unwrap(),
+                "http://h:1/api/atelier/v1/APP/action/query",
+            )
+            .unwrap();
+            let v = payload(&r);
+            assert_ne!(v["error_code"], "IRIS_UNREACHABLE", "{v}");
+            assert_eq!(r.is_error, Some(true), "{v}");
+            assert_eq!(
+                v["attempted_url"], "http://h:1/api/atelier/v1/APP/action/query",
+                "{v}"
+            );
+            assert!(
+                !v.to_string().contains("Check IRIS_HOST"),
+                "the host/port hint is for transport failures only: {v}"
+            );
+        }
+    }
+
+    /// Pins the DECISION, not only its consequences: if someone later collapses 401 and 403
+    /// into one code with one hint, this fails.
+    #[test]
+    fn a_401_and_a_403_do_not_share_an_error_code() {
+        assert_eq!(http_status_code(401), "IRIS_AUTH_FAILED");
+        assert_eq!(http_status_code(403), "IRIS_FORBIDDEN");
+        assert_ne!(http_status_code(401), http_status_code(403));
+        assert_eq!(auth_status_code(401), Some("IRIS_AUTH_FAILED"));
+        assert_eq!(auth_status_code(403), Some("IRIS_FORBIDDEN"));
+        assert_eq!(auth_status_code(404), None);
+        assert_eq!(auth_status_code(500), None);
+    }
+
+    /// A 401 caller edits an env var. A 403 caller must NOT: IRIS validated the password
+    /// before it could evaluate `%Development`, so on a 403 the password is provably correct
+    /// and sending the caller to re-check it is the same category of wrong answer as sending a
+    /// 401 caller to re-check IRIS_HOST.
+    #[test]
+    fn the_403_hint_never_tells_the_caller_to_check_their_password() {
+        let unauthorized = payload(&fail("IRIS_AUTH_FAILED", "HTTP 401 Unauthorized").unwrap());
+        let hint = unauthorized["hint"].as_str().unwrap();
+        assert!(hint.contains("IRIS_PASSWORD"), "{hint}");
+        assert!(!hint.contains("Check IRIS_HOST"), "{hint}");
+
+        let forbidden = payload(&fail("IRIS_FORBIDDEN", "HTTP 403 Forbidden").unwrap());
+        let hint = forbidden["hint"].as_str().unwrap();
+        assert!(
+            hint.contains("password is not the problem"),
+            "the sentence that stops a caller burning a session on the wrong variable: {hint}"
+        );
+        assert!(hint.contains("%Development"), "{hint}");
+        assert!(!hint.contains("Check IRIS_HOST"), "{hint}");
+    }
+
+    /// The Bug-18 guard, and the thing most likely to bite: a loose `contains("401")` would
+    /// match an IRIS message ID, a line number or a byte count and would ship a NEW wrong
+    /// answer to fix an old one.
+    #[test]
+    fn auth_error_code_requires_the_token_pair() {
+        assert_eq!(
+            auth_error_code("PUT doc failed: HTTP 401 Unauthorized"),
+            Some("IRIS_AUTH_FAILED")
+        );
+        assert_eq!(
+            auth_error_code("HTTP 403 from http://h/api/atelier/v1/APP/action/query"),
+            Some("IRIS_FORBIDDEN")
+        );
+        for innocent in [
+            "ERROR #401: something unrelated",
+            "compile errors at line 401",
+            "read 403 bytes",
+            "SQLCODE: -401",
+            "error sending request for url",
+        ] {
+            assert_eq!(auth_error_code(innocent), None, "{innocent}");
+        }
     }
 
     #[test]

--- a/crates/iris-agentic-dev-core/src/tools/info.rs
+++ b/crates/iris-agentic-dev-core/src/tools/info.rs
@@ -84,10 +84,9 @@ pub async fn handle_iris_info(
     };
 
     if !resp.status().is_success() {
-        return err_json(
-            "IRIS_UNREACHABLE",
-            &format!("HTTP {} for {}", resp.status(), url),
-        );
+        // #101: IRIS answered — it is reachable by definition. This said IRIS_UNREACHABLE for
+        // every status, so a wrong password sent the caller to debug networking.
+        return crate::tools::envelope::http_status_fail("iris_info", resp.status(), &url);
     }
 
     let body: serde_json::Value = resp.json().await.unwrap_or_default();
@@ -137,7 +136,13 @@ pub async fn handle_iris_macro(
     match p.action.as_str() {
         "list" => {
             // Bug 14: use versioned_ns_url instead of hardcoded /v1/.
-            let url = iris.versioned_ns_url(&namespace, "/docnames/INC");
+            // `INC` is not an Atelier document CATEGORY — the categories are CLS / RTN / CSP /
+            // OTH, and .inc files live under RTN. `/docnames/INC` answers HTTP 400 Bad Request
+            // on every instance (verified live on IRIS 2026.1 Build 235U), so this listing has
+            // never once worked. Nobody noticed because the non-2xx arm below swallowed it into
+            // `success:true, macros:[], "No include files found in this namespace"` — the very
+            // #102 P0 lie. Unmasking the status is what made the broken URL visible.
+            let url = iris.versioned_ns_url(&namespace, "/docnames/RTN");
             let resp = match client
                 .get(&url)
                 .basic_auth(&iris.username, Some(&iris.password))
@@ -152,19 +157,40 @@ pub async fn handle_iris_macro(
                     )
                 }
             };
+            // #102 P0: EVERY non-2xx used to become `success:true, macros:[], "No include
+            // files found in this namespace"` — a confident negative FACT produced by a call
+            // that never succeeded. Verified live with a wrong password against a namespace
+            // that exists and is reachable: HTTP 401, and the tool said there were no include
+            // files. A 2xx with an empty content array still answers macros:[]; that is the
+            // legitimate negative and it is unchanged.
             if !resp.status().is_success() {
-                return ok_json(serde_json::json!({
-                    "success": true,
-                    "macros": [],
-                    "note": "No include files found in this namespace"
-                }));
+                let status = resp.status();
+                if status.as_u16() == 404 {
+                    if let Some(missing) = crate::tools::interop::namespace_missing_error(
+                        iris,
+                        client,
+                        &namespace,
+                        &url,
+                        "No macros were listed.",
+                    )
+                    .await
+                    {
+                        return missing;
+                    }
+                }
+                return crate::tools::envelope::http_status_fail("iris_macro", status, &url);
             }
             let body: serde_json::Value = resp.json().await.unwrap_or_default();
+            // RTN carries .mac / .int / .inc / .bas together, and each element is an object
+            // (`{"cat":"RTN","name":"%apiCBIND.inc",...}`), not a bare string — the old
+            // `as_str()` would have dropped every name even if the URL had been right.
             let inc_files: Vec<String> = body["result"]["content"]
                 .as_array()
                 .unwrap_or(&vec![])
                 .iter()
-                .filter_map(|v| v.as_str().map(|s| s.to_string()))
+                .filter_map(|v| v["name"].as_str().or_else(|| v.as_str()))
+                .filter(|n| n.to_ascii_lowercase().ends_with(".inc"))
+                .map(|n| n.to_string())
                 .collect();
             ok_json(serde_json::json!({
                 "success": true,
@@ -483,10 +509,26 @@ if rs.%Next() {{
     {
         Ok(v) => v,
         Err(e) => {
-            return crate::tools::envelope::fail(
-                "IRIS_EXECUTE_ERROR",
-                &format!("info::output: {e}"),
+            // #102: a mistyped namespace answered `info::output: PUT doc failed: HTTP 404 Not
+            // Found` — the generator's scaffolding, not the caller's mistake. #101: a wrong
+            // password answered the same shape under IRIS_EXECUTE_ERROR, which named neither
+            // credentials nor the 401.
+            if let Some(missing) = crate::tools::interop::namespace_missing_error_for(
+                iris,
+                client,
+                &namespace,
+                "No table info was read.",
+                &e,
             )
+            .await
+            {
+                return missing;
+            }
+            let msg = e.to_string();
+            return crate::tools::envelope::fail(
+                crate::tools::interop::classify_iris_error_or(&msg, "IRIS_EXECUTE_ERROR"),
+                &format!("info::output: {msg}"),
+            );
         }
     };
 

--- a/crates/iris-agentic-dev-core/src/tools/interop.rs
+++ b/crates/iris-agentic-dev-core/src/tools/interop.rs
@@ -23,6 +23,30 @@ pub(crate) fn is_network_error(msg: &str) -> bool {
         || msg.contains("timed out")
 }
 
+/// Issue #101: ONE decision for "what kind of IRIS failure is this string", replacing 34
+/// hand-copied `if is_network_error(..) { "IRIS_UNREACHABLE" } else { "INTEROP_ERROR" }`
+/// ternaries that had no auth arm at all — so every credential failure landed in the
+/// INTEROP_ERROR bucket and no message ever contained the word "password".
+///
+/// Order matters: auth first (an HTTP 401 response is proof IRIS is REACHABLE, so it must
+/// never fall through to the network arm), then network, then the interop default.
+pub(crate) fn classify_iris_error(msg: &str) -> &'static str {
+    classify_iris_error_or(msg, "INTEROP_ERROR")
+}
+
+/// [`classify_iris_error`] for the two arms whose non-auth, non-network default is
+/// `IRIS_EXECUTE_ERROR` rather than `INTEROP_ERROR`. Same precedence, different tail.
+pub(crate) fn classify_iris_error_or(msg: &str, fallback: &'static str) -> &'static str {
+    if let Some(code) = crate::tools::envelope::auth_error_code(msg) {
+        return code;
+    }
+    if is_network_error(msg) {
+        "IRIS_UNREACHABLE"
+    } else {
+        fallback
+    }
+}
+
 fn default_ns() -> String {
     "USER".to_string()
 }
@@ -123,7 +147,15 @@ pub async fn ensure_interop_namespace(
         .await;
     let n = match &probe {
         Ok(resp) => resp["result"]["content"][0]["n"].as_i64()?,
-        Err(_) => return None,
+        // #102: ONE arm, NINE tools. This pre-flight already runs ahead of iris_production,
+        // iris_production_item, iris_message_body, iris_business_rule_info,
+        // iris_production_diff, iris_credential_list, iris_credential_manage,
+        // iris_lookup_manage and iris_lookup_transfer — so a mistyped namespace that used to
+        // surface as `INTEROP_ERROR: "PUT doc failed: HTTP 404 Not Found"` is named here for
+        // all of them. Any other failure still returns None so the tool's own error survives.
+        Err(e) => {
+            return namespace_missing_error_for(iris, &client, ns, "Nothing was run.", e).await
+        }
     };
     if n >= 1 {
         if let Ok(mut c) = cache.lock() {
@@ -183,15 +215,90 @@ pub async fn namespace_missing_error(
     client: &reqwest::Client,
     ns: &str,
     attempted_url: &str,
+    effect: &str,
 ) -> Option<Result<CallToolResult, McpError>> {
-    let available = iris.accessible_namespaces(client).await?;
+    match classify_404(iris, client, ns, attempted_url, effect).await {
+        FourOhFour::Explained(e) => Some(e),
+        FourOhFour::TargetMissing | FourOhFour::Undetermined => None,
+    }
+}
+
+/// Issue #102: what a 404 at a tool's own URL turned out to MEAN.
+///
+/// [`namespace_missing_error`]'s `Option` says "I have a better error" / "I don't", which is
+/// all a caller needs when its own fallback is already an *error*. It is NOT enough for a
+/// caller whose fallback is a **negative answer reported as success** — `iris_doc` mode=head's
+/// `exists:false`. That caller must distinguish "the namespace is confirmed present, so the
+/// document really is absent" from "nothing was established", and the `Option` cannot: both
+/// arrive as `None`.
+///
+/// Collapsing them is exactly how head came to answer `{"success":true,"exists":false}` for
+/// `%Library.String.cls` — a class that answers `exists:true` one call earlier — under a wrong
+/// `IRIS_WEB_PREFIX`. "Unknowable" is not licence to answer.
+pub enum FourOhFour {
+    /// The namespace is visible to these credentials, so the 404 is about the target itself.
+    /// A negative answer about the target is now backed by evidence.
+    TargetMissing,
+    /// A definitively better error: the namespace does not exist, or the Atelier application
+    /// is not published at this URL at all.
+    Explained(Result<CallToolResult, McpError>),
+    /// The root descriptor established nothing. Keep your own ERROR — but never emit a
+    /// negative FACT that depends on this having been knowable.
+    Undetermined,
+}
+
+/// The one place that turns a 404 + the Atelier root descriptor into a verdict.
+/// [`namespace_missing_error`] is the two-state view of this for callers that only need
+/// "better error or not".
+pub async fn classify_404(
+    iris: &IrisConnection,
+    client: &reqwest::Client,
+    ns: &str,
+    attempted_url: &str,
+    effect: &str,
+) -> FourOhFour {
+    use crate::iris::connection::RootProbe;
+    let available = match iris.root_probe(client).await {
+        RootProbe::Namespaces(list) => list,
+        // #101 regression + #102 P0, one arm. A 404 at the tool's URL AND a 404 at the API's
+        // own root descriptor is not "cannot tell": nothing that serves Atelier 404s its root.
+        // Before this, the pair produced a bare `NOT_FOUND` about a document that was never
+        // looked for, and `IRIS_WEB_PREFIX` — the thing that is actually wrong — was named
+        // nowhere in the response.
+        RootProbe::NoAtelierHere { url } => {
+            return FourOhFour::Explained(atelier_not_found_error(
+                iris,
+                &url,
+                attempted_url,
+                effect,
+            ))
+        }
+        RootProbe::Unknown => return FourOhFour::Undetermined,
+    };
     if available
         .iter()
         .any(|n| n.trim().eq_ignore_ascii_case(ns.trim()))
     {
-        return None;
+        return FourOhFour::TargetMissing;
     }
-    Some(crate::tools::envelope::fail_with(
+    FourOhFour::Explained(namespace_not_found_error(
+        iris,
+        ns,
+        &available,
+        attempted_url,
+        effect,
+    ))
+}
+
+/// The #93 answer, split out so [`classify_404`] reads as three verdicts and one shape.
+fn namespace_not_found_error(
+    iris: &IrisConnection,
+    ns: &str,
+    available: &[String],
+    attempted_url: &str,
+    effect: &str,
+) -> Result<CallToolResult, McpError> {
+    crate::tools::envelope::fail_with(
         crate::tools::ERR_NAMESPACE_NOT_FOUND,
         &format!(
             "Namespace '{ns}' does not exist on this IRIS instance, or is not accessible to \
@@ -207,13 +314,121 @@ pub async fn namespace_missing_error(
             "attempted_url": attempted_url,
             // Explicit, so the IRIS_UNREACHABLE host/port hint this replaces can never
             // reappear through `builtin_hint` (envelope.rs).
+            // #102: `effect` is the caller's own "and here is what did NOT happen" tail.
+            // It was hard-coded to "Nothing was compiled." when only iris_compile called
+            // this; reusing the helper unchanged at the iris_doc / iris_query / iris_test
+            // sites would have had them all report a compile that never happened.
             "hint": format!(
                 "Pass namespace= one of the listed namespaces (omitting it targets the \
-                 connection namespace '{}'). Nothing was compiled.",
+                 connection namespace '{}'). {effect}",
                 iris.namespace
             ),
         }),
-    ))
+    )
+}
+
+/// Issue #101 (the `IRIS_WEB_PREFIX` regression) + #102 P0: a 404 at the tool's URL whose
+/// cause is the URL itself, not anything in IRIS.
+///
+/// `IRIS_UNREACHABLE` — which the baseline used here, with "Check IRIS_HOST and
+/// IRIS_WEB_PORT" — is the one code this cannot be: IRIS answered, twice. But the code that
+/// replaced it, a bare `NOT_FOUND` about a document, was a confident negative about a
+/// document the request never went looking for. `ATELIER_NOT_FOUND` says the true thing: the
+/// host and port are fine, and the path is not.
+fn atelier_not_found_error(
+    iris: &IrisConnection,
+    root_url: &str,
+    attempted_url: &str,
+    effect: &str,
+) -> Result<CallToolResult, McpError> {
+    crate::tools::envelope::fail_with(
+        crate::tools::ERR_ATELIER_NOT_FOUND,
+        &format!(
+            "The Atelier REST API is not published at {base}/api/atelier — IRIS answered on \
+             {base}, but a GET of {root_url}, the API's own root descriptor that every IRIS \
+             with Atelier enabled serves, returned 404 as well. The request never reached a \
+             namespace or a document, so nothing here is evidence about either.",
+            base = iris.base_url.trim_end_matches('/'),
+        ),
+        serde_json::json!({
+            "attempted_url": attempted_url,
+            "root_url": root_url,
+            "base_url": iris.base_url,
+            // Explicit, so `builtin_hint` can never put the host/port advice back — the host
+            // and port are the two things this response has just PROVED are right.
+            "hint": format!(
+                "Check IRIS_WEB_PREFIX. This server is building every URL as \
+                 {base}/api/atelier/... — behind a web gateway the API is usually published \
+                 under a prefix, and a wrong or missing one 404s every request including the \
+                 root. Then confirm the /api/atelier web application is enabled (Management \
+                 Portal > System Administration > Security > Applications > Web \
+                 Applications). IRIS_HOST and IRIS_WEB_PORT are answering and are not the \
+                 problem. {effect}",
+                base = iris.base_url.trim_end_matches('/'),
+            ),
+        }),
+    )
+}
+
+/// Issue #102 P0: the answer when a 404 could not be attributed and the caller's own
+/// fallback would have been a negative FACT.
+///
+/// An Atelier 404 has a zero-byte body: "no such document" and "no such namespace" are the
+/// same bytes on the wire. When the root descriptor cannot settle which, the honest output is
+/// an error saying so — not `exists:false`, which reads as evidence and is indistinguishable
+/// from the true negative. `question` names what could not be settled.
+pub fn indeterminate_404_error(
+    iris: &IrisConnection,
+    ns: &str,
+    attempted_url: &str,
+    question: &str,
+) -> Result<CallToolResult, McpError> {
+    crate::tools::envelope::fail_with(
+        crate::tools::ERR_INDETERMINATE,
+        &format!(
+            "IRIS answered HTTP 404 for {attempted_url}, and this server could not establish \
+             what the 404 was about. An Atelier 404 carries a ZERO-byte body, so a missing \
+             document and a missing namespace are byte-for-byte identical; the follow-up read \
+             of {base}/api/atelier/ — the root descriptor, which lists the namespaces these \
+             credentials can reach — did not come back readable, so '{ns}' could be neither \
+             confirmed nor ruled out. {question}",
+            base = iris.base_url.trim_end_matches('/'),
+        ),
+        serde_json::json!({
+            "namespace": ns,
+            "attempted_url": attempted_url,
+            "base_url": iris.base_url,
+            "hint": format!(
+                "This is not a negative answer — it is the absence of one. Call check_config \
+                 to see the host, port and namespace in use, then confirm '{ns}' with \
+                 iris_query on it. If the root descriptor is unreadable because the instance \
+                 is unwell (5xx) the same call will show it; if IRIS is an older build that \
+                 does not list namespaces, name the namespace explicitly and retry."
+            ),
+        }),
+    )
+}
+
+/// Issue #102: the `anyhow` adapter for [`namespace_missing_error`]. It makes NO judgement of
+/// its own — it downcasts, checks the status is a 404, and delegates — so the
+/// `None`-means-cannot-tell contract still lives in exactly one place.
+///
+/// A 404 is the only status worth asking about: a 401/403 is credentials (#101 owns it) and a
+/// 5xx is a sick instance. This is what lets a `query()` / `execute_via_generator()` failure
+/// deep inside a tool be attributed to a mistyped namespace instead of being reported as
+/// Docker, or as an unreachable instance that is answering perfectly.
+pub async fn namespace_missing_error_for(
+    iris: &IrisConnection,
+    client: &reqwest::Client,
+    ns: &str,
+    effect: &str,
+    err: &anyhow::Error,
+) -> Option<Result<CallToolResult, McpError>> {
+    let http = crate::iris::connection::atelier_status(err)?;
+    if http.status != 404 {
+        return None;
+    }
+    namespace_missing_error(iris, client, ns, &http.url, effect).await
 }
 
 #[derive(Debug, Deserialize, JsonSchema)]
@@ -424,14 +639,7 @@ pub async fn interop_production_status_impl(
             }
         }
         Err(e) if e.to_string() == "DOCKER_REQUIRED" => docker_required_interop(),
-        Err(e) => err_json(
-            if is_network_error(&e.to_string()) {
-                "IRIS_UNREACHABLE"
-            } else {
-                "INTEROP_ERROR"
-            },
-            &e.to_string(),
-        ),
+        Err(e) => err_json(classify_iris_error(&e.to_string()), &e.to_string()),
     }
 }
 
@@ -478,14 +686,7 @@ pub async fn interop_production_start_impl(
             }
         }
         Err(e) if e.to_string() == "DOCKER_REQUIRED" => docker_required_interop(),
-        Err(e) => err_json(
-            if is_network_error(&e.to_string()) {
-                "IRIS_UNREACHABLE"
-            } else {
-                "INTEROP_ERROR"
-            },
-            &e.to_string(),
-        ),
+        Err(e) => err_json(classify_iris_error(&e.to_string()), &e.to_string()),
     }
 }
 
@@ -513,14 +714,7 @@ pub async fn interop_production_stop_impl(
             }
         }
         Err(e) if e.to_string() == "DOCKER_REQUIRED" => docker_required_interop(),
-        Err(e) => err_json(
-            if is_network_error(&e.to_string()) {
-                "IRIS_UNREACHABLE"
-            } else {
-                "INTEROP_ERROR"
-            },
-            &e.to_string(),
-        ),
+        Err(e) => err_json(classify_iris_error(&e.to_string()), &e.to_string()),
     }
 }
 
@@ -548,14 +742,7 @@ pub async fn interop_production_update_impl(
             }
         }
         Err(e) if e.to_string() == "DOCKER_REQUIRED" => docker_required_interop(),
-        Err(e) => err_json(
-            if is_network_error(&e.to_string()) {
-                "IRIS_UNREACHABLE"
-            } else {
-                "INTEROP_ERROR"
-            },
-            &e.to_string(),
-        ),
+        Err(e) => err_json(classify_iris_error(&e.to_string()), &e.to_string()),
     }
 }
 
@@ -574,14 +761,7 @@ pub async fn interop_production_needs_update_impl(
             ok_json(serde_json::json!({"success": true, "needs_update": output.trim() == "1"}))
         }
         Err(e) if e.to_string() == "DOCKER_REQUIRED" => docker_required_interop(),
-        Err(e) => err_json(
-            if is_network_error(&e.to_string()) {
-                "IRIS_UNREACHABLE"
-            } else {
-                "INTEROP_ERROR"
-            },
-            &e.to_string(),
-        ),
+        Err(e) => err_json(classify_iris_error(&e.to_string()), &e.to_string()),
     }
 }
 
@@ -605,14 +785,7 @@ pub async fn interop_production_recover_impl(
             }
         }
         Err(e) if e.to_string() == "DOCKER_REQUIRED" => docker_required_interop(),
-        Err(e) => err_json(
-            if is_network_error(&e.to_string()) {
-                "IRIS_UNREACHABLE"
-            } else {
-                "INTEROP_ERROR"
-            },
-            &e.to_string(),
-        ),
+        Err(e) => err_json(classify_iris_error(&e.to_string()), &e.to_string()),
     }
 }
 
@@ -664,14 +837,7 @@ pub async fn interop_logs_impl(
         Ok(resp) => ok_json(
             serde_json::json!({"success": true, "logs": resp["result"]["content"], "count": resp["result"]["content"].as_array().map(|a| a.len()).unwrap_or(0)}),
         ),
-        Err(e) => err_json(
-            if is_network_error(&e.to_string()) {
-                "IRIS_UNREACHABLE"
-            } else {
-                "INTEROP_ERROR"
-            },
-            &e.to_string(),
-        ),
+        Err(e) => err_json(classify_iris_error(&e.to_string()), &e.to_string()),
     }
 }
 
@@ -693,14 +859,7 @@ pub async fn interop_queues_impl(
         Ok(resp) => {
             ok_json(serde_json::json!({"success": true, "queues": resp["result"]["content"]}))
         }
-        Err(e) => err_json(
-            if is_network_error(&e.to_string()) {
-                "IRIS_UNREACHABLE"
-            } else {
-                "INTEROP_ERROR"
-            },
-            &e.to_string(),
-        ),
+        Err(e) => err_json(classify_iris_error(&e.to_string()), &e.to_string()),
     }
 }
 
@@ -874,13 +1033,9 @@ pub async fn interop_message_search_impl(
         .namespace
         .as_deref()
         .unwrap_or(iris.namespace.as_str());
-    let net_err = |e: &str| {
-        if is_network_error(e) {
-            "IRIS_UNREACHABLE"
-        } else {
-            "INTEROP_ERROR"
-        }
-    };
+    // #101: one shared classifier (auth, then network, then interop) — see
+    // `classify_iris_error`.
+    let net_err = classify_iris_error;
 
     let body_mode = params.body_class.is_some()
         || params.body_where.is_some()
@@ -1149,13 +1304,9 @@ pub async fn interop_trace_impl(
     };
     let client = IrisConnection::http_client().map_err(|_| iris_unreachable())?;
     let ns = namespace.as_deref().unwrap_or(iris.namespace.as_str());
-    let net_err = |e: &str| {
-        if is_network_error(e) {
-            "IRIS_UNREACHABLE"
-        } else {
-            "INTEROP_ERROR"
-        }
-    };
+    // #101: one shared classifier (auth, then network, then interop) — see
+    // `classify_iris_error`.
+    let net_err = classify_iris_error;
     // session_id is numeric (i64) — safe to inline.
     let msg_sql = format!("SELECT ID, TimeCreated, SourceConfigName, TargetConfigName, MessageBodyClassName, Status, IsError FROM Ens.MessageHeader WHERE SessionId = {} ORDER BY ID ASC", session_id);
     let log_sql = format!("SELECT ID, TimeLogged, Type, ConfigName, Text FROM Ens_Util.Log WHERE SessionId = {} ORDER BY ID ASC", session_id);
@@ -1213,14 +1364,7 @@ Write "OK""#,
             }
         }
         Err(e) if e.to_string() == "DOCKER_REQUIRED" => docker_required_interop(),
-        Err(e) => err_json(
-            if is_network_error(&e.to_string()) {
-                "IRIS_UNREACHABLE"
-            } else {
-                "INTEROP_ERROR"
-            },
-            &e.to_string(),
-        ),
+        Err(e) => err_json(classify_iris_error(&e.to_string()), &e.to_string()),
     }
 }
 
@@ -1252,14 +1396,7 @@ pub async fn interop_partners_impl(
             let count = rows.as_array().map(|a| a.len()).unwrap_or(0);
             ok_json(serde_json::json!({"success": true, "partners": rows, "count": count}))
         }
-        Err(e) => err_json(
-            if is_network_error(&e.to_string()) {
-                "IRIS_UNREACHABLE"
-            } else {
-                "INTEROP_ERROR"
-            },
-            &e.to_string(),
-        ),
+        Err(e) => err_json(classify_iris_error(&e.to_string()), &e.to_string()),
     }
 }
 
@@ -1426,11 +1563,7 @@ Write "OK""#
                     }
                 }
                 Err(e) => err_json(
-                    if is_network_error(&e.to_string()) {
-                        "IRIS_UNREACHABLE"
-                    } else {
-                        "INTEROP_ERROR"
-                    },
+                    classify_iris_error(&e.to_string()),
                     &e.to_string(),
                 ),
             }
@@ -1476,11 +1609,7 @@ Set tKey="" For {{ Set tSetting=tItem.Settings.GetNext(.tKey) Quit:tKey=""
                     )
                 }
                 Err(e) => err_json(
-                    if is_network_error(&e.to_string()) {
-                        "IRIS_UNREACHABLE"
-                    } else {
-                        "INTEROP_ERROR"
-                    },
+                    classify_iris_error(&e.to_string()),
                     &e.to_string(),
                 ),
             }
@@ -1549,11 +1678,7 @@ If $$$ISERR(tSC4) {{ Write "ERROR:INTEROP_ERROR:"_$System.Status.GetErrorText(tS
                     }
                 }
                 Err(e) => err_json(
-                    if is_network_error(&e.to_string()) {
-                        "IRIS_UNREACHABLE"
-                    } else {
-                        "INTEROP_ERROR"
-                    },
+                    classify_iris_error(&e.to_string()),
                     &e.to_string(),
                 ),
             }
@@ -1600,11 +1725,7 @@ If $$$ISERR(tSC4) {{ Write "ERROR:INTEROP_ERROR:"_$System.Status.GetErrorText(tS
                     }
                 }
                 Err(e) => err_json(
-                    if is_network_error(&e.to_string()) {
-                        "IRIS_UNREACHABLE"
-                    } else {
-                        "INTEROP_ERROR"
-                    },
+                    classify_iris_error(&e.to_string()),
                     &e.to_string(),
                 ),
             }
@@ -1632,11 +1753,7 @@ If $$$ISERR(tSC4) {{ Write "ERROR:INTEROP_ERROR:"_$System.Status.GetErrorText(tS
                     }
                 }
                 Err(e) => err_json(
-                    if is_network_error(&e.to_string()) {
-                        "IRIS_UNREACHABLE"
-                    } else {
-                        "INTEROP_ERROR"
-                    },
+                    classify_iris_error(&e.to_string()),
                     &e.to_string(),
                 ),
             }
@@ -1709,14 +1826,7 @@ pub async fn interop_credential_list_impl(
                 "total_count": total
             }))
         }
-        Err(e) => err_json(
-            if is_network_error(&e.to_string()) {
-                "IRIS_UNREACHABLE"
-            } else {
-                "INTEROP_ERROR"
-            },
-            &e.to_string(),
-        ),
+        Err(e) => err_json(classify_iris_error(&e.to_string()), &e.to_string()),
     }
 }
 
@@ -1760,14 +1870,7 @@ If $$$ISERR(tSC) {{ Write "ERROR:CREDENTIAL_EXISTS:"_$System.Status.GetErrorText
                         err_json("INTEROP_ERROR", out)
                     }
                 }
-                Err(e) => err_json(
-                    if is_network_error(&e.to_string()) {
-                        "IRIS_UNREACHABLE"
-                    } else {
-                        "INTEROP_ERROR"
-                    },
-                    &e.to_string(),
-                ),
+                Err(e) => err_json(classify_iris_error(&e.to_string()), &e.to_string()),
             }
         }
         "update" => {
@@ -1801,14 +1904,7 @@ If $$$ISERR(tSC) {{ Write "ERROR:INTEROP_ERROR:"_$System.Status.GetErrorText(tSC
                         err_json("INTEROP_ERROR", out)
                     }
                 }
-                Err(e) => err_json(
-                    if is_network_error(&e.to_string()) {
-                        "IRIS_UNREACHABLE"
-                    } else {
-                        "INTEROP_ERROR"
-                    },
-                    &e.to_string(),
-                ),
+                Err(e) => err_json(classify_iris_error(&e.to_string()), &e.to_string()),
             }
         }
         "delete" => {
@@ -1830,14 +1926,7 @@ If $$$ISERR(tSC) {{ Write "ERROR:INTEROP_ERROR:"_$System.Status.GetErrorText(tSC
                         err_json("INTEROP_ERROR", out)
                     }
                 }
-                Err(e) => err_json(
-                    if is_network_error(&e.to_string()) {
-                        "IRIS_UNREACHABLE"
-                    } else {
-                        "INTEROP_ERROR"
-                    },
-                    &e.to_string(),
-                ),
+                Err(e) => err_json(classify_iris_error(&e.to_string()), &e.to_string()),
             }
         }
         _ => err_json(
@@ -1899,14 +1988,7 @@ pub async fn interop_lookup_manage_impl(
                         serde_json::json!({"success":true,"tables":tables,"count":tables.len(),"truncated":truncated,"total_count":total}),
                     )
                 }
-                Err(e) => err_json(
-                    if is_network_error(&e.to_string()) {
-                        "IRIS_UNREACHABLE"
-                    } else {
-                        "INTEROP_ERROR"
-                    },
-                    &e.to_string(),
-                ),
+                Err(e) => err_json(classify_iris_error(&e.to_string()), &e.to_string()),
             }
         }
         "get" => {
@@ -1939,14 +2021,7 @@ Write tVal"#,
                         serde_json::json!({"success":true,"table":params.table,"key":params.key,"value":out}),
                     )
                 }
-                Err(e) => err_json(
-                    if is_network_error(&e.to_string()) {
-                        "IRIS_UNREACHABLE"
-                    } else {
-                        "INTEROP_ERROR"
-                    },
-                    &e.to_string(),
-                ),
+                Err(e) => err_json(classify_iris_error(&e.to_string()), &e.to_string()),
             }
         }
         "set" => {
@@ -1977,14 +2052,7 @@ If $$$ISERR(tSC) {{ Write "ERROR:INTEROP_ERROR:"_$System.Status.GetErrorText(tSC
                         err_json("INTEROP_ERROR", out)
                     }
                 }
-                Err(e) => err_json(
-                    if is_network_error(&e.to_string()) {
-                        "IRIS_UNREACHABLE"
-                    } else {
-                        "INTEROP_ERROR"
-                    },
-                    &e.to_string(),
-                ),
+                Err(e) => err_json(classify_iris_error(&e.to_string()), &e.to_string()),
             }
         }
         "delete" => {
@@ -2016,14 +2084,7 @@ If $$$ISERR(tSC) {{ Write "ERROR:INTEROP_ERROR:"_$System.Status.GetErrorText(tSC
                         err_json("INTEROP_ERROR", out)
                     }
                 }
-                Err(e) => err_json(
-                    if is_network_error(&e.to_string()) {
-                        "IRIS_UNREACHABLE"
-                    } else {
-                        "INTEROP_ERROR"
-                    },
-                    &e.to_string(),
-                ),
+                Err(e) => err_json(classify_iris_error(&e.to_string()), &e.to_string()),
             }
         }
         "list_keys" => {
@@ -2051,14 +2112,7 @@ Set tKey="" For {{ Set tKey=$ORDER(^Ens.LookupTable({t},tKey)) Quit:tKey=""  Wri
                         serde_json::json!({"success":true,"table":params.table,"keys":keys,"count":keys.len()}),
                     )
                 }
-                Err(e) => err_json(
-                    if is_network_error(&e.to_string()) {
-                        "IRIS_UNREACHABLE"
-                    } else {
-                        "INTEROP_ERROR"
-                    },
-                    &e.to_string(),
-                ),
+                Err(e) => err_json(classify_iris_error(&e.to_string()), &e.to_string()),
             }
         }
         _ => err_json(
@@ -2130,14 +2184,7 @@ Write tOut"#,
                         serde_json::json!({"success":true,"table":params.table,"xml":out,"entry_count":entry_count}),
                     )
                 }
-                Err(e) => err_json(
-                    if is_network_error(&e.to_string()) {
-                        "IRIS_UNREACHABLE"
-                    } else {
-                        "INTEROP_ERROR"
-                    },
-                    &e.to_string(),
-                ),
+                Err(e) => err_json(classify_iris_error(&e.to_string()), &e.to_string()),
             }
         }
         "import" => {
@@ -2157,14 +2204,7 @@ Write tOut"#,
                         err_json("INTEROP_ERROR", out)
                     }
                 }
-                Err(e) => err_json(
-                    if is_network_error(&e.to_string()) {
-                        "IRIS_UNREACHABLE"
-                    } else {
-                        "INTEROP_ERROR"
-                    },
-                    &e.to_string(),
-                ),
+                Err(e) => err_json(classify_iris_error(&e.to_string()), &e.to_string()),
             }
         }
         _ => err_json(
@@ -2213,14 +2253,7 @@ pub async fn interop_autostart_get_impl(
                 "production": if enabled { serde_json::Value::String(prod) } else { serde_json::Value::Null }
             }))
         }
-        Err(e) => err_json(
-            if is_network_error(&e.to_string()) {
-                "IRIS_UNREACHABLE"
-            } else {
-                "INTEROP_ERROR"
-            },
-            &e.to_string(),
-        ),
+        Err(e) => err_json(classify_iris_error(&e.to_string()), &e.to_string()),
     }
 }
 
@@ -2247,16 +2280,7 @@ If $$$ISERR(tSC) { Write "ERROR:INTEROP_ERROR:"_$System.Status.GetErrorText(tSC)
                 );
             }
             Ok(out) => return err_json("INTEROP_ERROR", out.trim()),
-            Err(e) => {
-                return err_json(
-                    if is_network_error(&e.to_string()) {
-                        "IRIS_UNREACHABLE"
-                    } else {
-                        "INTEROP_ERROR"
-                    },
-                    &e.to_string(),
-                )
-            }
+            Err(e) => return err_json(classify_iris_error(&e.to_string()), &e.to_string()),
         }
     }
 
@@ -2274,16 +2298,7 @@ If $$$ISERR(tSC) { Write "ERROR:INTEROP_ERROR:"_$System.Status.GetErrorText(tSC)
                 }
                 out
             }
-            Err(e) => {
-                return err_json(
-                    if is_network_error(&e.to_string()) {
-                        "IRIS_UNREACHABLE"
-                    } else {
-                        "INTEROP_ERROR"
-                    },
-                    &e.to_string(),
-                )
-            }
+            Err(e) => return err_json(classify_iris_error(&e.to_string()), &e.to_string()),
         }
     };
 
@@ -2297,14 +2312,7 @@ If $$$ISERR(tSC) {{ Write "ERROR:INTEROP_ERROR:"_$System.Status.GetErrorText(tSC
             serde_json::json!({"success":true,"namespace":ns,"autostart_enabled":true,"production":prod_name}),
         ),
         Ok(out) => err_json("INTEROP_ERROR", out.trim()),
-        Err(e) => err_json(
-            if is_network_error(&e.to_string()) {
-                "IRIS_UNREACHABLE"
-            } else {
-                "INTEROP_ERROR"
-            },
-            &e.to_string(),
-        ),
+        Err(e) => err_json(classify_iris_error(&e.to_string()), &e.to_string()),
     }
 }
 
@@ -2639,11 +2647,7 @@ pub async fn handle_iris_message_body(
             ok_json(resp)
         }
         Err(e) => err_json(
-            if is_network_error(&e.to_string()) {
-                "IRIS_UNREACHABLE"
-            } else {
-                "IRIS_EXECUTE_ERROR"
-            },
+            classify_iris_error_or(&e.to_string(), "IRIS_EXECUTE_ERROR"),
             &e.to_string(),
         ),
     }
@@ -2694,11 +2698,7 @@ pub async fn handle_iris_business_rule_info(
         Ok(_) => {}
         Err(e) => {
             return err_json(
-                if is_network_error(&e.to_string()) {
-                    "IRIS_UNREACHABLE"
-                } else {
-                    "IRIS_EXECUTE_ERROR"
-                },
+                classify_iris_error_or(&e.to_string(), "IRIS_EXECUTE_ERROR"),
                 &e.to_string(),
             )
         }
@@ -2751,7 +2751,7 @@ pub async fn handle_iris_business_rule_info(
                     "source": source,
                 }))
             }
-            Err(e) => err_json("IRIS_UNREACHABLE", &e.to_string()),
+            Err(e) => err_json(classify_iris_error(&e.to_string()), &e.to_string()),
         };
     }
 
@@ -2853,10 +2853,10 @@ For i=1:1:count {{
                         "actions": actions,
                     }))
                 }
-                Err(e) => err_json("IRIS_UNREACHABLE", &e.to_string()),
+                Err(e) => err_json(classify_iris_error(&e.to_string()), &e.to_string()),
             }
         }
-        Err(e) => err_json("IRIS_UNREACHABLE", &e.to_string()),
+        Err(e) => err_json(classify_iris_error(&e.to_string()), &e.to_string()),
     }
 }
 
@@ -2891,6 +2891,14 @@ async fn rule_classes_from_catalog(
 }
 
 /// Diff a running production's config items against the committed class source.
+///
+/// Issue #101, the filed repro after it was declared fixed: all four `execute_via_generator`
+/// arms below hard-coded `IRIS_UNREACHABLE`, so a wrong password came back as
+/// `{"error":"PUT doc failed: HTTP 401 Unauthorized","error_code":"IRIS_UNREACHABLE",
+/// "hint":"IRIS did not answer on the configured host/port …"}` — the exact response the
+/// issue was filed about, on an interop-profile tool, while `interop.rs`'s own header claimed
+/// the shared classifier had replaced 34 hand-copied ternaries. They now go through
+/// `classify_iris_error` like every other arm in this file.
 pub async fn handle_iris_production_diff(
     iris: Option<&IrisConnection>,
     params: &ProductionDiffParams,
@@ -2917,7 +2925,7 @@ pub async fn handle_iris_production_diff(
                 }
                 out
             }
-            Err(e) => return err_json("IRIS_UNREACHABLE", &e.to_string()),
+            Err(e) => return err_json(classify_iris_error(&e.to_string()), &e.to_string()),
         }
     };
 
@@ -2941,7 +2949,7 @@ If $System.Status.IsError(sc)||('isInSC) {{ Write "NO_SCM" }} Else {{ Write "IN_
             )
         }
         Ok(_) => {}
-        Err(e) => return err_json("IRIS_UNREACHABLE", &e.to_string()),
+        Err(e) => return err_json(classify_iris_error(&e.to_string()), &e.to_string()),
     }
 
     let exists_code = format!(
@@ -2956,7 +2964,7 @@ If $System.Status.IsError(sc)||('isInSC) {{ Write "NO_SCM" }} Else {{ Write "IN_
             )
         }
         Ok(_) => {}
-        Err(e) => return err_json("IRIS_UNREACHABLE", &e.to_string()),
+        Err(e) => return err_json(classify_iris_error(&e.to_string()), &e.to_string()),
     }
 
     // Current in-memory item set. Bound parameter, not interpolation.
@@ -2987,7 +2995,7 @@ If $System.Status.IsError(sc)||('isInSC) {{ Write "NO_SCM" }} Else {{ Write "IN_
                 )
             })
             .collect(),
-        Err(e) => return err_json("IRIS_UNREACHABLE", &e.to_string()),
+        Err(e) => return err_json(classify_iris_error(&e.to_string()), &e.to_string()),
     };
 
     // Committed source via Atelier REST GET /doc/<name>.
@@ -3072,6 +3080,8 @@ mod tests {
             source: crate::iris::connection::DiscoverySource::EnvVar,
             port_superserver: None,
             system_mode: crate::iris::connection::SystemMode::Development,
+            probe_status: None,
+            probe_reached: None,
         }
     }
 
@@ -3613,6 +3623,14 @@ mod namespace_missing_tests {
             .unwrap()
     }
 
+    fn payload(r: &CallToolResult) -> serde_json::Value {
+        let text = match &r.content[0].raw {
+            rmcp::model::RawContent::Text(t) => t.text.clone(),
+            _ => panic!("expected text content"),
+        };
+        serde_json::from_str(&text).unwrap()
+    }
+
     /// Mount an Atelier root descriptor answering with `namespaces`, then ask about `ns`.
     async fn ask(namespaces: &[&str], ns: &str) -> Option<serde_json::Value> {
         let server = MockServer::start().await;
@@ -3632,7 +3650,14 @@ mod namespace_missing_tests {
             DiscoverySource::EnvVar,
         );
         let client = reqwest::Client::new();
-        let out = namespace_missing_error(&iris, &client, ns, "http://x/attempted").await?;
+        let out = namespace_missing_error(
+            &iris,
+            &client,
+            ns,
+            "http://x/attempted",
+            "Nothing was compiled.",
+        )
+        .await?;
         let r = out.unwrap();
         assert_eq!(r.is_error, Some(true));
         let text = match &r.content[0].raw {
@@ -3690,14 +3715,18 @@ mod namespace_missing_tests {
         });
     }
 
-    /// `None` means CANNOT TELL and must never become a positive claim. A wrong
-    /// `IRIS_WEB_PREFIX` 404s the root GET as well — the case the host/port hint is
-    /// actually right for — and an old or foreign server answers without the array.
+    /// `None` means CANNOT TELL and must never become a positive claim about a NAMESPACE.
+    ///
+    /// #101/#102 narrowed what "cannot tell" covers, and this test with it. A 5xx root and a
+    /// 200 root without the array are genuinely unknowable — a sick instance, and an older or
+    /// foreign server — and still return `None`. A **404 root** is not: nothing that serves
+    /// Atelier 404s its own root descriptor, so that pair is a positive finding about the URL
+    /// and moved to `a_404_root_descriptor_names_the_prefix_instead_of_shrugging` below. The
+    /// rule is unchanged; the set of facts it applies to shrank by one.
     #[test]
     fn an_unreadable_root_descriptor_is_never_a_claim_about_a_namespace() {
         rt().block_on(async {
             for body in [
-                ResponseTemplate::new(404),
                 ResponseTemplate::new(500),
                 // 200, but no `namespaces` array (older Atelier).
                 ResponseTemplate::new(200).set_body_json(
@@ -3718,12 +3747,259 @@ mod namespace_missing_tests {
                     DiscoverySource::EnvVar,
                 );
                 assert!(
-                    namespace_missing_error(&iris, &reqwest::Client::new(), "ZZNOSUCHNS", "u")
-                        .await
-                        .is_none(),
+                    namespace_missing_error(
+                        &iris,
+                        &reqwest::Client::new(),
+                        "ZZNOSUCHNS",
+                        "u",
+                        "Nothing was compiled.",
+                    )
+                    .await
+                    .is_none(),
                     "a blind probe must leave the caller's error alone"
                 );
             }
+        });
+    }
+
+    /// #101 REGRESSION + #102 P0, one arm and one test.
+    ///
+    /// A wrong `IRIS_WEB_PREFIX` 404s the tool's URL *and* the Atelier root. Reading that
+    /// pair as "cannot tell" cost two answers at once: `iris_query` lost the
+    /// `IRIS_WEB_PREFIX` diagnosis it had at baseline and returned a bare `NOT_FOUND` about a
+    /// document it never looked for, and `iris_doc` mode=head fell through to
+    /// `{"success":true,"exists":false}` for `%Library.String.cls` — verified live against
+    /// IRIS 2026.1 with `IRIS_WEB_PREFIX=/zznoprefix`, and again against an all-404 stub.
+    ///
+    /// It is not "cannot tell". Every IRIS with Atelier enabled serves `/api/atelier/`.
+    #[test]
+    fn a_404_root_descriptor_names_the_prefix_instead_of_shrugging() {
+        rt().block_on(async {
+            let server = MockServer::start().await;
+            Mock::given(method("GET"))
+                .and(path_regex(r"^/api/atelier/$"))
+                .respond_with(ResponseTemplate::new(404))
+                .mount(&server)
+                .await;
+            let iris = IrisConnection::new(
+                server.uri(),
+                "APP",
+                "_SYSTEM",
+                "SYS",
+                DiscoverySource::EnvVar,
+            );
+            let v = payload(
+                &namespace_missing_error(
+                    &iris,
+                    &reqwest::Client::new(),
+                    "APP",
+                    "http://x/attempted",
+                    "Nothing was read.",
+                )
+                .await
+                .expect("a 404 root descriptor is a finding, not an absence of one")
+                .unwrap(),
+            );
+            assert_eq!(v["error_code"], "ATELIER_NOT_FOUND", "{v}");
+            let hint = v["hint"].as_str().unwrap();
+            assert!(
+                hint.contains("IRIS_WEB_PREFIX"),
+                "the variable that is actually wrong must be named: {v}"
+            );
+            assert!(
+                hint.contains("Nothing was read"),
+                "the caller's own effect line still rides along: {v}"
+            );
+            // IRIS answered twice. Neither the host/port advice nor a claim about a document
+            // may appear.
+            assert!(!v.to_string().contains("Check IRIS_HOST"), "{v}");
+            assert_ne!(v["error_code"], "IRIS_UNREACHABLE", "{v}");
+            assert_ne!(v["error_code"], "NOT_FOUND", "{v}");
+            // ...and it must not be pinned on the namespace either: `APP` was never disproved.
+            assert_ne!(v["error_code"], "NAMESPACE_NOT_FOUND", "{v}");
+        });
+    }
+
+    /// The guard on the arm above: a 404 at the tool's URL with a HEALTHY root descriptor is
+    /// still a document/namespace question, never a prefix one.
+    #[test]
+    fn a_healthy_root_descriptor_never_blames_the_prefix() {
+        rt().block_on(async {
+            assert!(
+                ask(&["APP", "USER"], "APP").await.is_none(),
+                "the namespace is listed — this 404 is about the document"
+            );
+            let v = ask(&["APP", "USER"], "ZZNOSUCHNS").await.unwrap();
+            assert_eq!(v["error_code"], "NAMESPACE_NOT_FOUND", "{v}");
+            assert!(
+                !v.to_string().contains("IRIS_WEB_PREFIX"),
+                "the prefix is demonstrably fine — the root descriptor was just read: {v}"
+            );
+        });
+    }
+}
+
+// ── Issue #101: one classifier, with an auth arm it never had ────────────────
+#[cfg(test)]
+mod classify_iris_error_tests {
+    use super::*;
+
+    /// Pins the PRECEDENCE across all 32 collapsed call sites at once. Auth must come first:
+    /// an HTTP 401 response proves IRIS is REACHABLE, so it may never fall through to the
+    /// network arm.
+    #[test]
+    fn auth_wins_then_network_then_the_interop_default() {
+        assert_eq!(
+            classify_iris_error("PUT doc failed: HTTP 401 Unauthorized"),
+            "IRIS_AUTH_FAILED"
+        );
+        assert_eq!(
+            classify_iris_error("HTTP 403 from http://h/x"),
+            "IRIS_FORBIDDEN"
+        );
+        assert_eq!(
+            classify_iris_error("error sending request for url (http://h/x)"),
+            "IRIS_UNREACHABLE"
+        );
+        assert_eq!(
+            classify_iris_error("ERROR <Ens>ErrGeneral: something interop-shaped"),
+            "INTEROP_ERROR"
+        );
+        // Bug 18 stays fixed: this is not a network error and it is not an auth error.
+        assert_eq!(
+            classify_iris_error("No Interoperability connection configured"),
+            "INTEROP_ERROR"
+        );
+        // The two arms whose default is IRIS_EXECUTE_ERROR keep it.
+        assert_eq!(
+            classify_iris_error_or("ERROR <Ens>ErrGeneral", "IRIS_EXECUTE_ERROR"),
+            "IRIS_EXECUTE_ERROR"
+        );
+        assert_eq!(
+            classify_iris_error_or("HTTP 401 Unauthorized", "IRIS_EXECUTE_ERROR"),
+            "IRIS_AUTH_FAILED"
+        );
+    }
+}
+
+// ── Issue #102: ONE Err arm, NINE interop tools ──────────────────────────────
+#[cfg(test)]
+mod interop_preflight_tests {
+    use super::*;
+    use crate::iris::connection::DiscoverySource;
+    use wiremock::matchers::{method, path_regex};
+    use wiremock::{Mock, MockServer, ResponseTemplate};
+
+    fn rt() -> tokio::runtime::Runtime {
+        tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .unwrap()
+    }
+
+    fn root(namespaces: &[&str]) -> ResponseTemplate {
+        ResponseTemplate::new(200).set_body_json(serde_json::json!({"result": {"content": {
+            "version": "IRIS for UNIX 2026.1", "api": 8, "namespaces": namespaces
+        }}}))
+    }
+
+    async fn preflight(
+        probe: ResponseTemplate,
+        root_tpl: ResponseTemplate,
+        ns: &str,
+    ) -> Option<serde_json::Value> {
+        let server = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path_regex(r".*/action/query$"))
+            .respond_with(probe)
+            .mount(&server)
+            .await;
+        Mock::given(method("GET"))
+            .and(path_regex(r"^/api/atelier/$"))
+            .respond_with(root_tpl)
+            .mount(&server)
+            .await;
+        let iris = IrisConnection::new(
+            server.uri(),
+            "APP",
+            "_SYSTEM",
+            "SYS",
+            DiscoverySource::EnvVar,
+        );
+        let r = ensure_interop_namespace(&iris, ns).await?.unwrap();
+        match &r.content[0].raw {
+            rmcp::model::RawContent::Text(t) => Some(serde_json::from_str(&t.text).unwrap()),
+            _ => panic!("expected text content"),
+        }
+    }
+
+    /// The lever: the probe's own 404 now names the namespace, and this pre-flight runs ahead
+    /// of iris_production, iris_production_item, iris_message_body, iris_business_rule_info,
+    /// iris_production_diff, iris_credential_list, iris_credential_manage, iris_lookup_manage
+    /// and iris_lookup_transfer.
+    #[test]
+    fn a_404_on_the_probe_names_a_namespace_that_is_absent_from_the_root() {
+        rt().block_on(async {
+            let v = preflight(
+                ResponseTemplate::new(404),
+                root(&["APP", "USER"]),
+                "ZZNOSUCHNS",
+            )
+            .await
+            .expect("absent from the list is definitively missing");
+            assert_eq!(v["error_code"], "NAMESPACE_NOT_FOUND", "{v}");
+            assert!(
+                v["hint"].as_str().unwrap().contains("Nothing was run"),
+                "{v}"
+            );
+            assert!(!v.to_string().contains("Check IRIS_HOST"), "{v}");
+        });
+    }
+
+    /// Cannot-tell stays cannot-tell: a 404 for a namespace that IS listed, or an unreadable
+    /// root, leaves the tool's own error in place.
+    #[test]
+    fn a_probe_failure_it_cannot_attribute_returns_none() {
+        rt().block_on(async {
+            assert!(
+                preflight(ResponseTemplate::new(404), root(&["APP"]), "APP")
+                    .await
+                    .is_none(),
+                "the namespace is listed — not our error to claim"
+            );
+            assert!(
+                preflight(ResponseTemplate::new(404), ResponseTemplate::new(500), "ZZ")
+                    .await
+                    .is_none(),
+                "an unreadable root is never a claim about a namespace"
+            );
+            assert!(
+                preflight(ResponseTemplate::new(401), root(&["APP"]), "ZZNOSUCHNS")
+                    .await
+                    .is_none(),
+                "a 401 is credentials (#101), not a missing namespace"
+            );
+        });
+    }
+
+    /// The pre-flight's original job is untouched: interop present -> None, absent -> the
+    /// NAMESPACE_NOT_INTEROP answer.
+    #[test]
+    fn the_interop_probe_itself_still_works() {
+        rt().block_on(async {
+            let present = ResponseTemplate::new(200)
+                .set_body_json(serde_json::json!({"result": {"content": [{"n": 1}]}}));
+            assert!(preflight(present, root(&["APP"]), "APP").await.is_none());
+
+            // A DIFFERENT namespace name on purpose: the positive above is cached per
+            // (base_url, namespace), and a dropped MockServer's ephemeral port can be handed
+            // straight back to the next one — same base_url, same cache key, silent None.
+            let absent = ResponseTemplate::new(200)
+                .set_body_json(serde_json::json!({"result": {"content": [{"n": 0}]}}));
+            let v = preflight(absent, root(&["APP", "NOINTEROP"]), "NOINTEROP")
+                .await
+                .expect("no Ens.Director means no interop");
+            assert_eq!(v["error_code"], "NAMESPACE_NOT_INTEROP", "{v}");
         });
     }
 }

--- a/crates/iris-agentic-dev-core/src/tools/mod.rs
+++ b/crates/iris-agentic-dev-core/src/tools/mod.rs
@@ -3838,10 +3838,10 @@ do ##class(%UnitTest.Manager).RunTest({pattern},"{flags}","{token}")"#,
         // #101: what the HTTP leg said, kept for the docker fallback's error message. The
         // `Ok(Err(_))` arm below used to DISCARD it, so a wrong password was reported as
         // DOCKER_REQUIRED — "set IRIS_CONTAINER", an env var with no bearing on the problem.
-        // (Deferred init: the only arm that falls through to docker is the one that sets it.)
-        let http_leg_error: String;
-
-        match gen_result {
+        // Bound as a match EXPRESSION: the other two arms diverge (both `return`), so only
+        // the fall-through arm yields a value. A deferred `let` + assignment trips
+        // clippy::needless_late_init on the CI toolchain (1.98) though not on 1.96.
+        let http_leg_error: String = match gen_result {
             Err(_) => {
                 self.record_call("iris_execute", false);
                 return envelope::fail(
@@ -3924,9 +3924,9 @@ do ##class(%UnitTest.Manager).RunTest({pattern},"{flags}","{token}")"#,
                 // `docker exec ... iris session` and does not use IRIS_USERNAME/IRIS_PASSWORD
                 // at all, so with a valid IRIS_CONTAINER a wrong Atelier password genuinely IS
                 // recoverable. Only what gets REPORTED when the docker leg also fails changes.
-                http_leg_error = e.to_string();
+                e.to_string()
             }
-        }
+        };
 
         // Fallback: docker exec (requires IRIS_CONTAINER env var).
         let docker_result =

--- a/crates/iris-agentic-dev-core/src/tools/mod.rs
+++ b/crates/iris-agentic-dev-core/src/tools/mod.rs
@@ -392,6 +392,15 @@ if $isobject(tCC)&&(tCC.PrimarySuper["%UnitTest.TestProduction") {{ do $classmet
 
 pub const ERR_NAMESPACE_NOT_FOUND: &str = "NAMESPACE_NOT_FOUND";
 pub const ERR_TEST_EXECUTION_ERROR: &str = "TEST_EXECUTION_ERROR";
+/// #101/#102: IRIS answered, but `/api/atelier` is not published where this server looks —
+/// the request never reached a namespace or a document. Distinct from `NOT_FOUND` (which is
+/// a claim about a document) and from `IRIS_UNREACHABLE` (which is a claim about the host
+/// and port, both of which just answered).
+pub const ERR_ATELIER_NOT_FOUND: &str = "ATELIER_NOT_FOUND";
+/// #102: a 404 whose cause could not be established. The honest answer when the only
+/// alternative is a negative FACT the server cannot back — never a substitute for an error
+/// a caller already has.
+pub const ERR_INDETERMINATE: &str = "INDETERMINATE";
 
 // ── Live connection hot-reload types (034) ───────────────────────────────────
 
@@ -2186,6 +2195,39 @@ pub fn validate_read_only_sql(sql: &str) -> Result<(), String> {
     Ok(())
 }
 
+/// Issue #102: the failure envelope `docs_introspect` never had. Names the namespace when a
+/// 404 is its fault (#93), otherwise codes the failure from the status IRIS actually returned
+/// — never `null` fields on a `success:true` answer.
+async fn introspect_failure(
+    iris: &IrisConnection,
+    client: &reqwest::Client,
+    namespace: &str,
+    class_name: &str,
+    e: &anyhow::Error,
+) -> Result<CallToolResult, McpError> {
+    if let Some(missing) = interop::namespace_missing_error_for(
+        iris,
+        client,
+        namespace,
+        "Nothing was introspected.",
+        e,
+    )
+    .await
+    {
+        return missing;
+    }
+    let msg = e.to_string();
+    let code = match crate::iris::connection::atelier_status(e) {
+        Some(http) => envelope::http_status_code(http.status),
+        None => interop::classify_iris_error_or(&msg, "IRIS_REQUEST_FAILED"),
+    };
+    envelope::fail_with(
+        code,
+        &msg,
+        serde_json::json!({ "class_name": class_name, "namespace": namespace }),
+    )
+}
+
 fn err_json_with_url(
     code: &str,
     msg: &str,
@@ -2759,9 +2801,14 @@ impl IrisTools {
                     // it as UPLOAD_FAILED "PUT X returned HTTP 404 Not Found" and never
                     // named the namespace. Only on 404: 401/403 and 5xx keep their meaning.
                     if put_resp.status().as_u16() == 404 {
-                        if let Some(e) =
-                            interop::namespace_missing_error(&iris, client, &namespace, &put_url)
-                                .await
+                        if let Some(e) = interop::namespace_missing_error(
+                            &iris,
+                            client,
+                            &namespace,
+                            &put_url,
+                            "Nothing was compiled.",
+                        )
+                        .await
                         {
                             return e;
                         }
@@ -2903,7 +2950,11 @@ impl IrisTools {
                     if let Ok(resp) = &other {
                         if resp.status().as_u16() == 404 {
                             if let Some(e) = interop::namespace_missing_error(
-                                &iris, client, &namespace, &fetch_url,
+                                &iris,
+                                client,
+                                &namespace,
+                                &fetch_url,
+                                "Nothing was compiled.",
                             )
                             .await
                             {
@@ -2946,37 +2997,37 @@ impl IrisTools {
             // wildcard can never see a .mac/.int/.inc routine, and a bare NOT_FOUND there
             // reads as "that routine does not exist" when it does and compiles by name.
             // #94: `scanned` STOPS meaning "documents in the namespace" the moment the
-            // listing is narrowed server-side — left alone, this sentence would start
-            // saying "scanned 0 CLS document(s) in namespace APP" for a typo'd package,
-            // which reads as "the namespace is empty". A new silent wrong answer
-            // introduced by a performance fix is not an acceptable trade, so the two
-            // cases get two sentences.
-            let msg = match listing_filter_used {
-                Some(f) => format!(
-                    "No documents match pattern '{}' — the CLS listing for namespace {} was \
-                     narrowed server-side to names containing '{}', which returned {} \
-                     candidate document(s). Wildcards expand CLASS documents only: compile a \
-                     .mac/.int/.inc routine by its exact name.",
-                    p.target, namespace, f, scanned
-                ),
-                None => format!(
-                    "No documents match pattern '{}' — scanned {} CLS document(s) in \
-                     namespace {}. Wildcards expand CLASS documents only: compile a \
-                     .mac/.int/.inc routine by its exact name.",
-                    p.target, scanned, namespace
-                ),
+            // listing is narrowed server-side.
+            // #100: and neither wording could support the negative it asserted — the CLS
+            // listing omits `Hidden = 1 OR GeneratedBy <> ''`, so "No documents match
+            // pattern" was a claim about the world, made from a source that cannot see all
+            // of it. Reproduced live: `EnsPortal.I*` answered NOT_FOUND while
+            // EnsPortal.InterfaceMaps existed and compiled fine by its exact name.
+            //
+            // All three concerns now live in `compile_not_found_error`, which is pure and
+            // therefore pinned by unit tests rather than by reading the call site.
+            //
+            // The cross-check is called from HERE and nowhere else. This block is reachable
+            // only from `WildcardExpansion::Matched(vec![])` — after a listing that returned
+            // 200 and matched nothing — so it cannot fire on the happy path, and it sits
+            // downstream of every #88/#93 guard by construction rather than by a flag anyone
+            // can flip: SCOPE_REQUIRED, TOO_BROAD, LISTING_UNAVAILABLE and the
+            // missing-namespace attribution have all already returned above.
+            let cross = if p.target.contains('*') {
+                not_listable_crosscheck(&iris, client, &p.target, &namespace).await
+            } else {
+                // An exact target never consulted a listing, so there is no listing blindness
+                // to second-guess and no query to pay for. (Unreachable today — an exact
+                // target yields exactly one element — but the outcome is stated, not assumed.)
+                CrossCheck::Unavailable("an exact target is not expanded from a listing".into())
             };
-            return crate::tools::envelope::fail_with(
-                "NOT_FOUND",
-                &msg,
-                serde_json::json!({
-                    "pattern": p.target,
-                    "namespace": namespace,
-                    // Machine-readable, so the distinction is not only in the prose.
-                    "listing_narrowed": listing_narrowed,
-                    "listing_filter": listing_filter_used,
-                    "candidates_scanned": scanned,
-                }),
+            return compile_not_found_error(
+                &p.target,
+                &namespace,
+                listing_filter_used,
+                listing_narrowed,
+                scanned,
+                cross,
             );
         }
 
@@ -3045,11 +3096,26 @@ impl IrisTools {
             // missing document; ask the root descriptor. Only on 404 — a 401/403 is
             // credentials and a 5xx is a sick instance, and both keep their current error.
             if status == 404 {
-                if let Some(e) =
-                    interop::namespace_missing_error(&iris, client, &namespace, &url_str).await
+                if let Some(e) = interop::namespace_missing_error(
+                    &iris,
+                    client,
+                    &namespace,
+                    &url_str,
+                    "Nothing was compiled.",
+                )
+                .await
                 {
                     return e;
                 }
+            }
+            // #101: 401/403 are credentials and privileges, not connectivity — IRIS
+            // answered, so it is reachable by definition. Only these two statuses move:
+            // every other status keeps its current code verbatim, which is what keeps
+            // `a_namespace_that_differs_only_in_case_is_not_reported_as_missing` (the #93
+            // scope tripwire, asserting IRIS_UNREACHABLE for a 404 whose namespace DOES
+            // exist) green. A failure there is a scope violation, not a test to update.
+            if envelope::auth_status_code(status).is_some() {
+                return envelope::http_status_fail("iris_compile", resp.status(), &url_str);
             }
             return err_json_with_url("IRIS_UNREACHABLE", &format!("HTTP {}", status), &url_str);
         }
@@ -3128,6 +3194,21 @@ impl IrisTools {
         if let Some(uri) = open_uri {
             resp["open_uri"] = serde_json::Value::String(uri);
         }
+        // #100 on the SUCCESS path. The listing blindness does not only produce false
+        // NOT_FOUNDs; it under-compiles and reports that as success. Reproduced live:
+        // `iris_compile {"target":"EnsPortal.*Maps"}` returned success:true /
+        // targets_compiled:1 while EnsPortal.InterfaceMaps also matches the pattern and was
+        // silently never compiled. A genuine fix needs the cross-check on the happy path,
+        // which costs a query on every successful wildcard compile; this discloses the
+        // limitation instead, as a string literal — zero round trips, so the "the
+        // cross-check never runs on the happy path" cost rule holds absolutely.
+        if p.target.contains('*') {
+            resp["expansion_source"] = serde_json::Value::String(
+                "atelier /docnames/CLS — Hidden and generated classes are not listed and were \
+                 not expanded; compile those by exact name"
+                    .into(),
+            );
+        }
 
         // Progressive disclosure (027): truncate errors array when count exceeds threshold.
         // Threshold counts distinct error+warning entries (not raw console lines).
@@ -3175,31 +3256,28 @@ impl IrisTools {
         let namespace = interop::resolve_namespace(p.namespace.as_deref(), Some(&iris));
         let client = self.http_client();
 
-        // US3: namespace existence check before running tests.
-        let ns_check_code = format!(
-            "write ##class(%SYS.Namespace).Exists({})",
-            os_str_expr(&namespace)
-        );
-        let ns_exists = tokio::time::timeout(
-            std::time::Duration::from_secs(10),
-            iris.execute_via_generator(&ns_check_code, "USER", client),
+        // US3 / #102: namespace pre-flight before running tests.
+        //
+        // This used to spend a whole `execute_via_generator` cycle — PUT + compile + SQL query
+        // + DELETE, four HTTP round trips — hardcoded into namespace USER, inside a 10s
+        // timeout, to ask `%SYS.Namespace.Exists`, and then `.unwrap_or(true)`: assume it
+        // exists. The #93 helper answers the same question with ONE GET of `/api/atelier/`,
+        // and answers it better — it lists the namespaces that DO exist, and it says "or is
+        // not accessible to user X", a distinction `%SYS.Namespace.Exists` cannot make (it
+        // reports raw existence, so a namespace the credentials cannot reach passed this
+        // pre-flight and failed later with a confusing error). `None` still means CANNOT TELL,
+        // which is the old optimistic default stated honestly. Same ERR_NAMESPACE_NOT_FOUND.
+        if let Some(missing) = interop::namespace_missing_error(
+            &iris,
+            client,
+            &namespace,
+            &iris.versioned_ns_url(&namespace, "/action/query"),
+            "No tests were run.",
         )
         .await
-        .ok()
-        .and_then(|r| r.ok())
-        .map(|s| s.trim().starts_with('1'))
-        .unwrap_or(true); // If we can't check, assume it exists and let RunTest fail naturally.
-
-        if !ns_exists {
+        {
             self.record_call("iris_test", false);
-            return envelope::fail_with(
-                ERR_NAMESPACE_NOT_FOUND,
-                &format!(
-                    "Namespace '{}' does not exist on this IRIS instance",
-                    namespace
-                ),
-                serde_json::json!({"namespace": namespace}),
-            );
+            return missing;
         }
 
         // Generate a UUID correlation token; used as UserParam in RunTest.
@@ -3297,12 +3375,37 @@ do ##class(%UnitTest.Manager).RunTest({pattern},"{flags}","{token}")"#,
                     .await
                     {
                         Ok(Ok(out)) => out,
-                        _ => {
+                        Err(_) => {
                             self.record_call("iris_test", false);
                             return envelope::fail(
-                                "DOCKER_REQUIRED",
-                                &format!("iris_test: IRIS_CONTAINER set but docker exec failed and HTTP fallback also failed.{DOCKER_REQUIRED_HINT}"),
+                                "TIMEOUT",
+                                &format!("Test run timed out after {}s", p.timeout),
                             );
+                        }
+                        Ok(Err(e)) => {
+                            // #101/#102: the HTTP leg's error was discarded here, so a wrong
+                            // password and a mistyped namespace both answered DOCKER_REQUIRED
+                            // — naming an env var with no bearing on either problem.
+                            self.record_call("iris_test", false);
+                            if let Some(missing) = interop::namespace_missing_error_for(
+                                &iris,
+                                client,
+                                &namespace,
+                                "No tests were run.",
+                                &e,
+                            )
+                            .await
+                            {
+                                return missing;
+                            }
+                            let msg = e.to_string();
+                            let code = interop::classify_iris_error_or(&msg, "DOCKER_REQUIRED");
+                            let text = if code == "DOCKER_REQUIRED" {
+                                format!("iris_test: IRIS_CONTAINER set but docker exec failed and HTTP fallback also failed: {msg}.{DOCKER_REQUIRED_HINT}")
+                            } else {
+                                format!("iris_test: docker exec failed and the HTTP fallback was rejected: {msg}")
+                            };
+                            return envelope::fail(code, &text);
                         }
                     }
                 }
@@ -3328,7 +3431,25 @@ do ##class(%UnitTest.Manager).RunTest({pattern},"{flags}","{token}")"#,
                 }
                 Ok(Err(e)) => {
                     self.record_call("iris_test", false);
-                    return envelope::fail(ERR_TEST_EXECUTION_ERROR, &e.to_string());
+                    // #101: "PUT doc failed: HTTP 401 Unauthorized" is a credentials failure,
+                    // not a test-execution failure — three tools used to give one cause three
+                    // different codes. #102: and a 404 here is a mistyped namespace.
+                    if let Some(missing) = interop::namespace_missing_error_for(
+                        &iris,
+                        client,
+                        &namespace,
+                        "No tests were run.",
+                        &e,
+                    )
+                    .await
+                    {
+                        return missing;
+                    }
+                    let msg = e.to_string();
+                    return envelope::fail(
+                        interop::classify_iris_error_or(&msg, ERR_TEST_EXECUTION_ERROR),
+                        &msg,
+                    );
                 }
                 Ok(Ok(out)) => out,
             }
@@ -3714,6 +3835,12 @@ do ##class(%UnitTest.Manager).RunTest({pattern},"{flags}","{token}")"#,
         )
         .await;
 
+        // #101: what the HTTP leg said, kept for the docker fallback's error message. The
+        // `Ok(Err(_))` arm below used to DISCARD it, so a wrong password was reported as
+        // DOCKER_REQUIRED — "set IRIS_CONTAINER", an env var with no bearing on the problem.
+        // (Deferred init: the only arm that falls through to docker is the one that sets it.)
+        let http_leg_error: String;
+
         match gen_result {
             Err(_) => {
                 self.record_call("iris_execute", false);
@@ -3777,8 +3904,27 @@ do ##class(%UnitTest.Manager).RunTest({pattern},"{flags}","{token}")"#,
                 }
                 return ok_json(resp);
             }
-            Ok(Err(_)) => {
-                // HTTP path failed — fall through to docker exec.
+            Ok(Err(e)) => {
+                // #102: a 404 here is very often a mistyped NAMESPACE. Docker was never the
+                // problem and cannot be the remedy, so answer it now rather than falling
+                // through and reporting the fallback's failure as the cause.
+                if let Some(missing) = interop::namespace_missing_error_for(
+                    &iris,
+                    client,
+                    &namespace,
+                    "Nothing was executed.",
+                    &e,
+                )
+                .await
+                {
+                    self.record_call("iris_execute", false);
+                    return missing;
+                }
+                // #101: the fall-through STAYS. `IrisConnection::execute` shells out via
+                // `docker exec ... iris session` and does not use IRIS_USERNAME/IRIS_PASSWORD
+                // at all, so with a valid IRIS_CONTAINER a wrong Atelier password genuinely IS
+                // recoverable. Only what gets REPORTED when the docker leg also fails changes.
+                http_leg_error = e.to_string();
             }
         }
 
@@ -3797,6 +3943,19 @@ do ##class(%UnitTest.Manager).RunTest({pattern},"{flags}","{token}")"#,
                 let msg = e.to_string();
                 self.record_call("iris_execute", false);
                 if msg == "DOCKER_REQUIRED" {
+                    // #101: both legs have now failed. If the HTTP leg was an auth refusal,
+                    // that is the cause and IRIS_CONTAINER is not the remedy — name both legs.
+                    // DOCKER_REQUIRED survives verbatim for every non-auth HTTP failure.
+                    if let Some(code) = envelope::auth_error_code(&http_leg_error) {
+                        return envelope::fail(
+                            code,
+                            &format!(
+                                "iris_execute: the HTTP path was rejected ({http_leg_error}); \
+                                 the docker exec fallback is unavailable because IRIS_CONTAINER \
+                                 is not set."
+                            ),
+                        );
+                    }
                     envelope::fail(
                         "DOCKER_REQUIRED",
                         &format!("iris_execute: HTTP execution failed and IRIS_CONTAINER is not set for docker exec fallback.{DOCKER_REQUIRED_HINT}"),
@@ -3934,11 +4093,30 @@ do ##class(%UnitTest.Manager).RunTest({pattern},"{flags}","{token}")"#,
         };
 
         if !resp.status().is_success() {
-            return err_json_with_url(
-                "IRIS_UNREACHABLE",
-                &format!("HTTP {}", resp.status()),
-                &query_url,
-            );
+            let status = resp.status();
+            // #93 first: the 404 body is ZERO bytes, so the transport alone cannot tell a
+            // missing namespace from a missing endpoint — ask the root descriptor. `None`
+            // means cannot tell, and the status-coded error below survives.
+            if status.as_u16() == 404 {
+                if let Some(missing) = interop::namespace_missing_error(
+                    &iris,
+                    client,
+                    &namespace,
+                    &query_url,
+                    "No rows were read.",
+                )
+                .await
+                {
+                    return missing;
+                }
+            }
+            // #101, the filed repro: this answered IRIS_UNREACHABLE + "Check IRIS_HOST and
+            // IRIS_WEB_PORT" for a 401 while IRIS was answering perfectly on that very host
+            // and port. An HTTP *response* is proof of reachability. The hint goes with the
+            // code: `http_status_fail` attaches `attempted_url` (useful) and lets
+            // `builtin_hint` supply the credentials advice (correct), instead of hard-coding
+            // networking advice that was wrong for every status.
+            return envelope::http_status_fail("iris_query", status, &query_url);
         }
 
         let body: serde_json::Value = resp.json().await.unwrap_or_default();
@@ -4189,7 +4367,7 @@ do ##class(%UnitTest.Manager).RunTest({pattern},"{flags}","{token}")"#,
     }
 
     #[tool(
-        description = "Return the active IRIS connection state + this MCP server's own version. It only reports the cached connection snapshot (no IRIS network call), so it ALWAYS succeeds — when IRIS is down it returns connected:false / connection_source:disconnected instead of erroring with IRIS_UNREACHABLE. That is the point: it's the one tool you can call to DIAGNOSE an unreachable IRIS (read the `connected` field) without the call itself failing — unlike iris_query/iris_execute/etc., which do return IRIS_UNREACHABLE. Also use to: verify hot-reload completed; confirm which container/host is active; validate the loaded MCP build (mcp_version). To switch connection mid-session without restart: call check_config first to get config_watch_path, then write a .iris-agentic-dev.toml to that exact path, then call any tool — the reload fires automatically. Fields: mcp_version, toolset, connected, connection_source (http|docker|disconnected), host, port, namespace, container, config_file, config_watch_path, config_loaded_at, iris_version, write_tools_enabled."
+        description = "Return the active IRIS connection state + this MCP server's own version. It only reports the cached connection snapshot (no IRIS network call), so it ALWAYS succeeds — when IRIS is down it returns connected:false / connection_source:disconnected instead of erroring with IRIS_UNREACHABLE. That is the point: it's the one tool you can call to DIAGNOSE an unreachable IRIS (read the `connected` field) without the call itself failing — unlike iris_query/iris_execute/etc., which do return IRIS_UNREACHABLE. If those tools instead return IRIS_AUTH_FAILED (HTTP 401) or IRIS_FORBIDDEN (HTTP 403), IRIS is REACHABLE and the credentials are the problem: read `auth_ok` and `probe_status` here — auth_ok:false means IRIS rejected IRIS_USERNAME/IRIS_PASSWORD (401) or refused this user the %Development privilege (403), and `connected` is false for that reason, not a network one. Also use to: verify hot-reload completed; confirm which container/host is active; validate the loaded MCP build (mcp_version). To switch connection mid-session without restart: call check_config first to get config_watch_path, then write a .iris-agentic-dev.toml to that exact path, then call any tool — the reload fires automatically. Fields: mcp_version, toolset, connected, auth_ok, probe_status, connection_source (http|docker|disconnected), host, port, namespace, container, config_file, config_watch_path, config_loaded_at, iris_version, write_tools_enabled."
     )]
     async fn check_config(
         &self,
@@ -4265,8 +4443,41 @@ do ##class(%UnitTest.Manager).RunTest({pattern},"{flags}","{token}")"#,
                 .unwrap_or(serde_json::Value::Null)
         };
 
+        // #101: `connected` was `conn.iris.is_some()` — a claim about whether an object
+        // exists, not about IRIS. Under a wrong password it answered `true`, and this tool's
+        // own description is what sends a model here to diagnose that. The root probe already
+        // knows: a 401/403 means these credentials cannot use this instance, so `connected` is
+        // false and `auth_ok` says why. Anything else (no probe yet, a transport failure, an
+        // odd status) leaves the old answer alone — cannot-tell must not become a claim.
+        let probe_status = conn.iris.as_ref().and_then(|i| i.probe_status);
+        let auth_ok = match probe_status {
+            Some(401) | Some(403) => Some(false),
+            Some(s) if (200..300).contains(&s) => Some(true),
+            _ => None,
+        };
+        // #101/#102, the rest of the same sentence. Keying `connected` on the 401/403 arm
+        // alone still left it `true` for a CLOSED PORT, an unroutable host, a wrong
+        // IRIS_WEB_PREFIX (probe_status 404) and a sick instance (500) — the exact states
+        // this tool's own description promises to report as `connected: false`, and the ones
+        // a model is sent here to diagnose. `connected` is a claim about IRIS, so it is
+        // answered from what the root probe saw:
+        //   2xx                       -> usable
+        //   any other status          -> IRIS answered, but this server cannot use it here
+        //   probe ran, no response    -> IRIS did not answer
+        //   probe never ran           -> cannot tell, and cannot-tell must not become a claim
+        let usable = match (
+            probe_status,
+            conn.iris.as_ref().and_then(|i| i.probe_reached),
+        ) {
+            (Some(s), _) if (200..300).contains(&s) => Some(true),
+            (Some(_), _) => Some(false),
+            (None, Some(false)) => Some(false),
+            (None, _) => None,
+        };
         let mut response = serde_json::json!({
-            "connected": conn.iris.is_some(),
+            "connected": conn.iris.is_some() && usable != Some(false),
+            "auth_ok": auth_ok,
+            "probe_status": probe_status,
             "connection_source": connection_source,
             "host": host,
             "port": port,
@@ -4402,7 +4613,37 @@ do ##class(%UnitTest.Manager).RunTest({pattern},"{flags}","{token}")"#,
                 "count": resp["result"]["content"].as_array().map(|a| a.len()).unwrap_or(0),
                 "query_hint": "Supports: plain text (substring), 'Pkg.*' (package prefix), 'Pkg.*.Name' (glob)",
             })),
-            Err(e) => err_json("IRIS_UNREACHABLE", &e.to_string()),
+            Err(e) => {
+                // #102: this said IRIS_UNREACHABLE for BOTH a missing namespace and a wrong
+                // password — and, because `query_once` never looked at the status, the message
+                // was "error decoding response body" (the 404 body is zero bytes, so serde
+                // reported EOF and the status was thrown away). Name the namespace when that
+                // is the cause, otherwise code the failure from the status IRIS actually sent.
+                // Only a genuine transport failure — no response at all — keeps
+                // IRIS_UNREACHABLE.
+                if let Some(missing) = interop::namespace_missing_error_for(
+                    &iris,
+                    client,
+                    &namespace,
+                    "No symbols were read.",
+                    &e,
+                )
+                .await
+                {
+                    return missing;
+                }
+                match crate::iris::connection::atelier_status(&e) {
+                    Some(http) => envelope::fail_with(
+                        envelope::http_status_code(http.status),
+                        &e.to_string(),
+                        serde_json::json!({ "attempted_url": http.url }),
+                    ),
+                    None => err_json(
+                        interop::classify_iris_error_or(&e.to_string(), "IRIS_REQUEST_FAILED"),
+                        &e.to_string(),
+                    ),
+                }
+            }
         }
     }
 
@@ -4468,13 +4709,24 @@ do ##class(%UnitTest.Manager).RunTest({pattern},"{flags}","{token}")"#,
         let client = self.http_client();
         // Bug 15: use parameterized queries instead of manual string escaping.
         let namespace = interop::resolve_namespace(p.namespace.as_deref(), Some(&iris));
-        let methods = iris.query(
+        // #102 P0: both queries used to end in `.unwrap_or_default()`, so ANY failure —
+        // a namespace that does not exist, a wrong password, a 500 — became
+        // `{"success":true,"methods":null,"properties":null}`. A class that genuinely has no
+        // methods answers `methods:[]`, so `null` vs `[]` was the ONLY thing separating
+        // "unreachable" from "no methods" and no caller makes that distinction. A failed call
+        // must never be answered with a negative FACT.
+        let methods = match iris.query(
             "SELECT Name,FormalSpec,ReturnType FROM %Dictionary.CompiledMethod WHERE parent=? ORDER BY Name",
             vec![serde_json::Value::String(p.class_name.clone())],
             &namespace,
             client,
-        ).await.unwrap_or_default();
-        let props = iris
+        ).await {
+            Ok(v) => v,
+            Err(e) => {
+                return introspect_failure(&iris, client, &namespace, &p.class_name, &e).await
+            }
+        };
+        let props = match iris
             .query(
                 "SELECT Name,Type FROM %Dictionary.CompiledProperty WHERE parent=? ORDER BY Name",
                 vec![serde_json::Value::String(p.class_name.clone())],
@@ -4482,7 +4734,12 @@ do ##class(%UnitTest.Manager).RunTest({pattern},"{flags}","{token}")"#,
                 client,
             )
             .await
-            .unwrap_or_default();
+        {
+            Ok(v) => v,
+            Err(e) => {
+                return introspect_failure(&iris, client, &namespace, &p.class_name, &e).await
+            }
+        };
         ok_json(
             serde_json::json!({"success": true, "class_name": p.class_name, "methods": methods["result"]["content"], "properties": props["result"]["content"]}),
         )
@@ -4520,7 +4777,7 @@ do ##class(%UnitTest.Manager).RunTest({pattern},"{flags}","{token}")"#,
                 "DOCKER_REQUIRED",
                 &format!("debug_map_int requires docker exec. Set IRIS_CONTAINER=<container_name>.{DOCKER_REQUIRED_HINT}"),
             ),
-            Err(e) => err_json("IRIS_UNREACHABLE", &e.to_string()),
+            Err(e) => err_json(interop::classify_iris_error_or(&e.to_string(), "IRIS_REQUEST_FAILED"), &e.to_string()),
         }
     }
 
@@ -4540,7 +4797,7 @@ do ##class(%UnitTest.Manager).RunTest({pattern},"{flags}","{token}")"#,
                 if msg.contains("SQLCODE: -30") || msg.contains("Table") && msg.contains("not found") {
                     ok_json(serde_json::json!({"success": true, "errors": [], "note": "%SYSTEM.Error not available on this IRIS edition"}))
                 } else {
-                    err_json("IRIS_UNREACHABLE", &msg)
+                    err_json(interop::classify_iris_error_or(&msg, "IRIS_REQUEST_FAILED"), &msg)
                 }
             }
         }
@@ -4583,7 +4840,10 @@ do ##class(%UnitTest.Manager).RunTest({pattern},"{flags}","{token}")"#,
                         serde_json::json!({"success": true, "logs": [], "note": "%SYSTEM.Error not available on this IRIS edition"}),
                     )
                 } else {
-                    err_json("IRIS_UNREACHABLE", &msg)
+                    err_json(
+                        interop::classify_iris_error_or(&msg, "IRIS_REQUEST_FAILED"),
+                        &msg,
+                    )
                 }
             }
         }
@@ -4618,7 +4878,7 @@ do ##class(%UnitTest.Manager).RunTest({pattern},"{flags}","{token}")"#,
                 "DOCKER_REQUIRED",
                 &format!("debug_source_map requires docker exec. Set IRIS_CONTAINER=<container_name>.{DOCKER_REQUIRED_HINT}"),
             ),
-            Err(e) => err_json("IRIS_UNREACHABLE", &e.to_string()),
+            Err(e) => err_json(interop::classify_iris_error_or(&e.to_string(), "IRIS_REQUEST_FAILED"), &e.to_string()),
         }
     }
 
@@ -5128,19 +5388,31 @@ Methods:
         ok_json(serde_json::json!({"calls": calls, "limit": p.limit}))
     }
 
-    #[tool(description = "Return learning agent status: skill count, pattern count, KB size.")]
+    // #99: the old description promised "skill count, pattern count, KB size" and delivered
+    // none of the three honestly — no pattern count and no KB size at all, and a
+    // `skill_count` that was the in-process `--subscribe` registry, not `^SKILLS`. It now
+    // says what it returns and, more importantly, what it does NOT do: report a zero it
+    // could not measure.
+    #[tool(
+        description = "Learning agent status. Returns the ^SKILLS skill count for the connection's namespace (skill_count, with namespace + source), the count of skills/KB items loaded from --subscribe GitHub packages (subscribed_skill_count / subscribed_kb_item_count / subscribed_source), the session call count and the learning flag. Reads ^SKILLS, so it FAILS with DOCKER_REQUIRED / SKILLS_PARSE_FAILED if that registry cannot be read — it never reports 0 for a registry it could not read. For session history alone, which needs no IRIS, use agent_history."
+    )]
     async fn agent_stats(&self, _: Parameters<NoParams>) -> Result<CallToolResult, McpError> {
-        let skill_count = self.registry.list_skills().len();
-        let session_calls = self.history.lock().map(|h| h.len()).unwrap_or(0);
-        let learning_enabled = std::env::var("OBJECTSCRIPT_LEARNING")
-            .map(|v| v != "false")
-            .unwrap_or(true);
-        ok_json(serde_json::json!({
-            "status": "ok",
-            "skill_count": skill_count,
-            "session_calls": session_calls,
-            "learning_enabled": learning_enabled,
-        }))
+        // #99: ONE implementation, shared with `agent_info(what=stats)` — the two used to be
+        // separate and reported different numbers for the same field in the same session.
+        //
+        // Deliberately NO `record_call` here, so `agent_stats` and `agent_info(what=stats)`
+        // report session_calls that differ by one (agent_info does record itself, at its own
+        // call site). Adding it would make this tool inflate the very number it is reporting;
+        // the documented off-by-one is the lesser evil, and it is stated in the PR rather
+        // than left to be discovered.
+        let iris = self.iris_arc();
+        skills_tools::agent_stats_result(
+            "agent_stats",
+            iris.as_deref(),
+            &self.history,
+            Some(self.registry.as_ref()),
+        )
+        .await
     }
 
     #[tool(
@@ -5505,6 +5777,21 @@ Methods:
         };
         let _iris_arc_hold = self.iris_arc();
         let iris_opt = _iris_arc_hold.as_deref();
+        // #102: the one interop tool with no `ensure_interop_namespace` pre-flight. Its five
+        // impls call `iris.query` directly, so a mistyped namespace surfaced as a raw decode
+        // failure and a non-interop namespace as a raw SQL error. One guard here aligns it
+        // with iris_production, iris_production_item, iris_message_body,
+        // iris_business_rule_info, iris_production_diff, iris_credential_list,
+        // iris_credential_manage, iris_lookup_manage and iris_lookup_transfer — and the
+        // #93 404 attribution rides along through that helper's Err arm.
+        if let Some(iris) = iris_opt {
+            let ns =
+                interop::resolve_namespace(p.get("namespace").and_then(|v| v.as_str()), Some(iris));
+            if let Some(blocked) = interop::ensure_interop_namespace(iris, &ns).await {
+                self.record_call("iris_interop_query", false);
+                return blocked;
+            }
+        }
         #[allow(unused_variables)]
         let result = match what {
             "logs" => {
@@ -6496,11 +6783,13 @@ fn expand_wildcard_target(names: &[&str], pattern: &str) -> WildcardExpansion {
     if wildcard_target_is_unqualified(pattern) {
         return WildcardExpansion::Unqualified;
     }
-    let re = match docname_pattern_regex(wildcard_pattern_stem(pattern)) {
-        Some(re) => re,
+    // #100: the selector is shared with `not_listable_crosscheck` so the two can never
+    // disagree about what a pattern names. `docname_stem` is applied HERE and only here:
+    // /docnames names carry their extension, %Dictionary.ClassDefinition names do not.
+    let (re, want_system) = match wildcard_matcher(pattern) {
+        Some(m) => m,
         None => return WildcardExpansion::Matched(Vec::new()),
     };
-    let want_system = pattern.starts_with('%');
     let matched: Vec<&str> = names
         .iter()
         .copied()
@@ -6557,6 +6846,380 @@ fn too_broad_wildcard_error(
                      a namespace-wide recompile, which is what this guard exists to stop.",
         }),
     )
+}
+
+// ── Issue #100: the classes an Atelier listing cannot see ─────────────────────
+
+/// Issue #100: the ONE selector a wildcard compile target uses, so the `/docnames` expansion
+/// and the `%Dictionary.ClassDefinition` cross-check below can never select differently.
+///
+/// Returns the anchored, case-insensitive regex for the pattern's stem plus whether the
+/// caller asked for `%`-prefixed system documents (only a pattern that itself starts with
+/// `%` reaches those — otherwise a package wildcard would drag library classes in behind
+/// it). `None` means the pattern cannot be compiled to a regex at all, which selects
+/// NOTHING; never `.*`.
+///
+/// TRAP — the two call sites legitimately differ on STEMMING, and getting it wrong is
+/// silent. `/docnames` names carry their extension (`Pkg.Foo.cls`), so
+/// `expand_wildcard_target` must run each name through `docname_stem` before matching.
+/// Names out of `%Dictionary.ClassDefinition` do NOT carry one, so they are matched
+/// DIRECTLY: `docname_stem` strips a trailing `.cls`/`.mac`/`.int`/`.inc`, and a real class
+/// named `Pkg.Int` would be mangled to `Pkg` and then fail to match its own pattern
+/// `Pkg.*`. Asserted, not merely commented — see
+/// `the_shared_matcher_selects_identically_for_docnames_and_sql_names`.
+fn wildcard_matcher(pattern: &str) -> Option<(regex::Regex, bool)> {
+    let re = docname_pattern_regex(wildcard_pattern_stem(pattern))?;
+    Some((re, pattern.starts_with('%')))
+}
+
+/// Issue #100: a `*` wildcard pattern as a SQL `LIKE` pattern, under `ESCAPE '\'`.
+///
+/// The pattern's own `\`, `%` and `_` are escaped FIRST and only then is `*` translated to
+/// `%`, so the SQL selection stays a superset of what `wildcard_matcher`'s regex selects and
+/// never a WIDER one. That ordering is the whole point: `%Library.*` left unescaped becomes
+/// `LIKE '%Library.%'`, a leading-wildcard *contains* match over the entire dictionary, and
+/// with a `TOP` cap in front of it the real match can be truncated away before the client
+/// regex ever sees it — inventing a brand-new false "no such class" inside the very fix that
+/// exists to remove one. Verified live: `\%Library.%` returns %Library classes only, while
+/// `%Library.%` returns the whole alphabet.
+///
+/// The `ESCAPE '\'` idiom is already used in this crate (mod.rs `probe_sql`, info.rs,
+/// interop.rs), so this is not a new technique here.
+fn like_pattern(pattern: &str) -> String {
+    let mut out = String::with_capacity(pattern.len() + 8);
+    for c in pattern.chars() {
+        match c {
+            '\\' => out.push_str(r"\\"),
+            '%' => out.push_str(r"\%"),
+            '_' => out.push_str(r"\_"),
+            '*' => out.push('%'),
+            _ => out.push(c),
+        }
+    }
+    out
+}
+
+/// Issue #100: one class that exists in `%Dictionary.ClassDefinition` but that Atelier's
+/// `/docnames/CLS` listing does not offer.
+#[derive(Debug, PartialEq)]
+pub(crate) struct NotListable {
+    pub(crate) name: String,
+    pub(crate) hidden: bool,
+    /// The generator's document name (`Ens.Alerting.AlertManager.CLS`), or `None` when the
+    /// class was authored. This is why `GeneratedBy` is selected at all: the advice SPLITS
+    /// on it — see `not_listable_advice`.
+    pub(crate) generated_by: Option<String>,
+}
+
+/// Issue #100: what the `%Dictionary.ClassDefinition` cross-check concluded.
+///
+/// Three states, never two. `Unavailable` exists because #89/#119 keep being reintroduced by
+/// folding "we could not check" into "there is nothing": a cross-check that failed must not
+/// be reported as an empty result, or the new code carries the old bug.
+#[derive(Debug, PartialEq)]
+pub(crate) enum CrossCheck {
+    /// Classes matching the pattern that the listing did not offer. `truncated` means the
+    /// row cap was hit, so the count is a floor.
+    Found {
+        rows: Vec<NotListable>,
+        truncated: bool,
+    },
+    /// The query ran, and nothing anywhere matches. The ONLY state that may say "no such
+    /// class".
+    NoSuchClass,
+    /// The query could not be run or could not be read. NOT a verdict.
+    Unavailable(String),
+}
+
+/// Issue #100: the most rows the cross-check will name. One more than this is fetched so a
+/// full page can be reported as a floor rather than as the truth.
+const NOT_LISTABLE_ROW_CAP: usize = 100;
+
+/// Issue #100: the most class names the cross-check prints into its message.
+const NOT_LISTABLE_NAMES_SHOWN: usize = 20;
+
+/// Issue #100: does a class matching `pattern` exist even though the CLS listing did not
+/// offer one?
+///
+/// `%Api.Atelier.v1:GetDocNames` runs `%Library.RoutineMgr:StudioOpenDialog`, which omits
+/// precisely `Hidden = 1 OR GeneratedBy <> ''`. Measured on the dev instance, per package,
+/// as (ClassDefinition rows / listed / delta / rows with `Hidden=1 OR GeneratedBy<>''`):
+/// `EnsPortal*` 251/224/27/27, `EnsLib.HL7*` 67/58/9/9, `Ens.Alerting*` 23/16/7/7,
+/// `EnsPortal.I*` 2/0/2/2. Passing `ShowGenerated=1` does NOT recover them (`Ens.Alerting*`
+/// stays 16 either way), so no Atelier flag can fix this — a second source is the only route.
+///
+/// SOURCE TABLE: `%Dictionary.ClassDefinition` alone. `%Dictionary.CompiledClass` returned
+/// identical counts for all three affected packages on this instance (67 / 251 / 2), so
+/// unioning it would exactly double the cost of a path chosen for being cheap. That is a
+/// measurement, not a preference — do not "improve" it back without re-measuring.
+///
+/// COST, measured end-to-end through the tool against the dev instance, not server-side:
+/// the empty wildcard path went from 39–43 ms to 53–64 ms, i.e. +20 ms / roughly +50%, on a
+/// call that has already failed and compiled nothing. The query itself is ~22 ms warm
+/// through the full MCP + HTTP round trip. That is MORE than the +5–11 ms a server-side-only
+/// measurement predicts — the number here is the one a caller actually feels, and the
+/// difference is the round trip plus the index trade-off below. It is worth paying: it turns
+/// a confident wrong answer into a correct one that names the classes. The happy path pays
+/// ZERO — it never reaches this function — pinned by
+/// `the_cross_check_never_runs_on_the_happy_path`.
+///
+/// `LIKE` on the WHOLE stem, not `%STARTSWITH` on the literal prefix: a mid-pattern `*`
+/// (`EnsPortal.*Maps`) under a prefix query returns `EnsPortal.…` in alphabetical order and
+/// the row cap could truncate the real match away — a new false negative. Pushing the whole
+/// pattern into `LIKE` makes the cap a genuine "too many to name".
+///
+/// `UPPER(Name) LIKE UPPER(?)` AND NOT the cheaper `Name LIKE ?`, which is the one place
+/// this function knowingly gives up an index. Measured on this instance: plain `LIKE` 5.8–6.8
+/// ms, `UPPER(...)` 15.9–23.5 ms. The plain form is CASE-SENSITIVE — verified live,
+/// `Name LIKE 'ensportal.i%'` returns 0 rows where `'EnsPortal.I%'` returns 2, and
+/// `%STARTSWITH 'ensportal.i'` returns 0 as well — while `wildcard_matcher`'s regex is
+/// `(?i)` and the /docnames expansion it is checking is case-insensitive too. A cross-check
+/// NARROWER than the selection it checks can only manufacture false negatives, which is the
+/// exact bug class this whole change exists to remove. So the ~16 ms is bought deliberately.
+/// Do not "optimise" the UPPER away without re-reading this paragraph.
+async fn not_listable_crosscheck(
+    iris: &IrisConnection,
+    client: &reqwest::Client,
+    pattern: &str,
+    namespace: &str,
+) -> CrossCheck {
+    let Some((re, want_system)) = wildcard_matcher(pattern) else {
+        // A pattern that compiles to no regex selects nothing anywhere — the expansion
+        // already reached the same conclusion by the same route.
+        return CrossCheck::NoSuchClass;
+    };
+    let like = like_pattern(wildcard_pattern_stem(pattern));
+    // Parameterised, via the existing `/action/query` path — no interpolation, no embedded
+    // ObjectScript, so neither the #67 escaping rule nor the postconditional rule gains any
+    // new surface here.
+    let sql = format!(
+        "SELECT TOP {} Name, Hidden, GeneratedBy FROM %Dictionary.ClassDefinition \
+         WHERE UPPER(Name) LIKE UPPER(?) ESCAPE '\\' ORDER BY Name",
+        NOT_LISTABLE_ROW_CAP + 1
+    );
+    let body = match iris
+        .query(
+            &sql,
+            vec![serde_json::Value::String(like)],
+            namespace,
+            client,
+        )
+        .await
+    {
+        Ok(b) => b,
+        Err(e) => return CrossCheck::Unavailable(e.to_string()),
+    };
+    let Some(content) = body["result"]["content"].as_array() else {
+        return CrossCheck::Unavailable(
+            "the /action/query response carried no result.content array".into(),
+        );
+    };
+    let truncated = content.len() > NOT_LISTABLE_ROW_CAP;
+    let rows: Vec<NotListable> = content
+        .iter()
+        .filter_map(|r| {
+            let name = r["Name"].as_str()?;
+            // NOT `docname_stem`: these names carry no extension. See `wildcard_matcher`.
+            if (!want_system && name.starts_with('%')) || !re.is_match(name) {
+                return None;
+            }
+            Some(NotListable {
+                name: name.to_string(),
+                // Atelier's JSON renders the boolean column as `true`/`false`; older shapes
+                // send 1/0. Accept both rather than silently reading "not hidden".
+                hidden: r["Hidden"].as_bool().unwrap_or(false)
+                    || matches!(r["Hidden"].as_i64(), Some(n) if n != 0),
+                generated_by: r["GeneratedBy"]
+                    .as_str()
+                    .filter(|s| !s.is_empty())
+                    .map(str::to_string),
+            })
+        })
+        .collect();
+    match (rows.is_empty(), truncated) {
+        // The cap was hit AND the client re-filter kept nothing: the rows that would match
+        // may have been truncated away before we ever saw them. That is "cannot tell", not
+        // "does not exist" — the whole reason `Unavailable` exists.
+        (true, true) => CrossCheck::Unavailable(format!(
+            "the cross-check hit its {NOT_LISTABLE_ROW_CAP}-row cap and none of the rows it \
+             saw matched, so a matching class may have been truncated away"
+        )),
+        (true, false) => CrossCheck::NoSuchClass,
+        (false, _) => CrossCheck::Found { rows, truncated },
+    }
+}
+
+/// Issue #100: what to tell the caller about classes the listing cannot reach.
+///
+/// The advice SPLITS, and the issue's own suggested wording gets one half wrong. Verified
+/// live on the dev instance:
+///   `iris_compile {"target":"EnsPortal.InterfaceMaps.cls"}` -> success, targets_compiled 1
+///   `iris_compile {"target":"Ens.Alerting.AlertManagerMessagesReceived.cls"}`
+///        -> COMPILE_ERROR "ERROR #5202: Nothing to compile"
+/// "Compile it by exact name" is right for a Hidden-but-authored class and WRONG for a
+/// generated one (`GeneratedBy = "Ens.Alerting.AlertManager.CLS"`), which has no source of
+/// its own — its generator must be compiled instead. The cross-check already has to read
+/// `GeneratedBy` to say this, and it arrives in the same row for free.
+fn not_listable_advice(rows: &[NotListable]) -> String {
+    let mut out = String::new();
+    let authored: Vec<&str> = rows
+        .iter()
+        .filter(|r| r.generated_by.is_none())
+        .map(|r| r.name.as_str())
+        .take(NOT_LISTABLE_NAMES_SHOWN)
+        .collect();
+    if !authored.is_empty() {
+        out.push_str(&format!(
+            " Compile these by exact name: {}.",
+            authored.join(", ")
+        ));
+    }
+    for r in rows
+        .iter()
+        .filter(|r| r.generated_by.is_some())
+        .take(NOT_LISTABLE_NAMES_SHOWN)
+    {
+        let gen = r.generated_by.as_deref().unwrap_or_default();
+        out.push_str(&format!(
+            " {} is generated by {} — compiling {} by name fails with ERROR #5202: Nothing \
+             to compile; compile {} instead.",
+            r.name,
+            docname_stem(gen),
+            r.name,
+            docname_stem(gen)
+        ));
+    }
+    out
+}
+
+/// Issue #100 (and #88/#94 before it): the NOT_FOUND a wildcard compile returns when the
+/// listing matched nothing.
+///
+/// Pure, so the wording and — far more importantly — the payload RULES are testable with no
+/// IRIS. The rules, in the order they matter:
+///
+/// 1. The sentence is about the LISTING, never about the world. `/docnames/CLS` omits Hidden
+///    and generated classes, so "no documents match" was asserting a negative the listing
+///    cannot support. Reproduced live: `iris_compile {"target":"EnsPortal.I*"}` answered
+///    NOT_FOUND while `EnsPortal.InterfaceMaps` existed and compiled fine by exact name.
+/// 2. `error_code` stays NOT_FOUND in every branch. Nothing was compiled, so it must remain
+///    an error, and callers branch on the code. The new information rides on `reason` /
+///    `crosscheck` / `not_listable`, the way #94 added `listing_narrowed` beside prose
+///    instead of minting a code.
+/// 3. `reason` exists ONLY when `crosscheck == "ok"`, and `not_listable` ONLY when the
+///    cross-check actually ran. A failed cross-check emitting `not_listable: []` would be
+///    #89 rewritten in a new function.
+fn compile_not_found_error(
+    target: &str,
+    namespace: &str,
+    listing_filter: Option<&str>,
+    listing_narrowed: bool,
+    scanned: usize,
+    cross: CrossCheck,
+) -> Result<CallToolResult, McpError> {
+    // #94: `scanned` STOPS meaning "documents in the namespace" the moment the listing is
+    // narrowed server-side, so the two cases get two sentences. Left alone, this would say
+    // "scanned 0 CLS document(s) in namespace APP" for a typo'd package — which reads as
+    // "the namespace is empty".
+    let mut msg = match listing_filter {
+        Some(f) => format!(
+            "iris_compile: the Atelier CLS listing for namespace {namespace} — narrowed \
+             server-side to names containing '{f}' — returned {scanned} candidate \
+             document(s), none matching '{target}'."
+        ),
+        None => format!(
+            "iris_compile: scanned {scanned} CLS document(s) in namespace {namespace}; none \
+             matches '{target}'."
+        ),
+    };
+    // The floor, present in every branch and costing nothing: what the listing cannot see.
+    msg.push_str(
+        " That listing (/docnames/CLS) does not include Hidden or generated classes, so a \
+         wildcard can never reach those — a class can still be compiled by its exact name, \
+         which needs no listing.",
+    );
+
+    let mut extra = serde_json::json!({
+        "pattern": target,
+        "namespace": namespace,
+        // Machine-readable, so the distinction is not only in the prose.
+        "listing_narrowed": listing_narrowed,
+        "listing_filter": listing_filter,
+        "candidates_scanned": scanned,
+        // Static, zero-cost, and the reason this NOT_FOUND is not proof of absence.
+        "listing_source": "atelier /docnames/CLS",
+        "listing_omits": ["Hidden", "generated"],
+    });
+
+    match cross {
+        CrossCheck::Found { rows, truncated } => {
+            let shown: Vec<&str> = rows
+                .iter()
+                .map(|r| r.name.as_str())
+                .take(NOT_LISTABLE_NAMES_SHOWN)
+                .collect();
+            let count = if truncated {
+                format!("at least {}", rows.len())
+            } else {
+                rows.len().to_string()
+            };
+            msg = format!(
+                "iris_compile: no LISTABLE class matches '{target}' in namespace \
+                 {namespace}, but %Dictionary.ClassDefinition holds {count} class(es) that \
+                 do: {}{}. Atelier's /docnames/CLS omits Hidden and generated classes, \
+                 which is why the wildcard cannot reach them.{}",
+                shown.join(", "),
+                if rows.len() > shown.len() {
+                    format!(" (showing {} of {count})", shown.len())
+                } else {
+                    String::new()
+                },
+                not_listable_advice(&rows),
+            );
+            extra["reason"] = serde_json::json!("not_listable");
+            extra["crosscheck"] = serde_json::json!("ok");
+            extra["not_listable_total"] = serde_json::json!(rows.len());
+            extra["not_listable_truncated"] = serde_json::json!(truncated);
+            extra["not_listable"] = serde_json::Value::Array(
+                rows.iter()
+                    .map(|r| {
+                        serde_json::json!({
+                            "name": r.name,
+                            "hidden": r.hidden,
+                            "generated_by": r.generated_by,
+                        })
+                    })
+                    .collect(),
+            );
+        }
+        CrossCheck::NoSuchClass => {
+            msg.push_str(
+                " %Dictionary.ClassDefinition — which DOES include Hidden and generated \
+                 classes — holds no match either, so this is a genuine miss.",
+            );
+            extra["reason"] = serde_json::json!("no_such_class");
+            extra["crosscheck"] = serde_json::json!("ok");
+            extra["not_listable"] = serde_json::json!([]);
+        }
+        CrossCheck::Unavailable(why) => {
+            // #89/#119 on the NEW path. "We could not check" must never be rendered as
+            // "it does not exist": no `reason`, and no empty `not_listable` array to be
+            // misread as one.
+            msg.push_str(&format!(
+                " The %Dictionary.ClassDefinition cross-check that would settle whether a \
+                 Hidden or generated class matches could not be run ({why}), so this is not \
+                 proof that no such class exists."
+            ));
+            extra["crosscheck"] = serde_json::json!("unavailable");
+            extra["crosscheck_error"] = serde_json::json!(why);
+        }
+    }
+
+    msg.push_str(
+        " Wildcards expand CLASS documents only: compile a .mac/.int/.inc routine by its \
+         exact name. Nothing was compiled.",
+    );
+    crate::tools::envelope::fail_with("NOT_FOUND", &msg, extra)
 }
 
 // ── Compile-console diagnostics (issue #80) ───────────────────────────────────
@@ -7937,6 +8600,469 @@ mod wildcard_listing_failure_tests {
                     .unwrap()
                     .contains("Nothing was compiled"),
                 "{v}"
+            );
+        });
+    }
+
+    // ── Issue #100: the classes /docnames/CLS cannot see ─────────────────────
+
+    /// An Atelier `/action/query` body for the cross-check: (Name, Hidden, GeneratedBy).
+    fn class_rows(rows: &[(&str, bool, &str)]) -> serde_json::Value {
+        serde_json::json!({"result": {"content": rows.iter()
+            .map(|(n, h, g)| serde_json::json!({"Name": n, "Hidden": h, "GeneratedBy": g}))
+            .collect::<Vec<_>>()}})
+    }
+
+    /// Mount `/action/query` with a fixed body, expecting exactly `times` calls.
+    async fn mount_query(server: &MockServer, body: serde_json::Value, times: u64) {
+        Mock::given(method("POST"))
+            .and(path_regex(r".*/action/query$"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(body))
+            .expect(times)
+            .mount(server)
+            .await;
+    }
+
+    /// Mount `/docnames/CLS?filter=<f>` returning `names`.
+    async fn mount_listing(server: &MockServer, filter: &str, names: &[&str]) {
+        Mock::given(method("GET"))
+            .and(path_regex(r".*/docnames/CLS$"))
+            .and(query_param("filter", filter))
+            .respond_with(ResponseTemplate::new(200).set_body_json(listing(names)))
+            .mount(server)
+            .await;
+    }
+
+    /// `/action/compile` must NEVER be called. `expect(0)` is asserted on drop.
+    async fn forbid_compile(server: &MockServer) {
+        Mock::given(method("POST"))
+            .and(path_regex(r".*/action/compile$"))
+            .respond_with(ResponseTemplate::new(200))
+            .expect(0)
+            .mount(server)
+            .await;
+    }
+
+    /// #100, the filed repro. `iris_compile {"target":"EnsPortal.I*"}` answered NOT_FOUND
+    /// "No documents match pattern" while `EnsPortal.InterfaceMaps` existed — `iris_doc`
+    /// said `exists:true` in the same session and the class compiled fine by exact name.
+    /// `%Api.Atelier.v1:GetDocNames` omits precisely `Hidden = 1 OR GeneratedBy <> ''`
+    /// (measured: EnsPortal.I* is 2 rows in %Dictionary.ClassDefinition and 0 in the
+    /// listing), and `ShowGenerated=1` does not recover them — so the listing alone can
+    /// never support the negative the old message asserted.
+    #[test]
+    fn a_wildcard_that_matches_no_listable_class_names_the_classes_that_exist() {
+        rt().block_on(async {
+            let server = MockServer::start().await;
+            mount_listing(&server, "EnsPortal.I", &[]).await;
+            mount_query(
+                &server,
+                class_rows(&[
+                    ("EnsPortal.InterfaceMaps", true, ""),
+                    ("EnsPortal.InterfaceReferences", true, ""),
+                ]),
+                1,
+            )
+            .await;
+            forbid_compile(&server).await;
+
+            let (is_err, v) = compile_against(&server, "APP", None, "EnsPortal.I*").await;
+            assert_eq!(is_err, Some(true), "nothing was compiled: {v}");
+            assert_eq!(v["error_code"], "NOT_FOUND", "the contract is stable: {v}");
+            assert_eq!(v["reason"], "not_listable", "{v}");
+            assert_eq!(v["crosscheck"], "ok", "{v}");
+            assert_eq!(v["not_listable_total"], 2, "{v}");
+            assert_eq!(v["not_listable_truncated"], false, "{v}");
+            assert_eq!(
+                v["not_listable"][0]["name"], "EnsPortal.InterfaceMaps",
+                "{v}"
+            );
+            assert_eq!(v["not_listable"][0]["hidden"], true, "{v}");
+            assert!(v["not_listable"][0]["generated_by"].is_null(), "{v}");
+
+            let msg = v["error"].as_str().unwrap();
+            assert!(msg.contains("EnsPortal.InterfaceMaps"), "{v}");
+            assert!(msg.contains("EnsPortal.InterfaceReferences"), "{v}");
+            assert!(msg.contains("no LISTABLE class matches"), "{v}");
+            assert!(
+                msg.contains("Compile these by exact name"),
+                "a Hidden but AUTHORED class compiles by name — verified live: {v}"
+            );
+            assert!(
+                !msg.contains("No documents match pattern"),
+                "the old sentence asserted a negative the listing cannot support: {v}"
+            );
+            assert!(msg.contains("Nothing was compiled"), "{v}");
+            assert_eq!(v["listing_source"], "atelier /docnames/CLS", "{v}");
+            assert_eq!(
+                v["listing_omits"],
+                serde_json::json!(["Hidden", "generated"]),
+                "{v}"
+            );
+        });
+    }
+
+    /// #100: the advice SPLITS, and the issue's own suggested wording gets one half wrong.
+    /// Verified live: `iris_compile {"target":"EnsPortal.InterfaceMaps.cls"}` succeeds, but
+    /// `iris_compile {"target":"Ens.Alerting.AlertManagerMessagesReceived.cls"}` fails with
+    /// COMPILE_ERROR "ERROR #5202: Nothing to compile" — a generated class has no source of
+    /// its own. Telling a caller to "compile it by exact name" would send them straight into
+    /// that error, which is why `GeneratedBy` is selected at all.
+    #[test]
+    fn a_generated_class_is_told_to_compile_its_generator_not_itself() {
+        rt().block_on(async {
+            let server = MockServer::start().await;
+            mount_listing(&server, "Ens.Alerting.AlertManagerM", &[]).await;
+            mount_query(
+                &server,
+                class_rows(&[(
+                    "Ens.Alerting.AlertManagerMessagesReceived",
+                    true,
+                    "Ens.Alerting.AlertManager.CLS",
+                )]),
+                1,
+            )
+            .await;
+            forbid_compile(&server).await;
+
+            let (_, v) = compile_against(&server, "APP", None, "Ens.Alerting.AlertManagerM*").await;
+            assert_eq!(v["error_code"], "NOT_FOUND", "{v}");
+            assert_eq!(v["reason"], "not_listable", "{v}");
+            assert_eq!(
+                v["not_listable"][0]["generated_by"], "Ens.Alerting.AlertManager.CLS",
+                "{v}"
+            );
+            let msg = v["error"].as_str().unwrap();
+            assert!(
+                msg.contains("is generated by Ens.Alerting.AlertManager "),
+                "name the GENERATOR, stemmed of its .CLS: {v}"
+            );
+            assert!(
+                msg.contains("ERROR #5202"),
+                "say what compiling it by name would actually do: {v}"
+            );
+            assert!(
+                !msg.contains("Compile these by exact name"),
+                "that advice is WRONG for a generated class and must not appear: {v}"
+            );
+        });
+    }
+
+    /// #100 B4, the explicit false-positive criterion. A genuine typo must still be a clean
+    /// NOT_FOUND — the cross-check exists to sharpen the verdict, not to soften it. Verified
+    /// live that `Zzz.Nope.*` and `%ZzzNope.*` really do return zero rows.
+    #[test]
+    fn a_pattern_that_matches_nothing_anywhere_is_still_not_found() {
+        rt().block_on(async {
+            let server = MockServer::start().await;
+            mount_listing(&server, "Zzz.Nope.", &[]).await;
+            mount_query(&server, class_rows(&[]), 1).await;
+            forbid_compile(&server).await;
+
+            let (is_err, v) = compile_against(&server, "APP", None, "Zzz.Nope.*").await;
+            assert_eq!(is_err, Some(true), "{v}");
+            assert_eq!(v["error_code"], "NOT_FOUND", "{v}");
+            assert_eq!(v["reason"], "no_such_class", "{v}");
+            assert_eq!(v["crosscheck"], "ok", "{v}");
+            assert_eq!(v["not_listable"], serde_json::json!([]), "{v}");
+            assert!(
+                v["error"].as_str().unwrap().contains("genuine miss"),
+                "the cross-check RAN and settled it — say so: {v}"
+            );
+        });
+    }
+
+    /// #100, THE COST GUARD. The cross-check is inside `if targets.is_empty()`, reachable
+    /// only after a listing that returned 200 and matched nothing, so a successful compile
+    /// pays exactly zero extra round trips. `expect(0)` on `/action/query` is asserted when
+    /// the server drops: this is the test that fails the day someone "helpfully" hoists the
+    /// cross-check above the emptiness check.
+    #[test]
+    fn the_cross_check_never_runs_on_the_happy_path() {
+        rt().block_on(async {
+            let server = MockServer::start().await;
+            mount_listing(
+                &server,
+                "APPPKG.",
+                &["APPPKG.FoundationProduction.cls", "APPPKG.Sub.Helper.cls"],
+            )
+            .await;
+            mount_query(&server, class_rows(&[]), 0).await;
+            Mock::given(method("POST"))
+                .and(path_regex(r".*/action/compile$"))
+                .respond_with(ResponseTemplate::new(200).set_body_json(clean_compile()))
+                .expect(1)
+                .mount(&server)
+                .await;
+
+            let (is_err, v) = compile_against(&server, "APP", None, "APPPKG.*").await;
+            assert_eq!(is_err, Some(false), "{v}");
+            assert_eq!(v["targets_compiled"], 2, "{v}");
+        });
+    }
+
+    /// #100 C: the success payload over-claims too. Reproduced live:
+    /// `iris_compile {"target":"EnsPortal.*Maps"}` returns success:true /
+    /// targets_compiled:1 while EnsPortal.InterfaceMaps also matches and was silently never
+    /// compiled. A genuine fix needs the cross-check on the happy path, which the cost rule
+    /// above forbids — so the limitation is DISCLOSED, as a string literal costing nothing.
+    #[test]
+    fn the_happy_path_payload_discloses_what_the_listing_omits() {
+        rt().block_on(async {
+            let server = MockServer::start().await;
+            mount_listing(&server, "APPPKG.", &["APPPKG.FoundationProduction.cls"]).await;
+            mount_query(&server, class_rows(&[]), 0).await;
+            Mock::given(method("POST"))
+                .and(path_regex(r".*/action/compile$"))
+                .respond_with(ResponseTemplate::new(200).set_body_json(clean_compile()))
+                .mount(&server)
+                .await;
+
+            let (is_err, v) = compile_against(&server, "APP", None, "APPPKG.*").await;
+            assert_eq!(is_err, Some(false), "{v}");
+            let src = v["expansion_source"].as_str().unwrap_or_default();
+            assert!(src.contains("Hidden"), "{v}");
+            assert!(src.contains("generated"), "{v}");
+            assert!(src.contains("exact name"), "{v}");
+        });
+    }
+
+    /// #100: every #88/#93 guard returns BEFORE the emptiness check, so the cross-check is
+    /// downstream of them by construction rather than by a flag anyone can flip. Pinned with
+    /// `expect(0)` mocks instead of by reading the call site, and each message asserted
+    /// unchanged.
+    #[test]
+    fn the_cross_check_never_runs_for_the_88_guards() {
+        rt().block_on(async {
+            // (a) SCOPE_REQUIRED — refused before the listing is even fetched.
+            {
+                let server = MockServer::start().await;
+                Mock::given(method("GET"))
+                    .and(path_regex(r".*/docnames/CLS$"))
+                    .respond_with(ResponseTemplate::new(200).set_body_json(listing(&[])))
+                    .expect(0)
+                    .mount(&server)
+                    .await;
+                mount_query(&server, class_rows(&[]), 0).await;
+                forbid_compile(&server).await;
+                let (is_err, v) = compile_against(&server, "APP", None, "*").await;
+                assert_eq!(is_err, Some(true), "{v}");
+                assert_eq!(v["error_code"], "SCOPE_REQUIRED", "{v}");
+                assert!(
+                    v["error"]
+                        .as_str()
+                        .unwrap()
+                        .contains("has nothing before its first '*'"),
+                    "{v}"
+                );
+            }
+            // (b) TOO_BROAD — the expansion matched more than the cap.
+            {
+                let server = MockServer::start().await;
+                let names: Vec<String> = (0..WILDCARD_EXPANSION_CAP + 1)
+                    .map(|i| format!("APPPKG.C{i}.cls"))
+                    .collect();
+                let refs: Vec<&str> = names.iter().map(String::as_str).collect();
+                mount_listing(&server, "APPPKG.", &refs).await;
+                mount_query(&server, class_rows(&[]), 0).await;
+                forbid_compile(&server).await;
+                let (is_err, v) = compile_against(&server, "APP", None, "APPPKG.*").await;
+                assert_eq!(is_err, Some(true), "{v}");
+                assert_eq!(v["error_code"], "TOO_BROAD", "{v}");
+                assert_eq!(v["matched"], WILDCARD_EXPANSION_CAP + 1, "{v}");
+                assert!(
+                    v["error"]
+                        .as_str()
+                        .unwrap()
+                        .contains("Nothing was compiled"),
+                    "{v}"
+                );
+            }
+            // (c) LISTING_UNAVAILABLE — nothing to expand against, so nothing to cross-check.
+            {
+                let server = MockServer::start().await;
+                Mock::given(method("GET"))
+                    .and(path_regex(r".*/docnames/CLS$"))
+                    .respond_with(ResponseTemplate::new(500))
+                    .mount(&server)
+                    .await;
+                mount_query(&server, class_rows(&[]), 0).await;
+                forbid_compile(&server).await;
+                let (is_err, v) = compile_against(&server, "APP", None, "APPPKG.*").await;
+                assert_eq!(is_err, Some(true), "{v}");
+                assert_eq!(v["error_code"], "LISTING_UNAVAILABLE", "{v}");
+                assert!(
+                    v["error"]
+                        .as_str()
+                        .unwrap()
+                        .contains("Nothing was compiled"),
+                    "{v}"
+                );
+            }
+        });
+    }
+
+    /// #100 B5 — the #89/#119 rule applied to the NEW path, and the one that is easiest to
+    /// get wrong. A cross-check that could not run (SQL error, HTTP error, transport drop,
+    /// no privilege on %Dictionary) must NOT emit `not_listable: []` and must NOT set
+    /// `reason` to "no_such_class": an empty array here would read as "it does not exist"
+    /// and would be #89 rewritten one function over. The verdict stays NOT_FOUND — a caller
+    /// who could compile before must still be told the same thing — and only the extra
+    /// sentence changes.
+    #[test]
+    fn a_failed_cross_check_does_not_read_as_no_such_class() {
+        rt().block_on(async {
+            let server = MockServer::start().await;
+            mount_listing(&server, "EnsPortal.I", &[]).await;
+            Mock::given(method("POST"))
+                .and(path_regex(r".*/action/query$"))
+                .respond_with(ResponseTemplate::new(500))
+                .mount(&server)
+                .await;
+            forbid_compile(&server).await;
+
+            let (is_err, v) = compile_against(&server, "APP", None, "EnsPortal.I*").await;
+            assert_eq!(is_err, Some(true), "{v}");
+            assert_eq!(
+                v["error_code"], "NOT_FOUND",
+                "the verdict must not move: {v}"
+            );
+            assert_eq!(v["crosscheck"], "unavailable", "{v}");
+            assert!(
+                v.get("reason").is_none(),
+                "no verdict may be recorded when the check did not run: {v}"
+            );
+            assert!(
+                v.get("not_listable").is_none(),
+                "an empty array here IS the bug: {v}"
+            );
+            let msg = v["error"].as_str().unwrap();
+            assert!(msg.contains("could not be run"), "{v}");
+            assert!(
+                msg.contains("not proof that no such class exists"),
+                "cannot-tell must never be stated as a fact: {v}"
+            );
+        });
+    }
+
+    /// #100, pure: the escape must happen BEFORE `*` is translated, or a pattern's own
+    /// literal `%` widens the LIKE into a leading-wildcard scan and the row cap can truncate
+    /// the real match away — a brand-new false "no such class" inside the fix for one.
+    #[test]
+    fn like_pattern_escapes_literal_wildcards_before_translating_star() {
+        assert_eq!(like_pattern("EnsPortal.I*"), "EnsPortal.I%");
+        assert_eq!(like_pattern("%Library.*"), r"\%Library.%");
+        assert_eq!(like_pattern("A_B.*"), r"A\_B.%");
+        assert_eq!(like_pattern("EnsPortal.*Maps"), "EnsPortal.%Maps");
+        // A literal backslash is escaped too, so `ESCAPE '\'` cannot swallow the next char.
+        assert_eq!(like_pattern(r"Odd\Name*"), r"Odd\\Name%");
+    }
+
+    /// #100, pure: the shared matcher, and the stemming TRAP it makes easy to get wrong.
+    /// `/docnames` names carry `.cls` and must be stemmed; `%Dictionary.ClassDefinition`
+    /// names do not and must NOT be — `docname_stem` would mangle a real class named
+    /// `Pkg.Int` into `Pkg` and it would then fail to match its own pattern. Asserted rather
+    /// than merely commented.
+    #[test]
+    fn the_shared_matcher_selects_identically_for_docnames_and_sql_names() {
+        let (re, want_system) = wildcard_matcher("EnsPortal.I*").unwrap();
+        assert!(!want_system);
+        assert!(re.is_match("EnsPortal.InterfaceMaps"), "raw SQL name");
+        assert!(
+            re.is_match(docname_stem("EnsPortal.InterfaceMaps.cls")),
+            "stemmed docname"
+        );
+
+        // The trap: a SQL name whose last segment happens to be a document extension.
+        let (re, _) = wildcard_matcher("Pkg.*").unwrap();
+        assert!(
+            re.is_match("Pkg.Int"),
+            "a SQL name must be matched DIRECTLY — stemming it would leave 'Pkg'"
+        );
+        assert!(
+            !re.is_match(docname_stem("Pkg.Int")),
+            "…and this is what stemming it would do, which is why it must not happen"
+        );
+
+        // `%` system documents need an explicit `%` pattern, on both sides.
+        let (re, want_system) = wildcard_matcher("Foo.*").unwrap();
+        assert!(!want_system, "a non-% pattern must not drag % classes in");
+        assert!(!re.is_match("%Foo.Bar"));
+        let (_, want_system) = wildcard_matcher("%Api.*").unwrap();
+        assert!(want_system);
+
+        // Regex metacharacters in the pattern are LITERAL — `docname_pattern_regex` runs
+        // `regex::escape` before translating `*`, so `A|*` cannot become an unanchored
+        // alternation that selects the whole namespace.
+        let (re, _) = wildcard_matcher("A[*").unwrap();
+        assert!(re.is_match("A[Anything"), "'[' is literal");
+        assert!(!re.is_match("AAnything"), "'[' is not a character class");
+        let (re, _) = wildcard_matcher("A|*").unwrap();
+        assert!(
+            !re.is_match("Zzz.Whatever"),
+            "the right branch must not float free"
+        );
+    }
+
+    /// #100: the row cap is a "too many to name" cap, so a full page must be reported as a
+    /// FLOOR. Printing 20 names and a bare count of 101 would understate a package the
+    /// caller is about to go looking through by hand.
+    #[test]
+    fn a_capped_cross_check_reports_a_floor_not_a_count() {
+        rt().block_on(async {
+            let server = MockServer::start().await;
+            mount_listing(&server, "Big.Pkg.", &[]).await;
+            let names: Vec<String> = (0..NOT_LISTABLE_ROW_CAP + 1)
+                .map(|i| format!("Big.Pkg.C{i:03}"))
+                .collect();
+            let rows: Vec<(&str, bool, &str)> =
+                names.iter().map(|n| (n.as_str(), true, "")).collect();
+            mount_query(&server, class_rows(&rows), 1).await;
+            forbid_compile(&server).await;
+
+            let (_, v) = compile_against(&server, "APP", None, "Big.Pkg.*").await;
+            assert_eq!(v["error_code"], "NOT_FOUND", "{v}");
+            assert_eq!(v["reason"], "not_listable", "{v}");
+            assert_eq!(v["not_listable_truncated"], true, "{v}");
+            let msg = v["error"].as_str().unwrap();
+            assert!(
+                msg.contains(&format!("at least {}", NOT_LISTABLE_ROW_CAP + 1)),
+                "a full page is a floor, not a total: {v}"
+            );
+            assert!(
+                msg.contains(&format!("showing {NOT_LISTABLE_NAMES_SHOWN} of at least")),
+                "say how many of them are actually printed: {v}"
+            );
+        });
+    }
+
+    /// #100: the truncation failure mode `like_pattern`'s escaping exists to prevent, caught
+    /// on the other side as well. If the cap was hit AND the client re-filter kept nothing,
+    /// the rows that would have matched may have been cut off before we ever saw them — that
+    /// is "cannot tell", and folding it into `no_such_class` would manufacture exactly the
+    /// false negative this whole issue is about.
+    #[test]
+    fn a_truncated_cross_check_that_matched_nothing_is_unavailable_not_absent() {
+        rt().block_on(async {
+            let server = MockServer::start().await;
+            mount_listing(&server, "Big.Pkg.", &[]).await;
+            // A full page, none of which survives the client-side regex.
+            let names: Vec<String> = (0..NOT_LISTABLE_ROW_CAP + 1)
+                .map(|i| format!("Unrelated.C{i:03}"))
+                .collect();
+            let rows: Vec<(&str, bool, &str)> =
+                names.iter().map(|n| (n.as_str(), true, "")).collect();
+            mount_query(&server, class_rows(&rows), 1).await;
+            forbid_compile(&server).await;
+
+            let (_, v) = compile_against(&server, "APP", None, "Big.Pkg.*").await;
+            assert_eq!(v["error_code"], "NOT_FOUND", "{v}");
+            assert_eq!(v["crosscheck"], "unavailable", "{v}");
+            assert!(v.get("reason").is_none(), "{v}");
+            assert!(v.get("not_listable").is_none(), "{v}");
+            assert!(
+                v["error"].as_str().unwrap().contains("truncated away"),
+                "say WHY it could not tell: {v}"
             );
         });
     }
@@ -9434,5 +10560,787 @@ mod get_log_params_tests {
         assert_ne!(r.is_error, Some(true));
         assert_eq!(with_noise, bare, "the exemptions must be invisible");
         assert!(with_noise.get("warnings").is_none(), "{with_noise}");
+    }
+}
+
+// ── Issues #101 / #102: what a tool says when IRIS answers something other than 200 ──
+//
+// Drives the REAL tool handlers against a mock Atelier, so every assertion here is the wire
+// answer a caller gets. The matrix is deliberately the same at every site: a 2xx keeps
+// today's answer, a 404 whose namespace IS listed keeps the tool's own not-found answer, a
+// 404 whose namespace is NOT listed names the namespace, and a 401 is an ERROR — never a
+// confident negative fact. The 401 cases were written first: the issue text described the
+// defect as 404-blindness, and reproducing it with a wrong password against a namespace that
+// EXISTS showed the sites were blind to every non-2xx.
+#[cfg(test)]
+mod http_status_answer_tests {
+    use super::*;
+    use crate::iris::connection::{DiscoverySource, IrisConnection};
+    use wiremock::matchers::{method, path_regex};
+    use wiremock::{Mock, MockServer, ResponseTemplate};
+
+    fn rt() -> tokio::runtime::Runtime {
+        tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .unwrap()
+    }
+
+    fn root_descriptor(namespaces: &[&str]) -> serde_json::Value {
+        serde_json::json!({"result": {"content": {
+            "version": "IRIS for UNIX 2026.1", "api": 8, "namespaces": namespaces
+        }}})
+    }
+
+    fn tools_for(server: &MockServer) -> IrisTools {
+        let conn = IrisConnection::new(
+            server.uri(),
+            "APP",
+            "_SYSTEM",
+            "SYS",
+            DiscoverySource::EnvVar,
+        );
+        IrisTools::new_with_toolset(Some(conn), Toolset::Interop).unwrap()
+    }
+
+    fn payload(r: &CallToolResult) -> serde_json::Value {
+        match &r.content[0].raw {
+            rmcp::model::RawContent::Text(t) => serde_json::from_str(&t.text).unwrap(),
+            _ => panic!("expected text content"),
+        }
+    }
+
+    /// A mock Atelier: `verb`+`path` answers `tpl`, and the root descriptor lists `["APP"]`.
+    async fn server_with(verb: &str, path: &str, tpl: ResponseTemplate) -> MockServer {
+        let server = MockServer::start().await;
+        Mock::given(method(verb))
+            .and(path_regex(path))
+            .respond_with(tpl)
+            .mount(&server)
+            .await;
+        Mock::given(method("GET"))
+            .and(path_regex(r"^/api/atelier/$"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(root_descriptor(&["APP"])))
+            .mount(&server)
+            .await;
+        server
+    }
+
+    async fn introspect(server: &MockServer, ns: &str) -> (Option<bool>, serde_json::Value) {
+        let r = tools_for(server)
+            .docs_introspect(Parameters(
+                serde_json::from_value(
+                    serde_json::json!({"class_name": "Ens.Director", "namespace": ns}),
+                )
+                .unwrap(),
+            ))
+            .await
+            .expect("the tool must answer, not error out of the transport");
+        (r.is_error, payload(&r))
+    }
+
+    /// (a)+(b) The two answers that must NOT change. `methods:[]` for a class that genuinely
+    /// has none is the control captured live — turning THAT into an error would be a new bug.
+    #[test]
+    fn introspect_still_answers_an_empty_method_list_for_an_unknown_class() {
+        rt().block_on(async {
+            let server = server_with(
+                "POST",
+                r".*/action/query$",
+                ResponseTemplate::new(200)
+                    .set_body_json(serde_json::json!({"result": {"content": []}})),
+            )
+            .await;
+            let (is_err, v) = introspect(&server, "APP").await;
+            assert_ne!(is_err, Some(true), "{v}");
+            assert_eq!(v["success"], true, "{v}");
+            assert_eq!(v["methods"], serde_json::json!([]), "{v}");
+            assert_eq!(v["properties"], serde_json::json!([]), "{v}");
+        });
+    }
+
+    /// #102 P0. `null` vs `[]` was the ONLY thing separating "I could not reach it" from "it
+    /// has no methods", and no caller makes that distinction.
+    #[test]
+    fn introspect_never_reports_null_methods_on_a_successful_envelope() {
+        rt().block_on(async {
+            for (status, expected) in [
+                (401u16, "IRIS_AUTH_FAILED"),
+                (403, "IRIS_FORBIDDEN"),
+                (500, "IRIS_SERVER_ERROR"),
+            ] {
+                let server =
+                    server_with("POST", r".*/action/query$", ResponseTemplate::new(status)).await;
+                let (is_err, v) = introspect(&server, "APP").await;
+                assert_eq!(is_err, Some(true), "{v}");
+                assert_eq!(v["error_code"], expected, "{v}");
+                assert_eq!(v["success"], false, "{v}");
+                assert!(v.get("methods").is_none(), "no negative FACT: {v}");
+                assert_eq!(v["namespace"], "APP", "{v}");
+            }
+        });
+    }
+
+    #[test]
+    fn introspect_names_the_namespace_on_a_404() {
+        rt().block_on(async {
+            let server = server_with("POST", r".*/action/query$", ResponseTemplate::new(404)).await;
+            let (is_err, v) = introspect(&server, "ZZNOSUCHNS").await;
+            assert_eq!(is_err, Some(true), "{v}");
+            assert_eq!(v["error_code"], ERR_NAMESPACE_NOT_FOUND, "{v}");
+            assert!(
+                v["hint"]
+                    .as_str()
+                    .unwrap()
+                    .contains("Nothing was introspected"),
+                "the hint must not claim a compile that never happened: {v}"
+            );
+        });
+    }
+
+    async fn query(server: &MockServer, ns: &str) -> (Option<bool>, serde_json::Value) {
+        let r = tools_for(server)
+            .iris_query(Parameters(
+                serde_json::from_value(
+                    serde_json::json!({"query": "SELECT 1 AS n", "namespace": ns}),
+                )
+                .unwrap(),
+            ))
+            .await
+            .expect("the tool must answer");
+        (r.is_error, payload(&r))
+    }
+
+    /// The verbatim #101 repro. A 401 sent the caller to debug networking — "Check IRIS_HOST
+    /// and IRIS_WEB_PORT" — while IRIS was answering perfectly on that very host and port.
+    #[test]
+    fn a_wrong_password_is_named_instead_of_blaming_the_host_and_port() {
+        rt().block_on(async {
+            let server = server_with(
+                "POST",
+                r".*/action/query$",
+                ResponseTemplate::new(401).set_body_string("Unauthorized"),
+            )
+            .await;
+            let (is_err, v) = query(&server, "APP").await;
+            assert_eq!(is_err, Some(true), "{v}");
+            assert_eq!(v["error_code"], "IRIS_AUTH_FAILED", "{v}");
+            assert!(
+                !v.to_string().contains("Check IRIS_HOST"),
+                "the host and port are fine — IRIS answered: {v}"
+            );
+            assert!(v["hint"].as_str().unwrap().contains("IRIS_PASSWORD"), "{v}");
+            assert!(
+                v["attempted_url"]
+                    .as_str()
+                    .unwrap()
+                    .contains("/action/query"),
+                "{v}"
+            );
+        });
+    }
+
+    /// 401's sibling. If someone later collapses the two codes into one, this fails.
+    #[test]
+    fn a_forbidden_response_does_not_tell_the_caller_to_check_their_password() {
+        rt().block_on(async {
+            let server = server_with("POST", r".*/action/query$", ResponseTemplate::new(403)).await;
+            let (_, v) = query(&server, "APP").await;
+            assert_eq!(v["error_code"], "IRIS_FORBIDDEN", "{v}");
+            let hint = v["hint"].as_str().unwrap();
+            assert!(!v.to_string().contains("Check IRIS_HOST"), "{v}");
+            // The password is mentioned exactly once, to rule it OUT. IRIS validated it
+            // before it could evaluate %Development, so on a 403 it is provably correct and
+            // sending the caller back to it burns the session on the wrong variable.
+            assert!(hint.contains("password is not the problem"), "{v}");
+            assert!(
+                hint.contains("Do not change IRIS_USERNAME / IRIS_PASSWORD"),
+                "{v}"
+            );
+            assert!(hint.contains("%Development"), "{v}");
+        });
+    }
+
+    /// #102 P2: `iris_query` builds its own POST and checked the status itself, so fixing
+    /// `query_once` alone would never have reached it. No HTTP status may leave this tool as
+    /// IRIS_UNREACHABLE — an HTTP response is proof of reachability.
+    #[test]
+    fn iris_query_never_answers_unreachable_for_a_response_that_arrived() {
+        rt().block_on(async {
+            for status in [400u16, 401, 403, 404, 409, 423, 500, 503] {
+                let server =
+                    server_with("POST", r".*/action/query$", ResponseTemplate::new(status)).await;
+                let (is_err, v) = query(&server, "APP").await;
+                assert_eq!(is_err, Some(true), "{v}");
+                assert_ne!(v["error_code"], "IRIS_UNREACHABLE", "HTTP {status}: {v}");
+            }
+            // ...and a 404 whose namespace is absent from the root descriptor is attributed.
+            let server = server_with("POST", r".*/action/query$", ResponseTemplate::new(404)).await;
+            let (_, v) = query(&server, "ZZNOSUCHNS").await;
+            assert_eq!(v["error_code"], ERR_NAMESPACE_NOT_FOUND, "{v}");
+            assert_eq!(v["available_namespaces"], serde_json::json!(["APP"]), "{v}");
+        });
+    }
+
+    /// A SQL error still arrives byte-for-byte: Atelier reports it as 200 + `status.errors`,
+    /// and the body-first ordering in `query_once` keeps `status.errors` winning.
+    #[test]
+    fn a_sql_error_is_still_a_sql_error() {
+        rt().block_on(async {
+            let server = server_with(
+                "POST",
+                r".*/action/query$",
+                ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                    "status": {"errors": [{"error": "ERROR #5540: SQLCODE: -30 Table not found"}]}
+                })),
+            )
+            .await;
+            let (_, v) = query(&server, "APP").await;
+            assert_eq!(v["error_code"], "SQL_ERROR", "{v}");
+            assert!(v["error"].as_str().unwrap().contains("SQLCODE: -30"), "{v}");
+        });
+    }
+
+    /// #102 P2 for the two tools that DO go through `query_once`. Both used to answer
+    /// IRIS_UNREACHABLE + "error decoding response body".
+    #[test]
+    fn iris_symbols_names_the_namespace_and_the_credentials() {
+        rt().block_on(async {
+            let symbols = |server: &MockServer, ns: &str| {
+                let tools = tools_for(server);
+                let ns = ns.to_string();
+                async move {
+                    let r = tools
+                        .iris_symbols(Parameters(
+                            serde_json::from_value(
+                                serde_json::json!({"query": "Ens.*", "namespace": ns}),
+                            )
+                            .unwrap(),
+                        ))
+                        .await
+                        .expect("the tool must answer");
+                    payload(&r)
+                }
+            };
+            let server = server_with("POST", r".*/action/query$", ResponseTemplate::new(404)).await;
+            let v = symbols(&server, "ZZNOSUCHNS").await;
+            assert_eq!(v["error_code"], ERR_NAMESPACE_NOT_FOUND, "{v}");
+            assert!(
+                !v.to_string().contains("error decoding response body"),
+                "{v}"
+            );
+
+            let server = server_with("POST", r".*/action/query$", ResponseTemplate::new(401)).await;
+            let v = symbols(&server, "APP").await;
+            assert_eq!(v["error_code"], "IRIS_AUTH_FAILED", "{v}");
+        });
+    }
+
+    async fn macros(server: &MockServer, ns: &str) -> (Option<bool>, serde_json::Value) {
+        let r = tools_for(server)
+            .iris_macro(Parameters(
+                serde_json::from_value(serde_json::json!({"action": "list", "namespace": ns}))
+                    .unwrap(),
+            ))
+            .await
+            .expect("the tool must answer");
+        (r.is_error, payload(&r))
+    }
+
+    /// #102 P0, the third lying-with-success site. A 2xx with nothing in it keeps today's
+    /// answer; a 401 must not be dressed up as "this namespace has no include files".
+    #[test]
+    fn iris_macro_list_separates_no_macros_from_no_answer() {
+        rt().block_on(async {
+            // The RTN listing carries .mac / .int / .inc together as OBJECTS. Unmasking the
+            // status (below) is what exposed that this tool asked for `/docnames/INC` — not an
+            // Atelier category at all, HTTP 400 on every instance — so the listing had never
+            // once worked and the swallowed non-2xx made it look like an empty namespace.
+            let server = server_with(
+                "GET",
+                r".*/docnames/RTN$",
+                ResponseTemplate::new(200).set_body_json(
+                    serde_json::json!({"result": {"content": [
+                        {"cat": "RTN", "name": "%assert.inc", "gen": false},
+                        {"cat": "RTN", "name": "MyApp.Util.mac", "gen": false},
+                        {"cat": "RTN", "name": "MyApp.Macros.INC", "gen": false},
+                    ]}}),
+                ),
+            )
+            .await;
+            let (is_err, v) = macros(&server, "APP").await;
+            assert_ne!(is_err, Some(true), "{v}");
+            assert_eq!(v["success"], true, "{v}");
+            assert_eq!(
+                v["macros"],
+                serde_json::json!(["%assert.inc", "MyApp.Macros.INC"]),
+                "only include files, case-insensitively, and .mac must not leak in: {v}"
+            );
+
+            let server = server_with(
+                "GET",
+                r".*/docnames/RTN$",
+                ResponseTemplate::new(200)
+                    .set_body_json(serde_json::json!({"result": {"content": []}})),
+            )
+            .await;
+            let (is_err, v) = macros(&server, "APP").await;
+            assert_ne!(is_err, Some(true), "{v}");
+            assert_eq!(
+                v["macros"],
+                serde_json::json!([]),
+                "the legitimate empty answer: {v}"
+            );
+
+            let server = server_with("GET", r".*/docnames/RTN$", ResponseTemplate::new(401)).await;
+            let (is_err, v) = macros(&server, "APP").await;
+            assert_eq!(is_err, Some(true), "{v}");
+            assert_eq!(v["error_code"], "IRIS_AUTH_FAILED", "{v}");
+            assert!(
+                !v.to_string().contains("No include files found"),
+                "a failed call must not answer with a negative fact: {v}"
+            );
+
+            let server = server_with("GET", r".*/docnames/RTN$", ResponseTemplate::new(404)).await;
+            let (_, v) = macros(&server, "ZZNOSUCHNS").await;
+            assert_eq!(v["error_code"], ERR_NAMESPACE_NOT_FOUND, "{v}");
+        });
+    }
+
+    /// #102 P3: `iris_execute` threw the HTTP error away and then reported the DOCKER
+    /// fallback's failure, so a mistyped namespace answered "set IRIS_CONTAINER".
+    #[test]
+    fn iris_execute_names_the_namespace_instead_of_demanding_docker() {
+        rt().block_on(async {
+            let server = server_with("PUT", r".*/doc/.*", ResponseTemplate::new(404)).await;
+            let r = tools_for(&server)
+                .iris_execute(Parameters(
+                    serde_json::from_value(
+                        serde_json::json!({"code": "write 1", "namespace": "ZZNOSUCHNS"}),
+                    )
+                    .unwrap(),
+                ))
+                .await
+                .expect("the tool must answer");
+            let v = payload(&r);
+            assert_eq!(v["error_code"], ERR_NAMESPACE_NOT_FOUND, "{v}");
+            assert_ne!(
+                v["error_code"], "DOCKER_REQUIRED",
+                "Docker was never the problem: {v}"
+            );
+            assert!(
+                v["hint"].as_str().unwrap().contains("Nothing was executed"),
+                "{v}"
+            );
+        });
+    }
+
+    /// #101 for the same tool: with the HTTP leg rejected and no container, the answer must
+    /// name the 401 rather than an env var with no bearing on the problem. The docker attempt
+    /// itself still happens — `IrisConnection::execute` does not use IRIS_USERNAME/IRIS_PASSWORD,
+    /// so a wrong Atelier password IS genuinely recoverable when a container is configured.
+    #[test]
+    fn iris_execute_reports_a_401_rather_than_docker_when_both_legs_fail() {
+        rt().block_on(async {
+            if std::env::var("IRIS_CONTAINER")
+                .ok()
+                .filter(|v| !v.is_empty())
+                .is_some()
+            {
+                eprintln!("IRIS_CONTAINER is set — the docker leg would really run; skipping");
+                return;
+            }
+            let server = server_with("PUT", r".*/doc/.*", ResponseTemplate::new(401)).await;
+            let r = tools_for(&server)
+                .iris_execute(Parameters(
+                    serde_json::from_value(
+                        serde_json::json!({"code": "write 1", "namespace": "APP"}),
+                    )
+                    .unwrap(),
+                ))
+                .await
+                .expect("the tool must answer");
+            let v = payload(&r);
+            assert_eq!(v["error_code"], "IRIS_AUTH_FAILED", "{v}");
+            assert!(v["error"].as_str().unwrap().contains("HTTP 401"), "{v}");
+            assert!(v["hint"].as_str().unwrap().contains("IRIS_PASSWORD"), "{v}");
+        });
+    }
+
+    /// The nine-tool lever, end to end: `iris_production` never touches
+    /// `namespace_missing_error` itself — it inherits the answer from the one Err arm in
+    /// `ensure_interop_namespace`.
+    #[test]
+    fn iris_production_inherits_the_namespace_answer_from_the_interop_preflight() {
+        rt().block_on(async {
+            let server = server_with("POST", r".*/action/query$", ResponseTemplate::new(404)).await;
+            let r = tools_for(&server)
+                .iris_production(Parameters(AnyParams(
+                    serde_json::json!({"action": "status", "namespace": "ZZNOSUCHNS"}),
+                )))
+                .await
+                .expect("the tool must answer");
+            let v = payload(&r);
+            assert_eq!(v["error_code"], ERR_NAMESPACE_NOT_FOUND, "{v}");
+            assert!(
+                !v.to_string().contains("PUT doc failed"),
+                "the generator's scaffolding is not the caller's mistake: {v}"
+            );
+        });
+    }
+
+    /// #102 step 5: the pre-flight used to spend a whole `execute_via_generator` cycle — PUT +
+    /// compile + SQL + DELETE — in namespace USER to ask %SYS.Namespace.Exists. This is
+    /// simultaneously the correctness test and the four-round-trips-to-one proof.
+    #[test]
+    fn iris_test_answers_a_missing_namespace_in_exactly_one_request() {
+        rt().block_on(async {
+            let server = MockServer::start().await;
+            Mock::given(method("GET"))
+                .and(path_regex(r"^/api/atelier/$"))
+                .respond_with(
+                    ResponseTemplate::new(200).set_body_json(root_descriptor(&["APP", "USER"])),
+                )
+                .mount(&server)
+                .await;
+            let r = tools_for(&server)
+                .iris_test(Parameters(
+                    serde_json::from_value(
+                        serde_json::json!({"pattern": "Nope.Test", "namespace": "ZZNOSUCHNS"}),
+                    )
+                    .unwrap(),
+                ))
+                .await
+                .expect("the tool must answer");
+            let v = payload(&r);
+            assert_eq!(v["error_code"], ERR_NAMESPACE_NOT_FOUND, "{v}");
+            assert!(
+                v["hint"].as_str().unwrap().contains("No tests were run"),
+                "{v}"
+            );
+            assert_eq!(
+                server.received_requests().await.unwrap().len(),
+                1,
+                "one GET of the root descriptor — not a PUT/compile/query/DELETE cycle"
+            );
+        });
+    }
+
+    /// #101 Phase 5, closing the diagnostic loop. `check_config`'s own description is what
+    /// tells a model to call it to diagnose exactly this — and under a wrong password it
+    /// answered `connected: true`, actively confirming the misdiagnosis. The server already
+    /// knew: `probe()` saw the 401 and logged it to a level nobody reads.
+    #[test]
+    fn check_config_stops_claiming_connected_under_a_rejected_password() {
+        rt().block_on(async {
+            let server = MockServer::start().await;
+            Mock::given(method("GET"))
+                .and(path_regex(r"^/api/atelier/$"))
+                .respond_with(ResponseTemplate::new(401))
+                .mount(&server)
+                .await;
+            let mut conn = IrisConnection::new(
+                server.uri(),
+                "APP",
+                "_SYSTEM",
+                "WRONGPW",
+                DiscoverySource::EnvVar,
+            );
+            conn.probe().await;
+            assert_eq!(conn.probe_status, Some(401), "the probe must remember");
+
+            let tools = IrisTools::new_with_toolset(Some(conn), Toolset::Interop).unwrap();
+            let v = payload(
+                &tools
+                    .check_config(Parameters(NoParams {}))
+                    .await
+                    .expect("check_config always answers"),
+            );
+            assert_eq!(v["connected"], false, "{v}");
+            assert_eq!(v["auth_ok"], false, "{v}");
+            assert_eq!(v["probe_status"], 401, "{v}");
+        });
+    }
+
+    /// The converse, and the guard against over-firing: a probe that succeeded, or one that
+    /// never ran, must not start reporting a credentials problem.
+    #[test]
+    fn check_config_still_reports_connected_when_the_probe_was_accepted() {
+        rt().block_on(async {
+            let server = MockServer::start().await;
+            Mock::given(method("GET"))
+                .and(path_regex(r"^/api/atelier/$"))
+                .respond_with(ResponseTemplate::new(200).set_body_json(root_descriptor(&["APP"])))
+                .mount(&server)
+                .await;
+            let mut conn = IrisConnection::new(
+                server.uri(),
+                "APP",
+                "_SYSTEM",
+                "SYS",
+                DiscoverySource::EnvVar,
+            );
+            conn.probe().await;
+            let tools = IrisTools::new_with_toolset(Some(conn), Toolset::Interop).unwrap();
+            let v = payload(&tools.check_config(Parameters(NoParams {})).await.unwrap());
+            assert_eq!(v["connected"], true, "{v}");
+            assert_eq!(v["auth_ok"], true, "{v}");
+
+            // Never probed: cannot tell, so the old answer stands.
+            let unprobed = IrisConnection::new(
+                "http://127.0.0.1:9",
+                "APP",
+                "_SYSTEM",
+                "SYS",
+                DiscoverySource::EnvVar,
+            );
+            let tools = IrisTools::new_with_toolset(Some(unprobed), Toolset::Interop).unwrap();
+            let v = payload(&tools.check_config(Parameters(NoParams {})).await.unwrap());
+            assert_eq!(v["connected"], true, "{v}");
+            assert_eq!(v["auth_ok"], serde_json::Value::Null, "{v}");
+        });
+    }
+
+    /// #101 at the second `err_json_with_url` call site. `iris_compile`'s 404 behaviour is
+    /// deliberately untouched (see `a_namespace_that_differs_only_in_case_is_not_reported_as_missing`,
+    /// the #93 scope tripwire); only 401/403 move here.
+    #[test]
+    fn iris_compile_names_the_credentials_on_a_401() {
+        rt().block_on(async {
+            let server =
+                server_with("POST", r".*/action/compile$", ResponseTemplate::new(401)).await;
+            let r = tools_for(&server)
+                .iris_compile(Parameters(CompileParams {
+                    target: "Ens.Director.cls".into(),
+                    flags: "cuk".into(),
+                    namespace: Some("APP".into()),
+                    force_writable: false,
+                    inline: false,
+                }))
+                .await
+                .expect("the tool must answer");
+            let v = payload(&r);
+            assert_eq!(v["error_code"], "IRIS_AUTH_FAILED", "{v}");
+            assert!(!v.to_string().contains("Check IRIS_HOST"), "{v}");
+        });
+    }
+
+    /// A mock Atelier where EVERY route answers `tpl` — no root descriptor either. The state
+    /// a wrong password, a wrong prefix or a dead app actually produces.
+    async fn all_routes(tpl_status: u16) -> MockServer {
+        let server = MockServer::start().await;
+        Mock::given(path_regex(r".*"))
+            .respond_with(ResponseTemplate::new(tpl_status))
+            .mount(&server)
+            .await;
+        server
+    }
+
+    /// #101 THE FILED REPRO, still standing on an interop-profile tool after the fix shipped:
+    /// `iris_production_diff` answered `{"error":"PUT doc failed: HTTP 401 Unauthorized",
+    /// "error_code":"IRIS_UNREACHABLE","hint":"IRIS did not answer on the configured
+    /// host/port …"}`. Four arms in `handle_iris_production_diff` still hard-coded
+    /// IRIS_UNREACHABLE while `interop.rs`'s header claimed the shared classifier had
+    /// replaced 34 of them.
+    #[test]
+    fn iris_production_diff_names_the_credentials_on_a_401() {
+        rt().block_on(async {
+            let server = all_routes(401).await;
+            let r = tools_for(&server)
+                .iris_production_diff(Parameters(
+                    serde_json::from_value(serde_json::json!({"namespace": "APP"})).unwrap(),
+                ))
+                .await
+                .expect("the tool must answer");
+            let v = payload(&r);
+            assert_eq!(v["error_code"], "IRIS_AUTH_FAILED", "{v}");
+            assert!(v["hint"].as_str().unwrap().contains("IRIS_PASSWORD"), "{v}");
+            assert!(
+                !v.to_string().contains("IRIS_WEB_PORT"),
+                "IRIS answered on that port — the host/port hint is the wrong advice: {v}"
+            );
+        });
+    }
+
+    /// #101 on `dict.rs`, the file the "one shared helper so every tool inherits it" claim
+    /// never reached (zero lines of diff). `extract_message_map_routing` reported a wrong
+    /// password as `IRIS_EXECUTE_ERROR` with no hint and no mention of a credential.
+    #[test]
+    fn extract_message_map_routing_names_the_credentials_on_a_401() {
+        rt().block_on(async {
+            let server = all_routes(401).await;
+            let r = tools_for(&server)
+                .extract_message_map_routing(Parameters(
+                    serde_json::from_value(
+                        serde_json::json!({"class_name": "Ens.Director", "namespace": "APP"}),
+                    )
+                    .unwrap(),
+                ))
+                .await
+                .expect("the tool must answer");
+            let v = payload(&r);
+            assert_eq!(v["error_code"], "IRIS_AUTH_FAILED", "{v}");
+            assert!(v["hint"].as_str().unwrap().contains("IRIS_PASSWORD"), "{v}");
+        });
+    }
+
+    /// #101 + #57: `find_subclass_implementations` escaped the envelope entirely on a 401 —
+    /// raw JSON-RPC `-32603 "hierarchy expansion failed: PUT doc failed: HTTP 401
+    /// Unauthorized"`, with no `error_code`, no `hint` and no `isError` for anything
+    /// downstream to branch on. A failure to read IRIS is a TOOL failure.
+    #[test]
+    fn find_subclass_implementations_stays_inside_the_envelope_on_a_401() {
+        rt().block_on(async {
+            let server = all_routes(401).await;
+            let r = tools_for(&server)
+                .find_subclass_implementations(Parameters(
+                    serde_json::from_value(serde_json::json!({
+                        "base_classes": ["Ens.BusinessOperation"],
+                        "method_name": "OnMessage",
+                        "namespace": "APP"
+                    }))
+                    .unwrap(),
+                ))
+                .await
+                .expect("a 401 must not become a JSON-RPC -32603");
+            let v = payload(&r);
+            assert_eq!(r.is_error, Some(true), "{v}");
+            assert_eq!(v["error_code"], "IRIS_AUTH_FAILED", "{v}");
+            assert!(v["hint"].as_str().unwrap().contains("IRIS_PASSWORD"), "{v}");
+        });
+    }
+
+    /// #101 REGRESSION, on the tool the issue's own repro used. A wrong `IRIS_WEB_PREFIX`
+    /// used to answer `IRIS_UNREACHABLE` + "Check IRIS_HOST and IRIS_WEB_PORT (and
+    /// IRIS_WEB_PREFIX if using a non-root gateway)". The fix replaced that with a bare
+    /// `{"error_code":"NOT_FOUND","error":"HTTP 404 Not Found"}` — no hint, and
+    /// `IRIS_WEB_PREFIX` named nowhere. Both are wrong in different directions: the first
+    /// blames a host and port that are answering, the second states a negative about a
+    /// document the request never went looking for.
+    #[test]
+    fn a_wrong_web_prefix_names_the_prefix_on_iris_query() {
+        rt().block_on(async {
+            let server = all_routes(404).await;
+            let r = tools_for(&server)
+                .iris_query(Parameters(
+                    serde_json::from_value(
+                        serde_json::json!({"query": "SELECT 1 AS n", "namespace": "APP"}),
+                    )
+                    .unwrap(),
+                ))
+                .await
+                .expect("the tool must answer");
+            let v = payload(&r);
+            assert_eq!(v["error_code"], "ATELIER_NOT_FOUND", "{v}");
+            let hint = v["hint"].as_str().unwrap_or_default();
+            assert!(hint.contains("IRIS_WEB_PREFIX"), "{v}");
+            assert!(
+                !hint.contains("Check IRIS_HOST and IRIS_WEB_PORT"),
+                "IRIS answered twice — the host and port are the two things this proves: {v}"
+            );
+            assert_ne!(v["error_code"], "IRIS_UNREACHABLE", "{v}");
+            assert_ne!(
+                v["error_code"], "NOT_FOUND",
+                "nothing here is a statement about a document: {v}"
+            );
+        });
+    }
+
+    /// #101/#102 caveat: `check_config` is the tool whose own description sends a model here
+    /// to diagnose a dead IRIS, and it reported `connected: true` for a closed port, an
+    /// unroutable host, a wrong prefix (probe_status 404) and a 500. Keying only on 401/403
+    /// fixed the credential case and left the rest.
+    #[test]
+    fn check_config_reports_connected_false_when_iris_did_not_answer_usefully() {
+        rt().block_on(async {
+            // (a) IRIS answered, but not with a usable root descriptor.
+            for status in [404u16, 500] {
+                let server = all_routes(status).await;
+                let mut conn = IrisConnection::new(
+                    server.uri(),
+                    "APP",
+                    "_SYSTEM",
+                    "SYS",
+                    DiscoverySource::EnvVar,
+                );
+                conn.probe().await;
+                let tools = IrisTools::new_with_toolset(Some(conn), Toolset::Interop).unwrap();
+                let v = payload(&tools.check_config(Parameters(NoParams {})).await.unwrap());
+                assert_eq!(v["connected"], false, "HTTP {status}: {v}");
+                assert_eq!(v["probe_status"], status, "{v}");
+            }
+
+            // (b) The probe ran and nothing came back at all — port 1 is reserved and closed.
+            let mut conn = IrisConnection::new(
+                "http://127.0.0.1:1",
+                "APP",
+                "_SYSTEM",
+                "SYS",
+                DiscoverySource::EnvVar,
+            );
+            conn.probe().await;
+            assert_eq!(conn.probe_reached, Some(false), "the probe must remember");
+            let tools = IrisTools::new_with_toolset(Some(conn), Toolset::Interop).unwrap();
+            let v = payload(&tools.check_config(Parameters(NoParams {})).await.unwrap());
+            assert_eq!(v["connected"], false, "{v}");
+            assert_eq!(
+                v["auth_ok"],
+                serde_json::Value::Null,
+                "nothing was learned about the credentials: {v}"
+            );
+        });
+    }
+}
+
+// ── Issue #99: the agent_stats tool's own wiring ──────────────────────────────
+//
+// The shared implementation is exercised in `skills_tools::agent_stats_shape_tests` (pure)
+// and in `tests/skills_tests.rs` (both tools, same unreachable registry). What is left to
+// pin HERE is the three lines of wiring the `#[tool]` handler contributes — that it reaches
+// the shared builder at all, rather than reading `self.registry.list_skills().len()` again.
+//
+// Deliberately no assertion on `namespace`: `OBJECTSCRIPT_SKILLMCP_NAMESPACE` is
+// process-global and `skills_tools`' own `skills_namespace_fallback_chain` sets it, and
+// cargo runs lib tests in parallel threads. This test is written so no environment variable
+// can change its outcome — with no connection at all, `agent_stats_result` returns before
+// anything is dialled, spawned or read.
+#[cfg(test)]
+mod agent_stats_wiring_tests {
+    use super::*;
+
+    /// #99: `agent_stats` used to answer `{"status":"ok","skill_count":0,…}` for a registry
+    /// it had never read — the same 0 it printed for "empty" and for "3 skills present". It
+    /// must now fail, and carry no count at all.
+    #[test]
+    fn agent_stats_never_answers_ok_about_a_registry_it_did_not_read() {
+        let rt = tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .unwrap();
+        rt.block_on(async {
+            let tools = IrisTools::new_with_toolset(None, Toolset::Merged).unwrap();
+            let r = tools
+                .agent_stats(rmcp::handler::server::wrapper::Parameters(NoParams {}))
+                .await
+                .expect("the tool must answer, not error out of the transport");
+            let v: serde_json::Value = match &r.content[0].raw {
+                rmcp::model::RawContent::Text(t) => serde_json::from_str(&t.text).unwrap(),
+                _ => panic!("expected text content"),
+            };
+            assert_eq!(r.is_error, Some(true), "a false zero is not success: {v}");
+            assert_eq!(v["error_code"], "DOCKER_REQUIRED", "{v}");
+            assert!(
+                v.get("skill_count").is_none(),
+                "the in-process registry must not stand in for ^SKILLS: {v}"
+            );
+            assert!(
+                v.get("status").is_none(),
+                "\"ok\" was an unconditional literal — it must not outlive a failure: {v}"
+            );
+            assert_eq!(
+                v["source"], "^SKILLS",
+                "say WHICH registry was unreadable: {v}"
+            );
+        });
     }
 }

--- a/crates/iris-agentic-dev-core/src/tools/scm.rs
+++ b/crates/iris-agentic-dev-core/src/tools/scm.rs
@@ -17,6 +17,16 @@ fn err_json(code: &str, msg: &str) -> Result<rmcp::model::CallToolResult, rmcp::
     crate::tools::envelope::fail(code, msg)
 }
 
+/// Issue #101: a wrong password made every SCM action answer `SCM_UNAVAILABLE` with no hint
+/// at all, which reads as "this instance has no source control" — a statement about the
+/// server's configuration, for a request IRIS rejected at the door. `SCM_UNAVAILABLE` is
+/// still right when the SCM session genuinely could not start; it is not right for a 401,
+/// a 403, or a closed port, and those three now say what they are and carry the hint that
+/// goes with them.
+fn scm_error_code(msg: &str) -> &'static str {
+    crate::tools::interop::classify_iris_error_or(msg, "SCM_UNAVAILABLE")
+}
+
 /// Menu prefix used for source control actions.
 pub const SCM_MENU: &str = "%SourceMenu";
 
@@ -171,7 +181,7 @@ pub async fn handle_iris_source_control(
                 Err(e) => {
                     // A transport/exec failure must NOT be reported as "editable" — that is the
                     // very inconsistency this path used to have. Surface it honestly.
-                    return err_json("SCM_UNAVAILABLE", &e.to_string());
+                    return err_json(scm_error_code(&e.to_string()), &e.to_string());
                 }
             };
             // The executor may append "ERROR($ZERROR): …" on later lines — find the SCMSTATUS
@@ -259,7 +269,7 @@ pub async fn handle_iris_source_control(
             let code = user_action_code("%CheckOut", doc, &iris.username, &iris.password);
             let raw = match xecute(iris, client, &code, ns).await {
                 Ok(o) => o,
-                Err(e) => return err_json("SCM_UNAVAILABLE", &e.to_string()),
+                Err(e) => return err_json(scm_error_code(&e.to_string()), &e.to_string()),
             };
             let out = raw.lines().next().unwrap_or("").trim();
             if out == "SCM_UNAVAILABLE" {
@@ -285,7 +295,7 @@ pub async fn handle_iris_source_control(
                             return err_json("SCM_CHECKOUT_FAILED", &aout);
                         }
                     }
-                    Err(e) => return err_json("SCM_UNAVAILABLE", &e.to_string()),
+                    Err(e) => return err_json(scm_error_code(&e.to_string()), &e.to_string()),
                 }
                 // Checkout committed — cache it so a following iris_doc write skips the probe.
                 checkout_cache.mark(ns, doc);
@@ -326,7 +336,7 @@ pub async fn handle_iris_source_control(
             let code = user_action_code(action_id, doc, &iris.username, &iris.password);
             let raw = match xecute(iris, client, &code, ns).await {
                 Ok(o) => o,
-                Err(e) => return err_json("SCM_UNAVAILABLE", &e.to_string()),
+                Err(e) => return err_json(scm_error_code(&e.to_string()), &e.to_string()),
             };
             let out = raw.lines().next().unwrap_or("").trim();
             if out == "SCM_UNAVAILABLE" {

--- a/crates/iris-agentic-dev-core/src/tools/skills_tools.rs
+++ b/crates/iris-agentic-dev-core/src/tools/skills_tools.rs
@@ -226,6 +226,32 @@ pub(crate) fn skills_read_fail(
     e: SkillsReadError,
 ) -> Result<rmcp::model::CallToolResult, rmcp::ErrorData> {
     match e {
+        // #101: `Unreachable` is a string from whatever failed, and this arm rendered EVERY
+        // such string as DOCKER_REQUIRED + "Set IRIS_CONTAINER=<container_name>" — advice
+        // about the one variable that is provably not the problem once IRIS has answered.
+        //
+        // Today every producer of this error is `IrisConnection::execute`, which is docker-exec
+        // only and fails with the literal "DOCKER_REQUIRED" before any HTTP, so a wrong
+        // password genuinely is not why a skills read failed and DOCKER_REQUIRED is the honest
+        // answer there — the live observation that correct and wrong credentials produce
+        // identical output has that benign cause. This guard is what keeps that true by
+        // construction rather than by coincidence: the moment a skills read learns to go over
+        // HTTP, an auth refusal must not be renamed into a container problem on its way out.
+        SkillsReadError::Unreachable(err)
+            if crate::tools::envelope::auth_error_code(&err.to_string()).is_some() =>
+        {
+            let code = crate::tools::envelope::auth_error_code(&err.to_string())
+                .expect("guarded by the match arm");
+            crate::tools::envelope::fail_with(
+                code,
+                &format!(
+                    "{tool} could not read ^SKILLS in namespace '{ns}': {err}. IRIS answered \
+                     and rejected the request, so it is reachable — this is a credentials \
+                     failure, not a missing container."
+                ),
+                serde_json::json!({"namespace": ns, "source": "^SKILLS"}),
+            )
+        }
         SkillsReadError::Unreachable(err) => crate::tools::envelope::fail_with(
             "DOCKER_REQUIRED",
             &format!(
@@ -613,6 +639,130 @@ fn default_limit() -> usize {
     20
 }
 
+/// #99: how many tool calls this session recorded, with the history mutex's poison
+/// RECOVERED rather than read as "no calls".
+///
+/// `agent_stats` computed this as `self.history.lock().map(|h| h.len()).unwrap_or(0)`, so a
+/// poisoned mutex — another tool panicked while holding it — reported `session_calls: 0`
+/// for a history that is still perfectly intact. That is the same false zero #89 removed
+/// from `agent_history` and from `agent_info(what=history)`, surviving one function over.
+/// `record_call` only pushes and pops a `VecDeque`, so a panic cannot leave the deque
+/// structurally invalid: the entries are there and must be counted.
+pub(crate) fn session_call_count(history: &std::sync::Mutex<VecDeque<ToolCallEntry>>) -> usize {
+    history.lock().unwrap_or_else(|e| e.into_inner()).len()
+}
+
+/// #99: the success payload of `agent_stats` / `agent_info(what=stats)`, as a pure function.
+///
+/// Split out so the field NAMES and the one rule that matters — a count appears only when a
+/// count was actually read — are unit-testable with no IRIS and no docker. Every failure
+/// path returns `skills_read_fail`'s envelope instead of reaching this function at all, so
+/// there is no branch here that could emit a zero nobody measured.
+///
+/// `subscribed` is `Some((skills, kb_items))` for `agent_stats`, which additionally reports
+/// the in-process `--subscribe` population, and `None` for `agent_info(what=stats)`, whose
+/// payload must stay field-for-field what it emits today.
+///
+/// `status: "ok"` rides with `subscribed` because it is `agent_stats`' own legacy field. It
+/// is kept rather than dropped: it is only ever emitted on success (the failure envelope
+/// carries `success: false` and no `status` at all), so it is not a lie, and removing it
+/// would break an existing consumer for nothing. `success: true` is added beside it as the
+/// field that actually carries the meaning.
+pub(crate) fn agent_stats_json(
+    skill_count: usize,
+    ns: &str,
+    session_calls: usize,
+    learning: bool,
+    subscribed: Option<(usize, usize)>,
+) -> serde_json::Value {
+    let mut v = serde_json::json!({
+        "success": true,
+        "skill_count": skill_count,
+        "session_calls": session_calls,
+        "learning_enabled": learning,
+        // #85: say WHICH registry the count came from. Every sibling reports these two.
+        "namespace": ns,
+        "source": SKILLS_GLOBAL,
+    });
+    if let Some((skills, kb_items)) = subscribed {
+        v["status"] = serde_json::json!("ok");
+        v["subscribed_skill_count"] = serde_json::json!(skills);
+        v["subscribed_kb_item_count"] = serde_json::json!(kb_items);
+        v["subscribed_source"] = serde_json::json!(
+            "--subscribe github packages (in-process, populated at startup only)"
+        );
+    }
+    v
+}
+
+/// #99: the ONE implementation of "learning agent status", shared by `agent_stats` and
+/// `agent_info(what=stats)` so the two can no longer drift apart.
+///
+/// `agent_stats` used to report `self.registry.list_skills().len()` — the in-process
+/// `SkillRegistry` — under the bare name `skill_count`, with no namespace and no source.
+/// That number is a STARTUP CONSTANT: `SkillRegistry::load_from_github` takes `&mut self`
+/// and is called only from `--subscribe <owner/repo>` before the server starts, and the
+/// registry is held behind an `Arc` with no interior mutability, so in every session
+/// started without `--subscribe` it is frozen at 0 for the whole process lifetime.
+///
+/// Reproduced live, twice, in one session against the dev instance: `agent_stats` answered
+/// `skill_count: 0` while `skill_list` and `agent_info(what=stats)` both answered 3 from
+/// `^SKILLS`; and with IRIS unreachable it answered `skill_count: 0, status: "ok"` while
+/// both siblings correctly answered DOCKER_REQUIRED. One field, three different meanings —
+/// "the registry is empty", "3 skills are present" and "IRIS was never reached" — and
+/// nothing in the payload to tell them apart. `agent_stats` is also the only agent_* skill
+/// count that survives into the `merged` profile, which prunes `agent_info`.
+///
+/// So `skill_count` MEANS `^SKILLS` in the connection's namespace here too — same builder,
+/// same namespace resolution (#85), same failure classification (#119) as `skill_list` —
+/// and the registry population is reported BESIDE it as `subscribed_*`, a name that says
+/// what it is. Nothing is dropped; the wrong number simply stops wearing the right name.
+///
+/// A failed read returns the shared envelope carrying NO count at all (#89/#119): "could
+/// not read it" must never arrive as "there are none".
+///
+/// COST: this makes `agent_stats` fallible and no longer free. Measured on the dev instance:
+/// 4.0 / 4.5 ms before (it touched no IRIS) against 51.7 / 54.7 ms for
+/// `agent_info(what=stats)` and 49.8 / 60.9 ms for `skill_list`, both of which do exactly
+/// this one `^SKILLS` read. `agent_history` still needs no connection.
+pub async fn agent_stats_result(
+    tool: &str,
+    iris: Option<&IrisConnection>,
+    history: &std::sync::Mutex<VecDeque<ToolCallEntry>>,
+    registry: Option<&crate::skills::SkillRegistry>,
+) -> Result<rmcp::model::CallToolResult, rmcp::ErrorData> {
+    // #85: the namespace resolves from the CONNECTION. With no connection there is nothing
+    // to resolve and this falls to "USER" — honest, because the very next line reports that
+    // IRIS was never reached. Identical to `skill_list`, deliberately: going through
+    // `get_iris_reloaded().await?` instead would raise a protocol-level McpError rather than
+    // this envelope, and callers branch on `error_code`.
+    let ns = skills_namespace(iris);
+    let Some(iris) = iris else {
+        return skills_read_fail(
+            tool,
+            &ns,
+            SkillsReadError::Unreachable("no IRIS connection configured".into()),
+        );
+    };
+    let code = skills_list_json_code(None, false);
+    let skill_count = match read_skills_json(iris, &code, &ns)
+        .await
+        .and_then(|v| skills_count_from_payload(&v))
+    {
+        Ok(n) => n,
+        // Never `unwrap_or(0)`, never `map_or(0, …)`: that is the bug this function exists
+        // to remove, and it is one refactor away at all times.
+        Err(e) => return skills_read_fail(tool, &ns, e),
+    };
+    ok_json(agent_stats_json(
+        skill_count,
+        &ns,
+        session_call_count(history),
+        learning_enabled(),
+        registry.map(|r| (r.list_skills().len(), r.list_kb_items().len())),
+    ))
+}
+
 pub async fn handle_agent_info(
     iris: &IrisConnection,
     // #89: the ^SKILLS read goes through read_skills_json -> IrisConnection::execute
@@ -622,35 +772,13 @@ pub async fn handle_agent_info(
     history: &std::sync::Mutex<VecDeque<ToolCallEntry>>,
 ) -> Result<rmcp::model::CallToolResult, rmcp::ErrorData> {
     match p.what.as_str() {
-        "stats" => {
-            let ns = skills_namespace(Some(iris));
-            // #89: count what `skill(action=list)` lists — SAME builder, SAME namespace
-            // (#85), SAME classification (#119) — so the two tools can no longer disagree
-            // about the registry. This arm was the last ^SKILLS *reader* in the crate that
-            // bypassed read_skills_json, hardcoded the global instead of SKILLS_GLOBAL, and
-            // pinned every failure to 0 with success:true.
-            let code = skills_list_json_code(None, false);
-            let skill_count = match read_skills_json(iris, &code, &ns)
-                .await
-                .and_then(|v| skills_count_from_payload(&v))
-            {
-                Ok(n) => n,
-                Err(e) => return skills_read_fail("agent_info(what=stats)", &ns, e),
-            };
-            // A poisoned mutex means another tool panicked holding the history; the deque
-            // itself is intact (record_call cannot leave it structurally invalid), so
-            // recover it rather than reporting "0 calls" — the same false zero again.
-            let session_calls = history.lock().unwrap_or_else(|e| e.into_inner()).len();
-            ok_json(serde_json::json!({
-                "success": true,
-                "skill_count": skill_count,
-                "session_calls": session_calls,
-                "learning_enabled": learning_enabled(),
-                // #85: which registry the count came from. Every sibling reports these.
-                "namespace": ns,
-                "source": "^SKILLS",
-            }))
-        }
+        // #89: count what `skill(action=list)` lists — SAME builder, SAME namespace (#85),
+        // SAME classification (#119) — so the two tools cannot disagree about the registry.
+        // #99: and SAME function as `agent_stats`, which had re-forked this arm from the
+        // in-process `SkillRegistry` and reintroduced #89's false zero one tool over.
+        // `registry: None` means no `subscribed_*` and no `status`, so this tool's payload
+        // is field-for-field what it emitted before the two implementations were merged.
+        "stats" => agent_stats_result("agent_info(what=stats)", Some(iris), history, None).await,
         "history" => {
             let limit = p.limit;
             // #89: same poison recovery — `.unwrap_or_default()` on the lock rendered an
@@ -996,6 +1124,51 @@ mod objectscript_escaping_tests {
             "the message must say IRIS WAS reached: {v}"
         );
     }
+    /// #101: the third state. `DOCKER_REQUIRED` + "Set IRIS_CONTAINER=<container_name>" came
+    /// back byte-for-byte identically with CORRECT and with WRONG credentials — verified live
+    /// across skill_list / agent_stats / agent_info / skill(action=list). IRIS had answered
+    /// 401; the container name is not what is wrong, and a caller following that hint edits
+    /// the one variable that was already right.
+    #[test]
+    fn a_rejected_password_is_not_reported_as_a_missing_container() {
+        fn payload(r: &rmcp::model::CallToolResult) -> serde_json::Value {
+            let text = match &r.content[0].raw {
+                rmcp::model::RawContent::Text(t) => &t.text,
+                _ => panic!("expected text content"),
+            };
+            serde_json::from_str(text).unwrap()
+        }
+
+        for (err, code) in [
+            ("PUT doc failed: HTTP 401 Unauthorized", "IRIS_AUTH_FAILED"),
+            ("PUT doc failed: HTTP 403 Forbidden", "IRIS_FORBIDDEN"),
+        ] {
+            let r = skills_read_fail(
+                "skill_list",
+                "APP",
+                SkillsReadError::Unreachable(err.into()),
+            )
+            .unwrap();
+            let v = payload(&r);
+            assert_eq!(r.is_error, Some(true), "{v}");
+            assert_eq!(v["error_code"], code, "{v}");
+            assert!(
+                !v.to_string().contains("IRIS_CONTAINER"),
+                "the container name is not the knob to turn here: {v}"
+            );
+        }
+        // The guard: a genuine "cannot reach IRIS at all" still says DOCKER_REQUIRED.
+        let v = payload(
+            &skills_read_fail(
+                "skill_list",
+                "APP",
+                SkillsReadError::Unreachable("DOCKER_REQUIRED".into()),
+            )
+            .unwrap(),
+        );
+        assert_eq!(v["error_code"], "DOCKER_REQUIRED", "{v}");
+    }
+
     /// #119 follow-up: an empty payload is an UNREACHABLE transport, not malformed JSON.
     /// `IrisConnection::execute` drops the exit status, so a failed `docker exec` arrives
     /// as `Ok("")`; classifying that as a parse failure made the tool state "IRIS WAS
@@ -1188,5 +1361,137 @@ mod skills_namespace_tests {
         assert_eq!(skills_namespace(None), "USER");
 
         std::env::remove_var("OBJECTSCRIPT_SKILLMCP_NAMESPACE");
+    }
+}
+
+// ── Issue #99: the two false zeros in agent_stats, as pure functions ──────────
+#[cfg(test)]
+mod agent_stats_shape_tests {
+    use super::*;
+
+    /// #99, the SECOND false zero — and the one that had no coverage anywhere in the tree.
+    /// `agent_stats` computed `session_calls` as `self.history.lock().map(|h| h.len())
+    /// .unwrap_or(0)`, so a mutex poisoned by an unrelated panic reported "0 calls" about a
+    /// deque that still holds every entry. `agent_history` got this fix in #89 and never got
+    /// a test; this is that test, on the path #89 missed.
+    #[test]
+    fn a_poisoned_history_is_not_zero_session_calls() {
+        let history = std::sync::Arc::new(std::sync::Mutex::new(VecDeque::new()));
+        for i in 0..3 {
+            history.lock().unwrap().push_back(ToolCallEntry {
+                tool: format!("tool{i}"),
+                success: true,
+                timestamp: std::time::Instant::now(),
+            });
+        }
+        assert_eq!(session_call_count(&history), 3, "control: not yet poisoned");
+
+        // Poison it exactly the way a panicking tool would: panic while holding the guard.
+        let h = std::sync::Arc::clone(&history);
+        let _ = std::thread::spawn(move || {
+            let _guard = h.lock().unwrap();
+            panic!("a tool panicked while holding the history");
+        })
+        .join();
+        assert!(history.lock().is_err(), "the mutex must really be poisoned");
+
+        assert_eq!(
+            session_call_count(&history),
+            3,
+            "a poisoned mutex means a tool panicked, not that the session made no calls"
+        );
+    }
+
+    /// #99: the registry population is REPORTED, not dropped — under a name that says what
+    /// it is. `skill_count` is the ^SKILLS number; the `--subscribe` number lives in
+    /// `subscribed_skill_count`, and the two are deliberately different here so a rename
+    /// that swapped them could not pass.
+    #[test]
+    fn agent_stats_names_the_registry_population_separately() {
+        let v = agent_stats_json(7, "APP", 4, true, Some((2, 9)));
+        assert_eq!(
+            v["skill_count"], 7,
+            "^SKILLS is what skill_count MEANS: {v}"
+        );
+        assert_eq!(v["namespace"], "APP", "{v}");
+        assert_eq!(v["source"], "^SKILLS", "{v}");
+        assert_eq!(v["subscribed_skill_count"], 2, "{v}");
+        assert_eq!(v["subscribed_kb_item_count"], 9, "{v}");
+        assert!(
+            v["subscribed_source"]
+                .as_str()
+                .unwrap()
+                .contains("--subscribe"),
+            "the second population must say where it came from: {v}"
+        );
+        assert!(
+            v["subscribed_source"].as_str().unwrap().contains("startup"),
+            "…and that it is frozen at startup, which is why it is not skill_count: {v}"
+        );
+    }
+
+    /// #99: pin the field names, so a rename cannot silently put one population back under
+    /// the other's name. `status` and the `subscribed_*` trio belong to `agent_stats` only —
+    /// `agent_info(what=stats)` must keep emitting exactly what it emits today.
+    #[test]
+    fn agent_stats_success_payload_shape() {
+        let stats = agent_stats_json(3, "APP", 1, true, Some((0, 0)));
+        for k in [
+            "success",
+            "status",
+            "skill_count",
+            "namespace",
+            "source",
+            "subscribed_skill_count",
+            "subscribed_kb_item_count",
+            "subscribed_source",
+            "session_calls",
+            "learning_enabled",
+        ] {
+            assert!(stats.get(k).is_some(), "agent_stats must emit {k}: {stats}");
+        }
+        assert_eq!(stats["success"], true, "{stats}");
+        assert_eq!(stats["status"], "ok", "{stats}");
+
+        let info = agent_stats_json(3, "APP", 1, true, None);
+        assert_eq!(
+            info,
+            serde_json::json!({
+                "success": true,
+                "skill_count": 3,
+                "session_calls": 1,
+                "learning_enabled": true,
+                "namespace": "APP",
+                "source": "^SKILLS",
+            }),
+            "agent_info(what=stats) must stay field-for-field what it emitted before #99"
+        );
+    }
+
+    /// #99/#89/#119: there is no path through the success payload that can carry a count
+    /// nobody measured, because the count is a `usize` parameter — a failed read returns
+    /// `skills_read_fail`'s envelope and never reaches this function. Pinned so a future
+    /// "partial success" refactor (`skill_count: null` + `skill_count_error`) has to argue
+    /// with a test: JSON null coerces to 0 in JS and is `or 0`-ed in Python, i.e. the same
+    /// false zero one hop downstream.
+    #[test]
+    fn a_failed_read_has_no_shape_here_at_all() {
+        let fail = skills_read_fail(
+            "agent_stats",
+            "APP",
+            SkillsReadError::Unreachable("no IRIS connection configured".into()),
+        )
+        .unwrap();
+        let text = match &fail.content[0].raw {
+            rmcp::model::RawContent::Text(t) => t.text.clone(),
+            _ => panic!("expected text content"),
+        };
+        let v: serde_json::Value = serde_json::from_str(&text).unwrap();
+        assert_eq!(fail.is_error, Some(true), "{v}");
+        assert_eq!(v["error_code"], "DOCKER_REQUIRED", "{v}");
+        assert!(v.get("skill_count").is_none(), "no count may survive: {v}");
+        assert!(v.get("status").is_none(), "no \"ok\" on a failure: {v}");
+        assert_eq!(v["namespace"], "APP", "{v}");
+        assert_eq!(v["source"], "^SKILLS", "{v}");
     }
 }

--- a/crates/iris-agentic-dev-core/tests/integration/test_e2e.rs
+++ b/crates/iris-agentic-dev-core/tests/integration/test_e2e.rs
@@ -272,7 +272,10 @@ fn e2e_execute_docker_required_has_instructions() {
             ec == "DOCKER_REQUIRED"
                 || text.contains("iris_container")
                 || text.contains("docker")
-                || ec == "IRIS_UNREACHABLE",
+                || ec == "IRIS_UNREACHABLE"
+                // #101: a mis-credentialed runner now gets the auth codes, not IRIS_UNREACHABLE.
+                || ec == "IRIS_AUTH_FAILED"
+                || ec == "IRIS_FORBIDDEN",
             "error without IRIS should mention Docker or container: {}",
             result
         );
@@ -3507,9 +3510,15 @@ fn e2e_resolve_dynamic_dispatch_returns_candidates() {
         serde_json::json!({"method_name": "Connect", "package_prefix": "EnsLib", "namespace": "USER"}),
     );
     // Accept NO_RESULTS if namespace has no EnsLib classes compiled
-    if result["error_code"].as_str() == Some("IRIS_UNREACHABLE")
-        || result["error_code"].as_str() == Some("TIMEOUT")
-    {
+    // #101: a mis-credentialed runner used to receive IRIS_UNREACHABLE here and skip.
+    // It now receives IRIS_AUTH_FAILED / IRIS_FORBIDDEN — same "environment not usable"
+    // condition, two new codes — so the sentinel has to recognise them or this test
+    // stops skipping and fails on an unrelated cause. Local gates never see it: our
+    // credentials are correct.
+    if matches!(
+        result["error_code"].as_str(),
+        Some("IRIS_UNREACHABLE" | "IRIS_AUTH_FAILED" | "IRIS_FORBIDDEN" | "TIMEOUT")
+    ) {
         eprintln!("resolve_dynamic_dispatch: IRIS unavailable — skipping");
         return;
     }
@@ -3549,9 +3558,10 @@ fn e2e_extract_message_map_no_message_map_class() {
         "extract_message_map_routing",
         serde_json::json!({"class_name": "%ASQ.AST", "namespace": "USER"}),
     );
-    if result["error_code"].as_str() == Some("IRIS_UNREACHABLE")
-        || result["error_code"].as_str() == Some("TIMEOUT")
-    {
+    if matches!(
+        result["error_code"].as_str(),
+        Some("IRIS_UNREACHABLE" | "IRIS_AUTH_FAILED" | "IRIS_FORBIDDEN" | "TIMEOUT")
+    ) {
         eprintln!("extract_message_map_routing: IRIS unavailable — skipping");
         return;
     }
@@ -3590,7 +3600,10 @@ fn e2e_extract_message_map_not_found() {
         "extract_message_map_routing",
         serde_json::json!({"class_name": "DoesNot.Exist.Class", "namespace": "USER"}),
     );
-    if result["error_code"].as_str() == Some("IRIS_UNREACHABLE") {
+    if matches!(
+        result["error_code"].as_str(),
+        Some("IRIS_UNREACHABLE" | "IRIS_AUTH_FAILED" | "IRIS_FORBIDDEN")
+    ) {
         return;
     }
     assert_eq!(
@@ -3613,9 +3626,10 @@ fn e2e_find_subclass_implementations_returns_results() {
             "namespace": "USER"
         }),
     );
-    if result["error_code"].as_str() == Some("IRIS_UNREACHABLE")
-        || result["error_code"].as_str() == Some("TIMEOUT")
-    {
+    if matches!(
+        result["error_code"].as_str(),
+        Some("IRIS_UNREACHABLE" | "IRIS_AUTH_FAILED" | "IRIS_FORBIDDEN" | "TIMEOUT")
+    ) {
         eprintln!("find_subclass_implementations: IRIS unavailable — skipping");
         return;
     }
@@ -3652,7 +3666,10 @@ fn e2e_find_subclass_implementations_empty_base_classes() {
             "namespace": "USER"
         }),
     );
-    if result["error_code"].as_str() == Some("IRIS_UNREACHABLE") {
+    if matches!(
+        result["error_code"].as_str(),
+        Some("IRIS_UNREACHABLE" | "IRIS_AUTH_FAILED" | "IRIS_FORBIDDEN")
+    ) {
         return;
     }
     assert_eq!(

--- a/crates/iris-agentic-dev-core/tests/integration/test_mcp_iris.rs
+++ b/crates/iris-agentic-dev-core/tests/integration/test_mcp_iris.rs
@@ -123,7 +123,12 @@ fn e2e_iris_compile_success() {
         result
     );
 
-    if result["error_code"].as_str() != Some("IRIS_UNREACHABLE") {
+    // #101: a mis-credentialed runner receives IRIS_AUTH_FAILED / IRIS_FORBIDDEN where it
+    // used to receive IRIS_UNREACHABLE — the same "environment not usable" skip condition.
+    if !matches!(
+        result["error_code"].as_str(),
+        Some("IRIS_UNREACHABLE" | "IRIS_AUTH_FAILED" | "IRIS_FORBIDDEN")
+    ) {
         assert_eq!(
             result["success"], true,
             "iris_compile should succeed with live IRIS: {}",

--- a/crates/iris-agentic-dev-core/tests/skills_tests.rs
+++ b/crates/iris-agentic-dev-core/tests/skills_tests.rs
@@ -330,3 +330,124 @@ fn agent_info_stats_reports_unreachable_not_a_count_of_zero() {
 
     std::env::remove_var("IRIS_CONTAINER");
 }
+
+// ── Issue #99: agent_stats must report the SAME registry agent_info does ──────
+
+/// #99, reproduced live twice on the dev instance and reproduced here offline.
+///
+/// `agent_stats` reported `self.registry.list_skills().len()` — the in-process
+/// `--subscribe` registry, a startup constant that is 0 in every session started without
+/// `--subscribe` — under the bare name `skill_count`, with no namespace and no source. In
+/// ONE live session it answered `{"skill_count":0,"status":"ok"}` while `skill_list` and
+/// `agent_info(what=stats)` both answered 3 from `^SKILLS`; with IRIS unreachable it
+/// answered `{"skill_count":0,"status":"ok"}` again while both siblings correctly answered
+/// DOCKER_REQUIRED. Character for character the #89 symptom, in the tool that survives into
+/// the `merged` profile (which prunes `agent_info`).
+///
+/// `IrisConnection::execute` is docker-exec ONLY, so with no `IRIS_CONTAINER` the read fails
+/// before anything is dialled or spawned: this test touches neither the network nor docker.
+///
+/// ONE `#[test]` on purpose — `IRIS_CONTAINER` and `OBJECTSCRIPT_SKILLMCP_NAMESPACE` are
+/// process-global and cargo runs tests in parallel threads, so splitting the sub-cases would
+/// race (same rule as `skills_namespace_fallback_chain` and the #89 test above).
+#[test]
+fn agent_stats_reports_unreachable_not_a_count_of_zero() {
+    use iris_agentic_dev_core::iris::connection::{DiscoverySource, IrisConnection};
+    use iris_agentic_dev_core::skills::SkillRegistry;
+    use iris_agentic_dev_core::tools::skills_tools::{
+        agent_stats_result, handle_agent_info, AgentInfoParams,
+    };
+
+    fn payload(r: &rmcp::model::CallToolResult) -> serde_json::Value {
+        let text = match &r.content[0].raw {
+            rmcp::model::RawContent::Text(t) => &t.text,
+            _ => panic!("expected text content"),
+        };
+        serde_json::from_str(text).unwrap()
+    }
+
+    std::env::remove_var("IRIS_CONTAINER");
+    std::env::remove_var("OBJECTSCRIPT_SKILLMCP_NAMESPACE");
+
+    let rt = tokio::runtime::Builder::new_current_thread()
+        .enable_all()
+        .build()
+        .unwrap();
+    // RFC 2606 `.invalid` host so a future edit cannot accidentally point this at the
+    // maintainer's live dev IRIS.
+    let iris = IrisConnection::new(
+        "http://never-dialled.invalid",
+        "APP",
+        "_SYSTEM",
+        "SYS",
+        DiscoverySource::EnvVar,
+    );
+    let client = reqwest::Client::new();
+    let history = std::sync::Mutex::new(std::collections::VecDeque::new());
+    let registry = SkillRegistry::new();
+
+    rt.block_on(async {
+        // 1. The issue itself: an unreadable ^SKILLS is an ERROR, not a count of zero — and
+        //    emphatically not `status: "ok"`.
+        let r = agent_stats_result("agent_stats", Some(&iris), &history, Some(&registry))
+            .await
+            .unwrap();
+        assert_eq!(r.is_error, Some(true), "a false zero is not success");
+        let stats = payload(&r);
+        assert_eq!(stats["error_code"], "DOCKER_REQUIRED", "{stats}");
+        assert!(
+            stats.get("skill_count").is_none(),
+            "no count may survive a failed read: {stats}"
+        );
+        assert!(
+            stats.get("status").is_none(),
+            "the unconditional \"ok\" literal must not outlive the failure: {stats}"
+        );
+        // #85: say WHICH registry — the count resolves from the connection (APP, not USER).
+        assert_eq!(stats["namespace"], "APP", "{stats}");
+        assert_eq!(stats["source"], "^SKILLS", "{stats}");
+
+        // 2. THE REGRESSION TEST THAT MATTERS: `agent_stats` and `agent_info(what=stats)`
+        //    are one implementation now, so they cannot report different things about the
+        //    same registry in the same session. This is the test that fails the day someone
+        //    re-forks them — which is exactly how #99 came to exist after #89 fixed #89.
+        let info = payload(
+            &handle_agent_info(
+                &iris,
+                &client,
+                AgentInfoParams {
+                    what: "stats".into(),
+                    limit: 20,
+                },
+                &history,
+            )
+            .await
+            .unwrap(),
+        );
+        for field in ["error_code", "namespace", "source", "success"] {
+            assert_eq!(
+                stats[field], info[field],
+                "agent_stats and agent_info(what=stats) disagree on {field}: \
+                 {stats} vs {info}"
+            );
+        }
+        assert_eq!(
+            stats.get("skill_count").is_none(),
+            info.get("skill_count").is_none(),
+            "one of them invented a count: {stats} vs {info}"
+        );
+
+        // 3. With no connection at all the answer is the same shape, not a cheap zero. This
+        //    is the `merged`-profile session an operator actually hits.
+        let r = agent_stats_result("agent_stats", None, &history, Some(&registry))
+            .await
+            .unwrap();
+        assert_eq!(r.is_error, Some(true), "still not a success");
+        let v = payload(&r);
+        assert_eq!(v["error_code"], "DOCKER_REQUIRED", "{v}");
+        assert!(v.get("skill_count").is_none(), "{v}");
+        assert_eq!(v["source"], "^SKILLS", "{v}");
+    });
+
+    std::env::remove_var("IRIS_CONTAINER");
+}


### PR DESCRIPTION
Closes #99, closes #100, closes #101, closes #102.

## #102 — the issue said "404". The real defect was wider.

The scout corrected the premise and the fix is built on the correction: three tools were **non-2xx blind**, not 404-blind. A 404-only patch would have left all of them lying on a 401.

**P0 — tools that answered `success: true` with a confident wrong fact:**

| tool | was | now |
|---|---|---|
| `iris_doc(head)` | `exists = status.is_success()` → `exists:false` on 401/404 | explicit three-way; 2xx → true, 404 → ask the #93 helper, else an error |
| `docs_introspect` | `methods: null`, `success: true` | a failure envelope; `methods` can never be null on success |
| `iris_macro(list)` | "No include files found in this namespace" | a failure envelope |

**P1** — `iris_doc` get/delete name the *namespace* when that is the cause, and still name the *document* whenever the root descriptor confirms the namespace is present.

**P2** — fixed at `query_once`, covering `iris_symbols` and all three `iris_interop_query` variants. **The issue was wrong that `iris_query` goes through `query_once`** — it has its own duplicated HTTP path, so it got its own gate.

**P3** — `iris_execute` stops reporting `DOCKER_REQUIRED` for a mistyped namespace; `iris_table_info` stops reporting the generator's PUT scaffolding; `iris_production` is covered by the single `Err` arm in `ensure_interop_namespace`, lighting up 9 tools at once.

Bonus, and a nice one: `iris_test`'s namespace pre-flight was a full `execute_via_generator` cycle — PUT + compile + SQL + DELETE, **4 round trips**, hardcoded to `USER`, inside a 10s timeout, ending in `.unwrap_or(true)`. It is now one GET of `/api/atelier/`. A test asserts exactly **one** HTTP request, which is both the correctness check and the 4-to-1 proof. It also now catches "exists but is not accessible to this user", which `%SYS.Namespace.Exists` cannot express.

## #101 — two codes, not one

`IRIS_AUTH_FAILED` (401) and `IRIS_FORBIDDEN` (403), because **the remedies are disjoint**. IRIS validates the password *before* it can evaluate `%Development`, so on a 403 the password is provably correct. A caller that auto-remediates by re-prompting for credentials must not fire on it — so the 403 hint says the password is not the problem out loud, and ends *"Do not change IRIS_USERNAME / IRIS_PASSWORD."*

34 `interop.rs` sites collapsed into `classify_iris_error`. `check_config` now reports `auth_ok` and `probe_status`, and `connected` goes false only on a **definitive** 401/403 — a probe that never ran leaves the previous answer alone.

The docker fall-through in `iris_execute` **stays**: `IrisConnection::execute` shells out via docker and does not use `IRIS_USERNAME`/`IRIS_PASSWORD`, so a wrong Atelier password genuinely *is* recoverable with a container. Only what is reported when *both* legs fail changed.

## #99 / #100

**#99** — `agent_stats` reported the in-process registry (populated only by GitHub subscribe, so `0` in a normal session) under a name callers read as the `^SKILLS` count. It now reads `^SKILLS` through the same path as `agent_info` and `skill_list`, and the registry number is kept under the name it actually deserves, `subscribed_skill_count`. Live: with 3 seeded skills `agent_stats` and `skill_list` agree; with IRIS unreachable both return the identical `DOCKER_REQUIRED` envelope, where `agent_stats` used to answer `{"skill_count":0,"status":"ok"}` in **both** situations.

**#100** — a wildcard matching nothing listable now cross-checks `%Dictionary.ClassDefinition` and names what it found, instead of asserting a negative the Atelier listing cannot support (EnsPortal: 251 classes exist, 224 listable). The cross-check runs **only** on the empty path, so the happy path keeps #94's ~42 ms.

## Error codes that changed

`IRIS_AUTH` is retired, split into `IRIS_AUTH_FAILED` / `IRIS_FORBIDDEN`. Blanket `IRIS_UNREACHABLE` returns in `admin.rs`, `dict.rs`, `scm.rs`, `info.rs` and `mod.rs` are reclassified to `IRIS_REQUEST_FAILED` / `IRIS_EXECUTE_ERROR` / `SCM_UNAVAILABLE` / `INTEROP_ERROR`.

The principle: **an HTTP response is proof of reachability** — the invariant `doc.rs` has asserted for itself since #57 and that these files violated from outside it.

Untouched: every "no IRIS connection" guard (never reaches HTTP), every `envelope::transport_fail`, `SQL_ERROR`, `COMPILE_ERROR`, `TABLE_NOT_FOUND`, and `DOCKER_REQUIRED` for genuine docker-absent failures.

## Verification

- Gate: **1098 passed, 0 failed, 46 ignored**, twice consecutively. Was 1028/0/46 — **+70 tests, ignored count unchanged**, so nothing was disabled to make this pass.
- `fmt --check` and `clippy --all-targets -D warnings` clean.
- Every P0 fix verified live in **both** directions — the false answer is gone *and* the true negative still works (`head` still reports `exists:false` for a genuinely missing document in a real namespace).
- Dev IRIS left as found. The concurrent eval campaign on 42101/EVALNS was not touched.

Residual findings are being filed separately rather than folded in — several are pre-existing instances of the same class, plus one significant discovery about toolset pruning.

🤖 Generated with [Claude Code](https://claude.com/claude-code)