### PR TITLE
fix: advertise the parameters every tool actually reads (#112)

### DIFF
--- a/crates/iris-agentic-dev-core/src/tools/info.rs
+++ b/crates/iris-agentic-dev-core/src/tools/info.rs
@@ -251,6 +251,11 @@ pub async fn handle_iris_macro(
 #[derive(Debug, Deserialize, JsonSchema)]
 pub struct DebugParams {
     /// Action: map_int, error_logs, capture, source_map
+    // #112: the valid set was in the description prose only, so the schema said "any
+    // string". Caught by `every_tool_advertises_the_parameters_it_reads` — iris_debug was
+    // the tool held up as the example of a well-described dispatcher, and it had the same
+    // gap one level down.
+    #[schemars(extend("enum" = ["map_int", "error_logs", "capture", "source_map"]))]
     pub action: String,
     /// Error string for map_int e.g. "<UNDEFINED>x+3^MyApp.Foo.1"
     pub error_string: Option<String>,

--- a/crates/iris-agentic-dev-core/src/tools/interop.rs
+++ b/crates/iris-agentic-dev-core/src/tools/interop.rs
@@ -1406,6 +1406,11 @@ pub async fn interop_partners_impl(
 
 #[derive(Debug, Deserialize, JsonSchema)]
 pub struct ProductionItemParams {
+    // #112: the enum belongs in the SCHEMA, not only in the INVALID_ACTION message.
+    // Nine of the campaign's 31 parameter errors were a guessed action on one of these
+    // tools; the runtime message names the valid set correctly, it just arrives a round
+    // trip late. `extend` puts the same set where the model reads it first.
+    #[schemars(extend("enum" = ["add", "remove", "enable", "disable", "get_settings", "set_settings"]))]
     pub action: String,
     pub item: String,
     #[serde(default = "default_ns")]
@@ -1777,6 +1782,11 @@ pub struct CredentialListParams {
 
 #[derive(Debug, Deserialize, JsonSchema)]
 pub struct CredentialManageParams {
+    // #112: the enum belongs in the SCHEMA, not only in the INVALID_ACTION message.
+    // Nine of the campaign's 31 parameter errors were a guessed action on one of these
+    // tools; the runtime message names the valid set correctly, it just arrives a round
+    // trip late. `extend` puts the same set where the model reads it first.
+    #[schemars(extend("enum" = ["create", "update", "delete"]))]
     pub action: String,
     pub id: String,
     pub username: Option<String>,
@@ -1942,6 +1952,11 @@ If $$$ISERR(tSC) {{ Write "ERROR:INTEROP_ERROR:"_$System.Status.GetErrorText(tSC
 
 #[derive(Debug, Deserialize, JsonSchema)]
 pub struct LookupManageParams {
+    // #112: the enum belongs in the SCHEMA, not only in the INVALID_ACTION message.
+    // Nine of the campaign's 31 parameter errors were a guessed action on one of these
+    // tools; the runtime message names the valid set correctly, it just arrives a round
+    // trip late. `extend` puts the same set where the model reads it first.
+    #[schemars(extend("enum" = ["get", "set", "delete", "list_keys", "list_tables"]))]
     pub action: String,
     pub table: Option<String>,
     pub key: Option<String>,
@@ -1952,6 +1967,11 @@ pub struct LookupManageParams {
 
 #[derive(Debug, Deserialize, JsonSchema)]
 pub struct LookupTransferParams {
+    // #112: the enum belongs in the SCHEMA, not only in the INVALID_ACTION message.
+    // Nine of the campaign's 31 parameter errors were a guessed action on one of these
+    // tools; the runtime message names the valid set correctly, it just arrives a round
+    // trip late. `extend` puts the same set where the model reads it first.
+    #[schemars(extend("enum" = ["export", "import"]))]
     pub action: String,
     pub table: String,
     pub xml: Option<String>,
@@ -2338,6 +2358,11 @@ fn default_max_bytes() -> u32 {
 
 #[derive(Debug, Deserialize, JsonSchema)]
 pub struct BusinessRuleInfoParams {
+    // #112: the enum belongs in the SCHEMA, not only in the INVALID_ACTION message.
+    // Nine of the campaign's 31 parameter errors were a guessed action on one of these
+    // tools; the runtime message names the valid set correctly, it just arrives a round
+    // trip late. `extend` puts the same set where the model reads it first.
+    #[schemars(extend("enum" = ["list", "get"]))]
     pub action: String,
     pub rule_name: Option<String>,
     #[serde(default = "default_ns")]

--- a/crates/iris-agentic-dev-core/src/tools/mod.rs
+++ b/crates/iris-agentic-dev-core/src/tools/mod.rs
@@ -37,6 +37,227 @@ impl std::ops::Deref for AnyParams {
         &self.0
     }
 }
+
+// #112: the advertised shape of `iris_production`. Schema only — the handler still reads
+// the raw object, because the nine actions take overlapping subsets and a strict struct
+// would reject valid calls. Every field below is one the handler actually reads; the
+// per-action applicability is in each field's description, which is where a model looks.
+//
+// `//`, not `///`, deliberately: schemars promotes a struct doc comment to the schema's
+// top-level `description`, which then ships on every tools/list. That is #82's rule.
+#[derive(Debug, Deserialize, JsonSchema)]
+#[allow(dead_code)] // read via the raw Value; this type exists to be the schema
+pub struct ProductionDispatchSchema {
+    /// REQUIRED. status=current state, start=start a production, stop=stop the running one,
+    /// restart=recycle ONE config item (pass item), update=hot-apply config changes,
+    /// check=report whether an update is needed, recover=recover a troubled production,
+    /// get_autostart / set_autostart=read or set this namespace's autostart production.
+    pub action: ProductionAction,
+    /// Interop-enabled namespace. Omit to use the connection namespace (IRIS_NAMESPACE).
+    #[serde(default)]
+    pub namespace: Option<String>,
+    /// start / stop / set_autostart: the production class, e.g. "MyPkg.MyProduction".
+    /// `production_name` and `name` are accepted as spellings of this same field.
+    #[serde(default)]
+    pub production: Option<String>,
+    /// restart: the config item to recycle. `component` is accepted for this field too.
+    #[serde(default)]
+    pub item: Option<String>,
+    /// status: include per-item detail rather than the production summary alone.
+    #[serde(default)]
+    pub full: Option<bool>,
+    /// start / stop / update: seconds to wait for the operation (default 30).
+    #[serde(default)]
+    pub timeout: Option<u32>,
+    /// start / stop / update: force the operation past a busy or troubled state.
+    #[serde(default)]
+    pub force: Option<bool>,
+    /// set_autostart: whether this namespace should autostart the production.
+    #[serde(default)]
+    pub enabled: Option<bool>,
+}
+
+/// The `action` discriminator, as a schema `enum` so a model picks rather than guesses.
+///
+/// The `JsonSchema` impl is hand-written for one reason: a derived enum is emitted as
+/// `{"$ref": "#/$defs/ProductionAction"}`, and an MCP client that does not resolve `$ref`
+/// sees a property with no enum at all — which is #112 again, one level down.
+/// `inline_schema()` is what keeps the advertised inputSchema self-contained.
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "snake_case")]
+#[allow(dead_code)]
+pub enum ProductionAction {
+    Status,
+    Start,
+    Stop,
+    Restart,
+    Update,
+    Check,
+    Recover,
+    GetAutostart,
+    SetAutostart,
+}
+
+impl JsonSchema for ProductionAction {
+    fn schema_name() -> std::borrow::Cow<'static, str> {
+        "ProductionAction".into()
+    }
+    fn json_schema(_gen: &mut schemars::SchemaGenerator) -> schemars::Schema {
+        schemars::json_schema!({"type": "string", "enum": [
+            "status", "start", "stop", "restart", "update",
+            "check", "recover", "get_autostart", "set_autostart"
+        ]})
+    }
+    fn inline_schema() -> bool {
+        true
+    }
+}
+
+// #112: the advertised shape of `iris_interop_query`. All 22 MISSING_WHAT errors in the
+// campaign were calls of exactly `{}` — with `what` declared and required there is nothing
+// left to omit. Schema only, for the same reason as ProductionDispatchSchema: the five
+// `what` values take different subsets. `//` not `///` — see the note there.
+#[derive(Debug, Deserialize, JsonSchema)]
+#[allow(dead_code)]
+pub struct InteropQueryDispatchSchema {
+    /// REQUIRED. logs=Ens_Util.Log entries, queues=message queue depths,
+    /// messages=the Ens.MessageHeader archive (optionally searching message CONTENT),
+    /// trace=one whole session by session_id, partners=Ens.Config.BusinessPartner rows.
+    pub what: InteropQueryWhat,
+    /// Interop-enabled namespace. Omit to use the connection namespace (IRIS_NAMESPACE).
+    #[serde(default)]
+    pub namespace: Option<String>,
+    /// logs: narrow to one config item. (`component` is this field's name on the wire.)
+    #[serde(default)]
+    pub component: Option<String>,
+    /// logs: comma-separated severities to include. Default "error,warning".
+    #[serde(default)]
+    pub log_type: Option<String>,
+    /// logs / messages / trace: narrow to one session. REQUIRED for what=trace.
+    #[serde(default)]
+    pub session_id: Option<i64>,
+    /// logs / messages: return only rows after this id — tails without a MAX(ID) round trip.
+    #[serde(default)]
+    pub since_id: Option<i64>,
+    /// logs / messages: row cap (default 50).
+    #[serde(default)]
+    pub limit: Option<u32>,
+    /// messages: narrow to messages sent by this config item.
+    #[serde(default)]
+    pub source: Option<String>,
+    /// messages: narrow to messages sent to this config item.
+    #[serde(default)]
+    pub target: Option<String>,
+    /// messages: narrow to one message class.
+    #[serde(default)]
+    pub message_class: Option<String>,
+    /// messages: join the body table of this message class server-side, so a WHERE can run
+    /// against message CONTENT. The SQL table name is resolved for you.
+    #[serde(default)]
+    pub body_class: Option<String>,
+    /// messages: SQL fragment applied to the body table named by body_class.
+    #[serde(default)]
+    pub body_where: Option<String>,
+    /// messages: body columns to return alongside the header.
+    #[serde(default)]
+    pub body_select: Option<Vec<String>>,
+    /// messages: search an indexed Search Table field instead of the body table —
+    /// {prop, value | value_like, class?, extent?}. extent defaults to
+    /// EnsLib.HL7.SearchTable; an error lists the searchable props.
+    #[serde(default)]
+    pub search_table: Option<serde_json::Value>,
+}
+
+/// The `what` discriminator, as a schema `enum`. Hand-written for the same reason as
+/// [`ProductionAction`] — it must inline rather than `$ref`.
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "snake_case")]
+#[allow(dead_code)]
+pub enum InteropQueryWhat {
+    Logs,
+    Queues,
+    Messages,
+    Trace,
+    Partners,
+}
+
+impl JsonSchema for InteropQueryWhat {
+    fn schema_name() -> std::borrow::Cow<'static, str> {
+        "InteropQueryWhat".into()
+    }
+    fn json_schema(_gen: &mut schemars::SchemaGenerator) -> schemars::Schema {
+        schemars::json_schema!({"type": "string", "enum": [
+            "logs", "queues", "messages", "trace", "partners"
+        ]})
+    }
+    fn inline_schema() -> bool {
+        true
+    }
+}
+
+/// Free-form JSON to the handler, `S`'s real schema on the wire.
+///
+/// #112: ten interop tools took [`AnyParams`], so `tools/list` advertised
+/// `{"type":"object"}` for each — no properties, no `required`. A model had nothing to
+/// work from but the prose description, and `{}` was a schema-valid call. Measured over a
+/// 1121-call OpenCode campaign: the 11 schema-less tools took 31 parameter errors in 223
+/// calls (13.9%), the 12 tools with real schemas took **zero** in 898. All 22
+/// `MISSING_WHAT` calls sent exactly `{}`, across 8 runs.
+///
+/// The handlers already had the answer: each one builds a typed `…Params` struct that
+/// derives `JsonSchema` and carries doc comments. The schema existed; the tool signature
+/// simply did not point at it. This wrapper publishes `S`'s schema while still handing the
+/// handler the raw `Value` it destructures today — so nothing about dispatch, defaults or
+/// the permissive per-action shapes changes. A field the schema does not name is still
+/// accepted, which is what keeps the dispatchers' unions working.
+pub struct Described<S>(pub serde_json::Value, std::marker::PhantomData<S>);
+
+impl<S> Described<S> {
+    /// Wrap a raw object — for tests and any caller driving a handler directly.
+    pub fn new(value: serde_json::Value) -> Self {
+        Described(value, std::marker::PhantomData)
+    }
+}
+
+impl<S> std::fmt::Debug for Described<S> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        std::fmt::Debug::fmt(&self.0, f)
+    }
+}
+
+impl<S> std::ops::Deref for Described<S> {
+    type Target = serde_json::Value;
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
+
+impl<'de, S> Deserialize<'de> for Described<S> {
+    fn deserialize<D: serde::Deserializer<'de>>(d: D) -> Result<Self, D::Error> {
+        // Deliberately infallible over any JSON object: the schema advertises the shape,
+        // the handler validates it and answers with a message that names the valid values.
+        // Deserialising strictly here would replace MISSING_WHAT ("one of logs, queues,
+        // messages, trace, partners") with rmcp's generic "missing field `what`".
+        serde_json::Value::deserialize(d).map(|v| Described(v, std::marker::PhantomData))
+    }
+}
+
+impl<S: JsonSchema> JsonSchema for Described<S> {
+    fn schema_name() -> std::borrow::Cow<'static, str> {
+        S::schema_name()
+    }
+    fn schema_id() -> std::borrow::Cow<'static, str> {
+        S::schema_id()
+    }
+    fn json_schema(generator: &mut schemars::SchemaGenerator) -> schemars::Schema {
+        S::json_schema(generator)
+    }
+    fn inline_schema() -> bool {
+        // The advertised inputSchema must be self-contained — a `$ref` into `$defs` is not
+        // something every MCP client resolves.
+        true
+    }
+}
 pub mod admin;
 pub mod concurrency;
 pub mod dict;
@@ -1144,20 +1365,20 @@ pub struct NoParams {}
 pub struct GetLogParams {
     /// The log_id a previous truncated:true result returned. If omitted (and `log_id` is
     /// omitted too), lists the stored entries. `log_id` is the SAME parameter, declared
-    /// separately so strict clients can emit it (issue #82); pass either one, or the same
-    /// value in both. A number is read as its decimal string (issue #81).
+    /// separately so strict clients can emit it; pass either one, or the same
+    /// value in both. A number is read as its decimal string.
     pub id: Option<String>,
     /// Identical to `id` — the name every truncating tool emits in its `log_id` field
-    /// (issue #78). Pass either; passing both with DIFFERENT values is an error.
+    /// Pass either; passing both with DIFFERENT values is an error.
     pub log_id: Option<String>,
     /// Max entries to return. Must be > 0 if provided. Paginates BOTH forms: the stored
-    /// result when an id is given, and the index listing when it is not (issue #83).
+    /// result when an id is given, and the index listing when it is not.
     // The runtime rejects 0 with INVALID_PARAMS, so the schema has to reject it too:
     // `usize` alone advertises `minimum: 0`, and a client that validates against the
     // published schema then believes 0 is legal and only learns otherwise from an error.
     #[schemars(range(min = 1))]
     pub limit: Option<usize>,
-    /// Start index. Default 0. Paginates both forms (issue #83).
+    /// Start index. Default 0. Paginates both forms.
     // Advertised as nullable even though it is read as a plain `usize`, because that is
     // the whole point of #82: a strict function-calling client puts EVERY declared
     // property in `required` and sends `null` for the ones it is not using. `offset` was
@@ -1169,16 +1390,16 @@ pub struct GetLogParams {
     #[serde(default)]
     #[schemars(with = "Option<usize>")]
     pub offset: usize,
-    /// Issue #78: every key serde did not recognise. Captured rather than dropped so a
-    /// mistyped addressing key (`logid`) can be NAMED instead of silently falling through
-    /// to the index listing, which is a different response shape. Not a caller-facing
-    /// parameter: schemars emits no property for a flattened map, only
-    /// `additionalProperties: true` (which `drop_default_additional_properties` removes
-    /// again on the wire).
+    // Issue #78: every key serde did not recognise. Captured rather than dropped so a
+    // mistyped addressing key (`logid`) can be NAMED instead of silently falling through
+    // to the index listing, which is a different response shape. Not a caller-facing
+    // parameter: schemars emits no property for a flattened map, only
+    // `additionalProperties: true` (which `drop_default_additional_properties` removes
+    // again on the wire).
     #[serde(flatten)]
     pub extra: serde_json::Map<String, serde_json::Value>,
-    /// Issue #81: what the deserializer coerced or could not use. Never a wire parameter —
-    /// `Deserialize` fills it, `get_log_impl` decides error vs warning.
+    // Issue #81: what the deserializer coerced or could not use. Never a wire parameter —
+    // `Deserialize` fills it, `get_log_impl` decides error vs warning.
     #[serde(skip)]
     #[schemars(skip)]
     pub issues: Vec<GetLogIssue>,
@@ -6093,7 +6314,7 @@ Methods:
     )]
     async fn iris_production(
         &self,
-        Parameters(p): Parameters<AnyParams>,
+        Parameters(p): Parameters<Described<ProductionDispatchSchema>>,
     ) -> Result<CallToolResult, McpError> {
         let action = p.get("action").and_then(|v| v.as_str()).unwrap_or("status");
         let _iris_arc_hold = self.iris_arc();
@@ -6216,7 +6437,7 @@ Methods:
     )]
     async fn iris_interop_query(
         &self,
-        Parameters(p): Parameters<AnyParams>,
+        Parameters(p): Parameters<Described<InteropQueryDispatchSchema>>,
     ) -> Result<CallToolResult, McpError> {
         // B9: `what` is required-with-enum — fail fast with the valid set instead of silently
         // defaulting (the workshop's missing-discriminator calls otherwise misfired).
@@ -6428,7 +6649,7 @@ Methods:
     )]
     async fn iris_production_item(
         &self,
-        Parameters(p): Parameters<AnyParams>,
+        Parameters(p): Parameters<Described<interop::ProductionItemParams>>,
     ) -> Result<CallToolResult, McpError> {
         let action = p
             .get("action")
@@ -6504,7 +6725,7 @@ Methods:
     )]
     async fn iris_message_body(
         &self,
-        Parameters(p): Parameters<AnyParams>,
+        Parameters(p): Parameters<Described<interop::MessageBodyParams>>,
     ) -> Result<CallToolResult, McpError> {
         let _iris_arc_hold = self.iris_arc();
         let iris_opt = _iris_arc_hold.as_deref();
@@ -6551,7 +6772,7 @@ Methods:
     )]
     async fn iris_business_rule_info(
         &self,
-        Parameters(p): Parameters<AnyParams>,
+        Parameters(p): Parameters<Described<interop::BusinessRuleInfoParams>>,
     ) -> Result<CallToolResult, McpError> {
         let _iris_arc_hold = self.iris_arc();
         let iris_opt = _iris_arc_hold.as_deref();
@@ -6588,7 +6809,7 @@ Methods:
     )]
     async fn iris_production_diff(
         &self,
-        Parameters(p): Parameters<AnyParams>,
+        Parameters(p): Parameters<Described<interop::ProductionDiffParams>>,
     ) -> Result<CallToolResult, McpError> {
         let _iris_arc_hold = self.iris_arc();
         let iris_opt = _iris_arc_hold.as_deref();
@@ -6622,7 +6843,7 @@ Methods:
     )]
     async fn iris_credential_list(
         &self,
-        Parameters(p): Parameters<AnyParams>,
+        Parameters(p): Parameters<Described<interop::CredentialListParams>>,
     ) -> Result<CallToolResult, McpError> {
         let _iris_arc_hold = self.iris_arc();
         let namespace = interop::resolve_namespace(
@@ -6649,7 +6870,7 @@ Methods:
     )]
     async fn iris_credential_manage(
         &self,
-        Parameters(p): Parameters<AnyParams>,
+        Parameters(p): Parameters<Described<interop::CredentialManageParams>>,
     ) -> Result<CallToolResult, McpError> {
         let _iris_arc_hold = self.iris_arc();
         let namespace = interop::resolve_namespace(
@@ -6698,7 +6919,7 @@ Methods:
     )]
     async fn iris_lookup_manage(
         &self,
-        Parameters(p): Parameters<AnyParams>,
+        Parameters(p): Parameters<Described<interop::LookupManageParams>>,
     ) -> Result<CallToolResult, McpError> {
         let _iris_arc_hold = self.iris_arc();
         let namespace = interop::resolve_namespace(
@@ -6741,7 +6962,7 @@ Methods:
     )]
     async fn iris_lookup_transfer(
         &self,
-        Parameters(p): Parameters<AnyParams>,
+        Parameters(p): Parameters<Described<interop::LookupTransferParams>>,
     ) -> Result<CallToolResult, McpError> {
         let _iris_arc_hold = self.iris_arc();
         let namespace = interop::resolve_namespace(
@@ -12028,7 +12249,7 @@ mod http_status_answer_tests {
         rt().block_on(async {
             let server = server_with("POST", r".*/action/query$", ResponseTemplate::new(404)).await;
             let r = tools_for(&server)
-                .iris_production(Parameters(AnyParams(
+                .iris_production(Parameters(Described::new(
                     serde_json::json!({"action": "status", "namespace": "ZZNOSUCHNS"}),
                 )))
                 .await

--- a/crates/iris-agentic-dev-core/tests/mcp_handshake.rs
+++ b/crates/iris-agentic-dev-core/tests/mcp_handshake.rs
@@ -9,6 +9,42 @@ use std::io::{BufRead, BufReader, Write};
 use std::process::{Command, Stdio};
 use std::time::{Duration, Instant};
 
+/// `#` followed by one or more digits — an issue reference. Hand-rolled so this test
+/// pulls in no new dependency.
+struct IssueRef;
+impl IssueRef {
+    fn find_iter<'a>(&self, hay: &'a str) -> impl Iterator<Item = IssueMatch<'a>> {
+        let bytes: Vec<(usize, char)> = hay.char_indices().collect();
+        let mut out = vec![];
+        for (i, (pos, c)) in bytes.iter().enumerate() {
+            if *c != '#' {
+                continue;
+            }
+            let mut end = *pos + 1;
+            let mut n = 0;
+            for (p2, c2) in bytes.iter().skip(i + 1) {
+                if c2.is_ascii_digit() {
+                    end = p2 + c2.len_utf8();
+                    n += 1;
+                } else {
+                    break;
+                }
+            }
+            if n > 0 {
+                out.push(IssueMatch(&hay[*pos..end]));
+            }
+        }
+        out.into_iter()
+    }
+}
+struct IssueMatch<'a>(&'a str);
+impl<'a> IssueMatch<'a> {
+    fn as_str(&self) -> &'a str {
+        self.0
+    }
+}
+const ISSUE_REF: IssueRef = IssueRef;
+
 fn iris_dev_bin() -> std::path::PathBuf {
     // Find the binary in the cargo target directory
     let mut path = std::path::PathBuf::from(env!("CARGO_MANIFEST_DIR"));
@@ -92,6 +128,107 @@ fn mcp_server_starts_and_responds_to_initialize() {
         "initialize response missing 'result': {}",
         response
     );
+
+    child.kill().ok();
+}
+
+/// #112: every tool that takes parameters must SAY SO in its advertised schema.
+///
+/// Ten of the 23 interop tools shipped `{"type":"object"}` — no properties, no `required` —
+/// because their handler signature was `Parameters<AnyParams>`. A model had nothing to work
+/// from but the tool description, and `{}` was a schema-valid call. Measured over a
+/// 1121-call OpenCode campaign: 31 parameter errors in 223 calls to those tools (13.9%),
+/// and ZERO in 898 calls to the twelve that had real schemas. All 22 `MISSING_WHAT` errors
+/// were calls of exactly `{}`.
+///
+/// This asserts at the wire, over the whole profile, so a new tool cannot quietly join the
+/// schema-less group.
+#[test]
+fn every_tool_advertises_the_parameters_it_reads() {
+    let bin = iris_dev_bin();
+    if !bin.exists() {
+        eprintln!("Skipping: iris-agentic-dev binary not found");
+        return;
+    }
+
+    let mut child = Command::new(&bin)
+        .arg("mcp")
+        .env("IRIS_WEB_PORT", "9")
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::null())
+        .spawn()
+        .expect("failed to spawn iris-agentic-dev mcp");
+
+    let mut stdin = child.stdin.take().unwrap();
+    let stdout = child.stdout.take().unwrap();
+    let mut reader = BufReader::new(stdout);
+    send_jsonrpc(
+        &mut stdin,
+        1,
+        "initialize",
+        r#"{"protocolVersion":"2024-11-05","capabilities":{},"clientInfo":{"name":"test","version":"0.1"}}"#,
+    );
+    let _ = read_jsonrpc(&mut reader);
+    stdin
+        .write_all(
+            b"{\"jsonrpc\":\"2.0\",\"method\":\"notifications/initialized\",\"params\":{}}\n",
+        )
+        .unwrap();
+    stdin.flush().unwrap();
+    std::thread::sleep(std::time::Duration::from_millis(50));
+    send_jsonrpc(&mut stdin, 2, "tools/list", "{}");
+    let response = read_jsonrpc(&mut reader);
+    let tools = response["result"]["tools"].as_array().unwrap();
+
+    // The ONLY tool that legitimately advertises no properties is the one that reads none.
+    // Adding a name here is a claim that the tool takes no parameters at all — check the
+    // handler before you do.
+    const TAKES_NO_PARAMETERS: &[&str] = &["check_config"];
+
+    for tool in tools {
+        let name = tool["name"].as_str().unwrap_or("?");
+        let schema = &tool["inputSchema"];
+        let props = schema.get("properties").and_then(|p| p.as_object());
+        if TAKES_NO_PARAMETERS.contains(&name) {
+            continue;
+        }
+        let props = props.unwrap_or_else(|| {
+            panic!(
+                "tool '{name}' advertises no properties. A caller — human or model — has \
+                 only the prose description to guess parameter names from, and `{{}}` is a \
+                 schema-valid call. Give the handler a typed params struct (or wrap the \
+                 existing one in `Described<…>`): {schema}"
+            )
+        });
+        assert!(
+            !props.is_empty(),
+            "tool '{name}' advertises an EMPTY properties map: {schema}"
+        );
+
+        // A dispatcher's discriminator must be required AND enumerated. Naming the field
+        // without its values only moves the guess one level down — which is what the nine
+        // INVALID_ACTION errors in the campaign were.
+        for key in ["action", "what"] {
+            let Some(prop) = props.get(key) else { continue };
+            let required: Vec<&str> = schema["required"]
+                .as_array()
+                .map(|a| a.iter().filter_map(|v| v.as_str()).collect())
+                .unwrap_or_default();
+            assert!(
+                required.contains(&key),
+                "tool '{name}' has a '{key}' discriminator that is not in `required` — a \
+                 model may legitimately omit it and will: {schema}"
+            );
+            assert!(
+                prop.get("enum")
+                    .and_then(|e| e.as_array())
+                    .is_some_and(|e| !e.is_empty()),
+                "tool '{name}' declares '{key}' without its valid values. The runtime error \
+                 names them correctly; it just arrives a round trip late: {prop}"
+            );
+        }
+    }
 
     child.kill().ok();
 }
@@ -333,6 +470,21 @@ fn mcp_server_tools_list_returns_interop_profile() {
                  Keep the rationale in the source as a `//` comment: {schema}"
             );
         }
+        // #112, a third route for the same leak, and the one the jargon list above could
+        // not see: an ISSUE NUMBER. `#82` shipped its own rationale — `iris_get_log`
+        // advertised "(issue #82)", "(issue #81)", "(issue #78)" and "(issue #83)" in its
+        // property descriptions for as long as that fix has existed, because none of those
+        // strings is Rust syntax. No caller-facing sentence needs a tracker reference:
+        // the reader of a tools/list cannot open the issue and does not want to. This is a
+        // precise marker — `#` followed by digits — not a substring match on prose.
+        let issue_refs: Vec<&str> = ISSUE_REF.find_iter(&schema).map(|m| m.as_str()).collect();
+        assert!(
+            issue_refs.is_empty(),
+            "tool '{name}' ships issue references {issue_refs:?} in its advertised \
+             inputSchema — maintainer bookkeeping, sent to every client on every \
+             tools/list. Keep it in the source as a `//` comment: {schema}"
+        );
+
         // The same leak by another route: schemars puts the params STRUCT NAME in the
         // schema's top-level `title` (`GetLogParams`, `CompileParams`, …). It names
         // nothing the caller can act on — the tool already has a `name` — and it went out


### PR DESCRIPTION
Ten of the 23 interop tools shipped `inputSchema: {"type":"object"}` — no properties, no `required` — because their handler signature was `Parameters<AnyParams>`, a newtype over `serde_json::Value` with a hand-written `JsonSchema`. A model had nothing but the prose description, and `{}` was a schema-valid call.

**The correlation from the campaign is total:**

| | calls | parameter errors |
|---|---|---|
| 11 schema-less tools | 223 | **31 (13.9%)** |
| 12 typed tools | 898 | **0 (0.0%)** |

All 22 `MISSING_WHAT` errors were calls of **exactly `{}`**, across 8 runs.

## The fix was smaller than the issue assumed

The handlers already had the answer: each builds a typed `…Params` struct that derives `JsonSchema` and carries doc comments. The schema existed — the tool signature just never pointed at it.

`Described<S>` publishes `S`'s schema while handing the handler the raw `Value` it destructures today. Dispatch, defaults and the permissive per-action shapes are untouched, and a field the schema does not name is still accepted — which is what keeps the dispatcher unions working. Eight tools point at their existing struct; `iris_production` (9 actions) and `iris_interop_query` (5) get purpose-built union schemas.

Deserialisation stays deliberately infallible. A strict struct would replace `MISSING_WHAT` — *"one of logs, queues, messages, trace, partners"* — with rmcp's generic `missing field 'what'`. Verified live: `iris_interop_query {}` still answers `MISSING_WHAT`.

## Discriminators carry their values now

```
iris_production        action = status|start|stop|restart|update|check|recover|get_autostart|set_autostart
iris_interop_query     what   = logs|queues|messages|trace|partners
iris_production_item   action = add|remove|enable|disable|get_settings|set_settings
iris_lookup_manage     action = get|set|delete|list_keys|list_tables
iris_credential_manage action = create|update|delete
iris_lookup_transfer   action = export|import
iris_business_rule_info action = list|get
iris_debug             action = map_int|error_logs|capture|source_map
```

Naming the field without its values only moves the guess one level down — that was 9 of the 31 errors. The runtime `INVALID_ACTION` message names them correctly; it just arrives a round trip late.

**Self-contained, checked:** the two discriminator enums have hand-written `JsonSchema` impls with `inline_schema() = true`. A derived enum emits `{"$ref": "#/$defs/…"}`, and a client that does not resolve `$ref` sees a property with no enum at all — #112 again, one level down. **No `$ref` or `$defs` appears anywhere in the advertised surface.**

## Two things the new test caught that I wasn't looking for

- **`iris_debug`** — the tool I cited in the issue as the well-described dispatcher — listed its four actions in the description prose only. Its schema said "any string".
- **#82's own fix shipped its rationale.** `iris_get_log` has advertised `"(issue #82)"`, `"(issue #81)"`, `"(issue #78)"` and `"(issue #83)"` in property descriptions for as long as that fix has existed — no issue reference is Rust syntax, so the jargon list could not see it. `mcp_handshake` now rejects `#<digits>` in any advertised schema.

Both are fixed here.

## Verification

- **Gate: 1116 passed / 0 failed / 46 ignored** on rust 1.98 (the CI toolchain), clippy and fmt clean.
- `every_tool_advertises_the_parameters_it_reads` asserts at the wire over the whole profile: no bare `{"type":"object"}` outside a by-name allowlist (`check_config`, which genuinely reads no parameters), and every `action`/`what` property must be in `required` **and** carry a non-empty `enum`. It failed on `iris_debug` the first time it ran.
- The issue-reference guard was **verified non-vacuous**: reintroducing `(issue #81)` fails it, removing it passes.
- All 15 affected tools re-smoked live against the dev instance — identical behaviour, zero RPC-level failures.
- Schema payload 18.1KB across 23 tools; the interop keep-list and the 23-tool count are unchanged. This is a schema change, not a surface change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
