### PR TITLE
chore(release): 0.8.5

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -945,7 +945,7 @@ dependencies = [
 
 [[package]]
 name = "iris-agentic-dev"
-version = "0.8.4"
+version = "0.8.5"
 dependencies = [
  "anyhow",
  "chrono",
@@ -963,7 +963,7 @@ dependencies = [
 
 [[package]]
 name = "iris-agentic-dev-core"
-version = "0.8.4"
+version = "0.8.5"
 dependencies = [
  "anyhow",
  "bollard",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "0.8.4"
+version = "0.8.5"
 edition = "2021"
 authors = ["Thomas Dyar <thomas.dyar@intersystems.com>"]
 license = "MIT"


### PR DESCRIPTION
Six commits since `v0.8.4-interop`, all fixes.

| PR | what |
|---|---|
| #111 | toolset pruning + the write gate enforced at **dispatch**, not just in `tools/list` (#104), plus #105–#110 |
| #113 | every tool advertises the parameters it reads (#112) |
| #115 | the write gate covers all seven write-capable tools and gates **mutations**, never reads (#114) |
| #121 | the production a caller names is the one opened (#118, #119), and a class name resolves to its SQL table (#120) |

`serverInfo` and `--version` both report `0.8.5`.

## Verified on the release binary, against live IRIS

```
serverInfo                                  {"name":"iris-interop-dev","version":"0.8.5"}
tools/list                                  23 tools; only check_config is schema-less
iris_search under interop                   TOOL_NOT_IN_TOOLSET                    (#104)
iris_interop_query {}                       MISSING_WHAT, not a deserialize error  (#112)
docs_introspect Ens.Util.LogXX              CLASS_NOT_FOUND + did_you_mean         (#107)
iris_execute on a dev connection            ok -> 42                               (#114)
iris_production_item get_settings           opens a STOPPED production by name     (#119)
  on APPPKG.FoundationProduction            -> ITEM_NOT_FOUND, not "Cannot open production"
iris_production_item, nothing running       NO_PRODUCTION, not INTEROP_ERROR       (#118)
iris_production set_autostart, no name      NO_PRODUCTION; autostart left untouched (#118)
iris_table_info EnsLib.HL7.Message          resolves to EnsLib_HL7.Message + note  (#120)
iris_table_info Ens.Rule.Definition         did_you_mean the five real Ens_Rule.*  (#120)
```

Gate: **1121 passed / 0 failed / 46 ignored** on rust 1.98, the toolchain CI uses. fmt and clippy clean.
`e2e-tests` (master-only, skipped by the `pull_request` event) dispatched explicitly on this branch.

## Pinned build staged

A codesigned copy is at `/opt/iist-mcp-bin/iris-interop-dev-0.8.5` for the eval harness:

```yaml
path:           /opt/iist-mcp-bin/iris-interop-dev-0.8.5
version_string: iris-interop-dev 0.8.5
sha256:         0ea40429904fed666df16b9eb0adadd48809bb8da100620f01f1adba4e865197
size:           68863552
built_from:     2619f495ac704c3e45f8a2d78ce0b7a851f4933c
```

The 0.8.4 pin an eval battery is currently running against is untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
