### PR TITLE
fix(#118,#119,#120): open the production the caller named, and resolve a class name to its table

### DIFF
--- a/crates/iris-agentic-dev-core/src/tools/info.rs
+++ b/crates/iris-agentic-dev-core/src/tools/info.rs
@@ -550,7 +550,9 @@ pub async fn handle_iris_generate(
 
 #[derive(Debug, serde::Deserialize, schemars::JsonSchema)]
 pub struct TableInfoParams {
-    /// SQL table name in Schema.Table format (e.g. "SQLUser.MyTable" or "MyApp.Orders").
+    /// SQL table in Schema.Table form ("SQLUser.MyTable", "Ens_Config.Item") — or the CLASS name
+    /// ("Ens.Config.Item"), which is resolved for you: IRIS projects class `A.B.C.Name` onto
+    /// schema `A_B_C`, table `Name`. A miss names the tables that do exist in that package.
     pub table: String,
     /// IRIS namespace to query. Defaults to the connection namespace (IRIS_NAMESPACE).
     #[serde(default)]
@@ -560,25 +562,135 @@ pub struct TableInfoParams {
     pub include_row_count: bool,
 }
 
+/// Every `(schema, table)` pair worth trying for one caller-supplied name, best first (#120).
+///
+/// `iris_table_info` used to accept the exact SQL table name and nothing else, so handing it the
+/// CLASS name — which is what a caller actually has, and what every other tool here takes —
+/// returned a bare `TABLE_NOT_FOUND`. Agents then brute-forced the separator, three and four
+/// calls at a time, while the success payload was already reporting `class` back to them.
+///
+/// IRIS projects class `A.B.C.Name` onto SQL schema `A_B_C`, table `Name`. That mapping is
+/// mechanical, so it is applied here rather than left to the caller:
+///
+/// * as given — split at the FIRST dot, `SQLUser` when there is none. Unchanged, so a name that
+///   resolved before still resolves first and no existing call changes meaning.
+/// * two dots or more — split at the LAST dot and underscore the schema
+///   (`EnsLib.HL7.Message` → `EnsLib_HL7` / `Message`).
+/// * no dot but underscores — split at the LAST underscore
+///   (`Admissions_MSG_AdmitNoticeReq` → `Admissions_MSG` / `AdmitNoticeReq`).
+pub fn sql_table_candidates(input: &str) -> Vec<(String, String)> {
+    let name = input.trim();
+    let mut out: Vec<(String, String)> = Vec::new();
+    let mut push = |schema: String, table: String| {
+        if !table.is_empty() && !out.iter().any(|(s, t)| *s == schema && *t == table) {
+            out.push((schema, table));
+        }
+    };
+
+    match name.find('.') {
+        Some(idx) => push(name[..idx].to_string(), name[idx + 1..].to_string()),
+        None => push("SQLUser".to_string(), name.to_string()),
+    }
+
+    if name.matches('.').count() >= 2 {
+        if let Some(idx) = name.rfind('.') {
+            push(name[..idx].replace('.', "_"), name[idx + 1..].to_string());
+        }
+    }
+
+    if !name.contains('.') {
+        if let Some(idx) = name.rfind('_') {
+            push(name[..idx].to_string(), name[idx + 1..].to_string());
+        }
+    }
+
+    out
+}
+
+/// Order and filter the tables offered back as `did_you_mean` (#120).
+///
+/// `pkg` are tables in the package the caller's name points at ("what does exist in `Ens_Rule`?");
+/// `near` are tables anywhere whose name starts the same way ("this table, in another schema?").
+/// Package hits rank first because they answer the more useful question.
+///
+/// A suggestion sharing nothing with the request is worse than no suggestion. The first cut of
+/// this offered `%DeepSee_Dashboard.Definition` for `Ens.Rule.Definition` and told the caller to
+/// pass it — so a candidate must share the request's leading segment, and a `%`-schema table is
+/// only ever offered to a caller who asked for one.
+pub fn rank_table_suggestions(requested: &str, pkg: Vec<String>, near: Vec<String>) -> Vec<String> {
+    let wants_system = requested.starts_with('%');
+    let lead = requested
+        .split(['.', '_'])
+        .next()
+        .unwrap_or("")
+        .to_ascii_lowercase();
+    let plausible = |cand: &String| {
+        if cand.starts_with('%') && !wants_system {
+            return false;
+        }
+        lead.is_empty() || cand.to_ascii_lowercase().starts_with(&lead)
+    };
+    let mut out: Vec<String> = Vec::new();
+    for cand in pkg.into_iter().chain(near) {
+        if plausible(&cand) && !out.contains(&cand) {
+            out.push(cand);
+        }
+    }
+    out.truncate(5);
+    out
+}
+
 pub async fn handle_iris_table_info(
     iris: &crate::iris::connection::IrisConnection,
     client: &reqwest::Client,
     p: TableInfoParams,
 ) -> Result<rmcp::model::CallToolResult, rmcp::ErrorData> {
     let namespace = crate::tools::interop::resolve_namespace(p.namespace.as_deref(), Some(iris));
-    // Split "Schema.Table" → (schema, table). Tables with no dot use SQLUser schema.
-    let (sql_schema, sql_table) = match p.table.find('.') {
-        Some(idx) => (p.table[..idx].to_string(), p.table[idx + 1..].to_string()),
-        None => ("SQLUser".to_string(), p.table.clone()),
-    };
+    let candidates = sql_table_candidates(&p.table);
+    // Two needles for did_you_mean, because they answer different questions. The most-normalised
+    // candidate's TABLE half ("did you mean this table, in some other schema?") and its SCHEMA
+    // half ("what does exist in this package?"). The second is the more useful of the two:
+    // `Ens.Rule.Definition` has no table anywhere, but `Ens_Rule.*` has five.
+    let (needle_schema, needle_table) = candidates
+        .last()
+        .cloned()
+        .unwrap_or_else(|| (String::new(), p.table.clone()));
+    let (mut sql_schema, mut sql_table) = candidates
+        .first()
+        .cloned()
+        .unwrap_or_else(|| ("SQLUser".to_string(), p.table.clone()));
+
+    let cand_list = candidates
+        .iter()
+        .map(|(s, t)| os_str_expr(&format!("{s}^{t}")))
+        .collect::<Vec<_>>()
+        .join(",");
 
     // Look up class projection: find a compiled class whose SQL mapping matches.
+    // Every candidate is tried inside ONE round trip — resolution must not cost the caller the
+    // extra calls it was meant to save. The `while` condition is fully parenthesised on purpose:
+    // ObjectScript has no operator precedence (see #118).
     let lookup_code = format!(
         r#"
-set sqlSchema = {schema}, sqlTable = {table}
-// Check table exists at all via INFORMATION_SCHEMA
-set rsEx = ##class(%SQL.Statement).%ExecDirect(,"SELECT COUNT(*) FROM INFORMATION_SCHEMA.TABLES WHERE TABLE_SCHEMA = ? AND TABLE_NAME = ?", sqlSchema, sqlTable)
-if rsEx.%Next() && (rsEx.%GetData(1) = 0) {{ write "NOT_FOUND",! quit }}
+set cands = $LISTBUILD({cands})
+set found = "", ci = 0
+while (found = "") && (ci < $LISTLENGTH(cands)) {{
+    set ci = ci + 1
+    set one = $LIST(cands, ci)
+    set cs = $PIECE(one, "^", 1), ct = $PIECE(one, "^", 2)
+    set rsEx = ##class(%SQL.Statement).%ExecDirect(,"SELECT COUNT(*) FROM INFORMATION_SCHEMA.TABLES WHERE TABLE_SCHEMA = ? AND TABLE_NAME = ?", cs, ct)
+    if rsEx.%Next() {{ if (rsEx.%GetData(1) '= 0) {{ set found = one }} }}
+}}
+if found = "" {{
+    set rsP = ##class(%SQL.Statement).%ExecDirect(,"SELECT TOP 5 TABLE_SCHEMA, TABLE_NAME FROM INFORMATION_SCHEMA.TABLES WHERE TABLE_SCHEMA %STARTSWITH ? ORDER BY TABLE_SCHEMA, TABLE_NAME", {needle_schema})
+    while rsP.%Next() {{ write "PKG:",rsP.%GetData(1),".",rsP.%GetData(2),! }}
+    set rsN = ##class(%SQL.Statement).%ExecDirect(,"SELECT TOP 8 TABLE_SCHEMA, TABLE_NAME FROM INFORMATION_SCHEMA.TABLES WHERE TABLE_NAME %STARTSWITH ? ORDER BY TABLE_SCHEMA", {needle_table})
+    while rsN.%Next() {{ write "NEAR:",rsN.%GetData(1),".",rsN.%GetData(2),! }}
+    write "NOT_FOUND",!
+    quit
+}}
+set sqlSchema = $PIECE(found, "^", 1), sqlTable = $PIECE(found, "^", 2)
+write "RESOLVED:",sqlSchema,".",sqlTable,!
 // Look for backing class
 set rs = ##class(%SQL.Statement).%ExecDirect(,"SELECT c.Name, c.ClassType, s.DataLocation, s.IndexLocation, s.IDLocation FROM %Dictionary.CompiledClass c LEFT JOIN %Dictionary.CompiledStorage s ON s.parent = c.Name WHERE c.SqlSchemaName = ? AND c.SqlTableName = ?", sqlSchema, sqlTable)
 if rs.%Next() {{
@@ -591,8 +703,9 @@ if rs.%Next() {{
     write "DDL_TABLE",!
 }}
 "#,
-        schema = os_str_expr(&sql_schema),
-        table = os_str_expr(&sql_table),
+        cands = cand_list,
+        needle_schema = os_str_expr(&needle_schema),
+        needle_table = os_str_expr(&needle_table),
     );
 
     let output = match iris
@@ -627,13 +740,63 @@ if rs.%Next() {{
     let lines: std::collections::HashMap<&str, &str> =
         output.lines().filter_map(|l| l.split_once(':')).collect();
 
-    if output.trim() == "NOT_FOUND" {
+    if output.lines().any(|l| l.trim() == "NOT_FOUND") {
+        // #120: a truthful "not found" that names no alternative is what made callers guess the
+        // separator. Same treatment #107 gave docs_introspect: say what was tried, and name what
+        // actually exists.
+        let collect = |prefix: &str| -> Vec<String> {
+            output
+                .lines()
+                .filter_map(|l| l.strip_prefix(prefix))
+                .map(|l| l.trim().to_string())
+                .filter(|l| !l.is_empty())
+                .collect()
+        };
+        let did_you_mean = rank_table_suggestions(&p.table, collect("PKG:"), collect("NEAR:"));
+        let tried: Vec<String> = candidates
+            .iter()
+            .map(|(sc, tb)| format!("{sc}.{tb}"))
+            .collect();
+        let mut extra = serde_json::json!({
+            "table": p.table,
+            "namespace": namespace,
+            "tried": tried,
+        });
+        if !did_you_mean.is_empty() {
+            extra["did_you_mean"] = did_you_mean.clone().into();
+            extra["hint"] = format!(
+                "No such table. IRIS projects class 'A.B.C.Name' onto SQL schema 'A_B_C', table \
+                 'Name' — pass the SQL name, not the class name. These exist in this namespace: \
+                 {}.",
+                did_you_mean.join(", ")
+            )
+            .into();
+        } else {
+            extra["hint"] = format!(
+                "No such table in namespace '{namespace}'. IRIS projects class 'A.B.C.Name' onto \
+                 SQL schema 'A_B_C', table 'Name'. Check the namespace, or call \
+                 iris_symbols/docs_introspect to confirm the class exists and is %Persistent."
+            )
+            .into();
+        }
         return crate::tools::envelope::fail_with(
             "TABLE_NOT_FOUND",
             &format!("Table '{}' not found in namespace '{}'", p.table, namespace),
-            serde_json::json!({"table": p.table, "namespace": namespace}),
+            extra,
         );
     }
+
+    // Which candidate actually resolved. Everything downstream — the row count, the DDL global
+    // names — must use the resolved pair, not what the caller typed.
+    let requested = format!("{sql_schema}.{sql_table}");
+    if let Some(resolved) = lines.get("RESOLVED").map(|v| v.trim()) {
+        if let Some(idx) = resolved.rfind('.') {
+            sql_schema = resolved[..idx].to_string();
+            sql_table = resolved[idx + 1..].to_string();
+        }
+    }
+    let resolved_table = format!("{sql_schema}.{sql_table}");
+    let renamed = resolved_table != requested;
 
     let result = if lines.contains_key("CLASS") {
         // Class-projected table
@@ -642,7 +805,7 @@ if rs.%Next() {{
         let index_global = lines.get("INDEX").copied().unwrap_or("").trim();
 
         let mut obj = serde_json::json!({
-            "table": p.table,
+            "table": resolved_table,
             "type": "class_projection",
             "class": class_name,
             "namespace": namespace,
@@ -663,7 +826,7 @@ if rs.%Next() {{
         let id_counter_global = format!("^{}.{}C", sql_schema, sql_table);
 
         let mut obj = serde_json::json!({
-            "table": p.table,
+            "table": resolved_table,
             "type": "ddl_table",
             "namespace": namespace,
             "data_global": data_global,
@@ -679,10 +842,20 @@ if rs.%Next() {{
         obj
     };
 
-    crate::tools::ok_json(serde_json::json!({
+    let mut payload = serde_json::json!({
         "success": true,
         "result": result,
-    }))
+    });
+    if renamed {
+        // Say so rather than silently answering about a different name than the one asked for.
+        payload["requested"] = p.table.clone().into();
+        payload["note"] = format!(
+            "'{}' is a class name; it resolves to SQL table '{}'.",
+            p.table, resolved_table
+        )
+        .into();
+    }
+    crate::tools::ok_json(payload)
 }
 
 async fn get_row_count(
@@ -708,5 +881,114 @@ if rs.%Next() {{ write rs.%GetData(1),! }} else {{ write "error",! }}"#,
             .map(serde_json::Value::from)
             .unwrap_or(serde_json::Value::Null),
         Err(_) => serde_json::Value::Null,
+    }
+}
+
+#[cfg(test)]
+mod table_candidate_tests {
+    use super::sql_table_candidates;
+
+    fn tried(input: &str) -> Vec<String> {
+        sql_table_candidates(input)
+            .into_iter()
+            .map(|(s, t)| format!("{s}.{t}"))
+            .collect()
+    }
+
+    /// The exact corpus failure: 37 `TABLE_NOT_FOUND`s, agents guessing separators.
+    #[test]
+    fn a_class_name_yields_the_projected_table() {
+        assert!(tried("EnsLib.HL7.Message").contains(&"EnsLib_HL7.Message".to_string()));
+        assert!(tried("Admissions.MSG.AdmitNoticeReq")
+            .contains(&"Admissions_MSG.AdmitNoticeReq".to_string()));
+    }
+
+    /// `Admissions_MSG_AdmitNoticeReq` was the second guess in the corpus; one underscore short.
+    #[test]
+    fn an_all_underscore_name_splits_at_the_last_underscore() {
+        assert!(tried("Admissions_MSG_AdmitNoticeReq")
+            .contains(&"Admissions_MSG.AdmitNoticeReq".to_string()));
+    }
+
+    /// No regression: whatever resolved before still resolves, and still resolves FIRST.
+    #[test]
+    fn the_exact_sql_name_is_always_tried_first() {
+        assert_eq!(tried("EnsLib_HL7.Message")[0], "EnsLib_HL7.Message");
+        assert_eq!(tried("SQLUser.MyTable")[0], "SQLUser.MyTable");
+        assert_eq!(tried("MyTable")[0], "SQLUser.MyTable");
+        assert_eq!(tried("Billing.LabCharge")[0], "Billing.LabCharge");
+    }
+
+    #[test]
+    fn candidates_are_deduped_and_never_empty_tabled() {
+        for input in ["A.B", "A_B", "A", "A.B.C", "A_B_C", "  Padded.Name  "] {
+            let c = sql_table_candidates(input);
+            assert!(!c.is_empty(), "{input} produced no candidate");
+            assert!(c.iter().all(|(_, t)| !t.is_empty()), "{input} empty table");
+            let mut seen = c.clone();
+            seen.sort();
+            seen.dedup();
+            assert_eq!(seen.len(), c.len(), "{input} produced duplicates");
+        }
+    }
+}
+
+#[cfg(test)]
+mod table_suggestion_tests {
+    use super::rank_table_suggestions;
+
+    fn v(items: &[&str]) -> Vec<String> {
+        items.iter().map(|s| s.to_string()).collect()
+    }
+
+    /// The regression this ranker exists for: the first cut answered `Ens.Rule.Definition` with
+    /// `%DeepSee_Dashboard.Definition` and told the caller to pass it.
+    #[test]
+    fn an_unrelated_system_table_is_never_offered() {
+        let out = rank_table_suggestions(
+            "Ens.Rule.Definition",
+            v(&["Ens_Rule.Assign", "Ens_Rule.Rule"]),
+            v(&["%DeepSee_Dashboard.Definition", "%IPM_Repo.Definition"]),
+        );
+        assert_eq!(out, v(&["Ens_Rule.Assign", "Ens_Rule.Rule"]));
+    }
+
+    #[test]
+    fn nothing_plausible_yields_nothing_rather_than_noise() {
+        let out = rank_table_suggestions(
+            "Totally.Bogus.Name",
+            vec![],
+            v(&["%Dictionary.ClassDefinition", "Ens_Rule.Rule"]),
+        );
+        assert!(out.is_empty(), "{out:?}");
+    }
+
+    /// A caller who asks for a `%` schema is asking for system tables.
+    #[test]
+    fn a_system_request_still_gets_system_answers() {
+        let out = rank_table_suggestions(
+            "%Dictionary.Nope",
+            v(&["%Dictionary.CompiledClass"]),
+            vec![],
+        );
+        assert_eq!(out, v(&["%Dictionary.CompiledClass"]));
+    }
+
+    #[test]
+    fn package_hits_rank_ahead_of_name_hits_and_duplicates_collapse() {
+        let out = rank_table_suggestions(
+            "Ens.Config.Nope",
+            v(&["Ens_Config.Item"]),
+            v(&["Ens_Config.Item", "Ens_Util.Nope"]),
+        );
+        assert_eq!(out, v(&["Ens_Config.Item", "Ens_Util.Nope"]));
+    }
+
+    #[test]
+    fn at_most_five_are_offered() {
+        let many = v(&[
+            "Ens_A.1", "Ens_A.2", "Ens_A.3", "Ens_A.4", "Ens_A.5", "Ens_A.6",
+        ]);
+        assert_eq!(rank_table_suggestions("Ens.A.X", many, vec![]).len(), 5);
     }
 }

--- a/crates/iris-agentic-dev-core/src/tools/interop.rs
+++ b/crates/iris-agentic-dev-core/src/tools/interop.rs
@@ -1428,7 +1428,9 @@ pub struct ProductionItemParams {
     /// add: enable the item on creation (default true).
     #[serde(default)]
     pub enabled: Option<bool>,
-    /// add/remove: target production by name. Defaults to the currently running production.
+    /// Target production by name (e.g. "MyApp.Production"), for every action. Defaults to the
+    /// currently running production. A production does NOT have to be running to be read or
+    /// edited — pass its name and it is opened from disk.
     #[serde(default)]
     pub production: Option<String>,
     /// add: optional PoolSize for the item.
@@ -1437,6 +1439,40 @@ pub struct ProductionItemParams {
     /// add: optional Category for portal grouping.
     #[serde(default)]
     pub category: Option<String>,
+}
+
+/// Strip the `ERROR:INTEROP_ERROR:` sentinel the generated ObjectScript writes so the envelope
+/// does not carry its own error code twice inside the message text (#118/#119: now that these
+/// messages name the production they failed on, the duplication is the only noise left).
+fn interop_error_text(out: &str) -> &str {
+    out.strip_prefix("ERROR:INTEROP_ERROR:")
+        .unwrap_or(out)
+        .trim()
+}
+
+/// The ObjectScript prologue that resolves `tProd`, the production every
+/// `iris_production_item` action operates on (pure → unit-testable).
+///
+/// `production` empty ⇒ fall back to the running production. Emitted by all six actions:
+/// #119 found `get_settings`/`set_settings`/`enable`/`disable` inlining their own copy that
+/// never read `production=` at all, so a stopped production was unreachable and `set_settings`
+/// silently wrote to whatever happened to be running instead. One helper, one behaviour.
+///
+/// The "no production" test is deliberately TWO statements rather than
+/// `If $$$ISERR(tSC)||tProdName=""`. ObjectScript has no operator precedence — it evaluates
+/// strictly left to right — so that one-liner parses as `(($$$ISERR(tSC))||tProdName)=""`,
+/// and since `||` yields 0 or 1 while neither `0=""` nor `1=""` holds, it is ALWAYS FALSE.
+/// #118 shipped that dead guard at three sites; callers fell through to `%OpenId("")` and got
+/// `Cannot open production` where `NO_PRODUCTION` was meant.
+pub fn resolve_production_prologue(production: &str) -> String {
+    format!(
+        r#"Set tProdName={prod}
+If tProdName="" {{ Set tSCr=##class(Ens.Director).GetProductionStatus(.tProdName,.sr) }}
+If tProdName="" {{ Write "ERROR:NO_PRODUCTION:No production running and no production= given" Quit }}
+Set tProd=##class(Ens.Config.Production).%OpenId(tProdName,,.tSC2)
+If '$IsObject(tProd) {{ Write "ERROR:INTEROP_ERROR:Cannot open production "_tProdName Quit }}"#,
+        prod = os_str_expr(production)
+    )
 }
 
 /// Build the ObjectScript that adds a config item to a production (pure → unit-testable).
@@ -1453,7 +1489,6 @@ pub fn build_add_item_code(
 ) -> String {
     let item_e = os_str_expr(item);
     let class_e = os_str_expr(class_name);
-    let prod_e = os_str_expr(production);
     let mut extra = String::new();
     if let Some(ps) = pool_size {
         extra.push_str(&format!("Set tItem.PoolSize={}\n", ps));
@@ -1474,10 +1509,7 @@ pub fn build_add_item_code(
         ));
     }
     format!(
-        r#"Set tProdName={prod}
-If tProdName="" {{ Set tSC=##class(Ens.Director).GetProductionStatus(.tProdName,.s) If tProdName="" {{ Write "ERROR:NO_PRODUCTION:No production running and no production= given" Quit }} }}
-Set tProd=##class(Ens.Config.Production).%OpenId(tProdName,,.tSC2)
-If '$IsObject(tProd) {{ Write "ERROR:INTEROP_ERROR:Cannot open production "_tProdName Quit }}
+        r#"{prologue}
 If $IsObject(tProd.FindItemByConfigName({item})) {{ Write "ERROR:ITEM_EXISTS:Item already exists: "_{item} Quit }}
 Set tItem=##class(Ens.Config.Item).%New()
 Set tItem.Name={item}
@@ -1489,7 +1521,7 @@ If $$$ISERR(tSC4) {{ Write "ERROR:INTEROP_ERROR:"_$System.Status.GetErrorText(tS
 Set tRun="" Do ##class(Ens.Director).GetProductionStatus(.tRun,.s2)
 If tRun=tProdName {{ Set tSC5=##class(Ens.Director).UpdateProduction(10,0) If $$$ISERR(tSC5) {{ Write "ERROR:UPDATE_FAILED:"_$System.Status.GetErrorText(tSC5) Quit }} }}
 Write "OK:"_tProdName"#,
-        prod = prod_e,
+        prologue = resolve_production_prologue(production),
         item = item_e,
         class = class_e,
         enabled = if enabled { 1 } else { 0 },
@@ -1500,12 +1532,8 @@ Write "OK:"_tProdName"#,
 /// Build the ObjectScript that removes a config item from a production (pure → unit-testable).
 pub fn build_remove_item_code(production: &str, item: &str) -> String {
     let item_e = os_str_expr(item);
-    let prod_e = os_str_expr(production);
     format!(
-        r#"Set tProdName={prod}
-If tProdName="" {{ Set tSC=##class(Ens.Director).GetProductionStatus(.tProdName,.s) If tProdName="" {{ Write "ERROR:NO_PRODUCTION:No production running and no production= given" Quit }} }}
-Set tProd=##class(Ens.Config.Production).%OpenId(tProdName,,.tSC2)
-If '$IsObject(tProd) {{ Write "ERROR:INTEROP_ERROR:Cannot open production "_tProdName Quit }}
+        r#"{prologue}
 Set tIdx=0 For i=1:1:tProd.Items.Count() {{ If tProd.Items.GetAt(i).Name={item} {{ Set tIdx=i Quit }} }}
 If tIdx=0 {{ Write "ERROR:ITEM_NOT_FOUND:Item not found: "_{item} Quit }}
 Do tProd.Items.RemoveAt(tIdx)
@@ -1514,7 +1542,7 @@ If $$$ISERR(tSC4) {{ Write "ERROR:INTEROP_ERROR:"_$System.Status.GetErrorText(tS
 Set tRun="" Do ##class(Ens.Director).GetProductionStatus(.tRun,.s2)
 If tRun=tProdName {{ Set tSC5=##class(Ens.Director).UpdateProduction(10,0) If $$$ISERR(tSC5) {{ Write "ERROR:UPDATE_FAILED:"_$System.Status.GetErrorText(tSC5) Quit }} }}
 Write "OK:"_tProdName"#,
-        prod = prod_e,
+        prologue = resolve_production_prologue(production),
         item = item_e
     )
 }
@@ -1528,6 +1556,9 @@ pub async fn interop_production_item_impl(
         None => return err_json("IRIS_UNREACHABLE", "No IRIS connection"),
     };
     let item = os_str_expr(&params.item);
+    // #119: every action resolves its target the same way — `production=` when given, the
+    // running production otherwise. `add`/`remove` get theirs inside build_*_item_code.
+    let prologue = resolve_production_prologue(params.production.as_deref().unwrap_or(""));
     let ns = &params.namespace;
     let client = IrisConnection::http_client()
         .map_err(|_| McpError::invalid_request("IRIS_UNREACHABLE", None))?;
@@ -1536,11 +1567,7 @@ pub async fn interop_production_item_impl(
         "enable" | "disable" => {
             let enabled_val = if params.action == "enable" { "1" } else { "0" };
             let code = format!(
-                r#"Set tSC=##class(Ens.Director).GetProductionStatus(.n,.s)
-If $$$ISERR(tSC) {{ Write "ERROR:NO_PRODUCTION:"_$System.Status.GetErrorText(tSC) Quit }}
-If n="" {{ Write "ERROR:NO_PRODUCTION:No production running" Quit }}
-Set tProd=##class(Ens.Config.Production).%OpenId(n,,.tSC2)
-If '$IsObject(tProd) {{ Write "ERROR:INTEROP_ERROR:Cannot open production" Quit }}
+                r#"{prologue}
 Set tItem=tProd.FindItemByConfigName({item},,.tSC3)
 If '$IsObject(tItem) {{ Write "ERROR:ITEM_NOT_FOUND:Item not found: "_{item} Quit }}
 Set tItem.Enabled={enabled_val}
@@ -1564,7 +1591,7 @@ Write "OK""#
                     } else if let Some(msg) = out.strip_prefix("ERROR:UPDATE_FAILED:") {
                         err_json("UPDATE_FAILED", msg)
                     } else {
-                        err_json("INTEROP_ERROR", out)
+                        err_json("INTEROP_ERROR", interop_error_text(out))
                     }
                 }
                 Err(e) => err_json(
@@ -1575,10 +1602,7 @@ Write "OK""#
         }
         "get_settings" => {
             let code = format!(
-                r#"Set tSC=##class(Ens.Director).GetProductionStatus(.n,.s)
-If $$$ISERR(tSC)||n="" {{ Write "ERROR:NO_PRODUCTION:No production running" Quit }}
-Set tProd=##class(Ens.Config.Production).%OpenId(n,,.tSC2)
-If '$IsObject(tProd) {{ Write "ERROR:INTEROP_ERROR:Cannot open production" Quit }}
+                r#"{prologue}
 Set tItem=tProd.FindItemByConfigName({item},,.tSC3)
 If '$IsObject(tItem) {{ Write "ERROR:ITEM_NOT_FOUND:Item not found: "_{item} Quit }}
 Set tKey="" For {{ Set tSetting=tItem.Settings.GetNext(.tKey) Quit:tKey=""
@@ -1594,7 +1618,7 @@ Set tKey="" For {{ Set tSetting=tItem.Settings.GetNext(.tKey) Quit:tKey=""
                         return err_json("NO_PRODUCTION", msg);
                     }
                     if out.starts_with("ERROR:") {
-                        return err_json("INTEROP_ERROR", out);
+                        return err_json("INTEROP_ERROR", interop_error_text(out));
                     }
                     let settings: std::collections::HashMap<String, String> = out
                         .lines()
@@ -1648,10 +1672,7 @@ Set tS.Value={v}
                 ""
             };
             let code = format!(
-                r#"Set tSC=##class(Ens.Director).GetProductionStatus(.n,.s)
-If $$$ISERR(tSC)||n="" {{ Write "ERROR:NO_PRODUCTION:No production running" Quit }}
-Set tProd=##class(Ens.Config.Production).%OpenId(n,,.tSC2)
-If '$IsObject(tProd) {{ Write "ERROR:INTEROP_ERROR:Cannot open production" Quit }}
+                r#"{prologue}
 Set tItem=tProd.FindItemByConfigName({item},,.tSC3)
 If '$IsObject(tItem) {{ Write "ERROR:ITEM_NOT_FOUND:Item not found: "_{item} Quit }}
 {setting_lines}Set tSC4=tProd.%Save()
@@ -1679,7 +1700,7 @@ If $$$ISERR(tSC4) {{ Write "ERROR:INTEROP_ERROR:"_$System.Status.GetErrorText(tS
                     } else if let Some(msg) = out.strip_prefix("ERROR:UPDATE_FAILED:") {
                         err_json("UPDATE_FAILED", msg)
                     } else {
-                        err_json("INTEROP_ERROR", out)
+                        err_json("INTEROP_ERROR", interop_error_text(out))
                     }
                 }
                 Err(e) => err_json(
@@ -1877,7 +1898,7 @@ If $$$ISERR(tSC) {{ Write "ERROR:CREDENTIAL_EXISTS:"_$System.Status.GetErrorText
                     } else if let Some(msg) = out.strip_prefix("ERROR:CREDENTIAL_EXISTS:") {
                         err_json("CREDENTIAL_EXISTS", msg)
                     } else {
-                        err_json("INTEROP_ERROR", out)
+                        err_json("INTEROP_ERROR", interop_error_text(out))
                     }
                 }
                 Err(e) => err_json(classify_iris_error(&e.to_string()), &e.to_string()),
@@ -1911,7 +1932,7 @@ If $$$ISERR(tSC) {{ Write "ERROR:INTEROP_ERROR:"_$System.Status.GetErrorText(tSC
                             serde_json::json!({"success":true,"action":"update","id":params.id}),
                         )
                     } else {
-                        err_json("INTEROP_ERROR", out)
+                        err_json("INTEROP_ERROR", interop_error_text(out))
                     }
                 }
                 Err(e) => err_json(classify_iris_error(&e.to_string()), &e.to_string()),
@@ -1933,7 +1954,7 @@ If $$$ISERR(tSC) {{ Write "ERROR:INTEROP_ERROR:"_$System.Status.GetErrorText(tSC
                     } else if let Some(msg) = out.strip_prefix("ERROR:CREDENTIAL_NOT_FOUND:") {
                         err_json("CREDENTIAL_NOT_FOUND", msg)
                     } else {
-                        err_json("INTEROP_ERROR", out)
+                        err_json("INTEROP_ERROR", interop_error_text(out))
                     }
                 }
                 Err(e) => err_json(classify_iris_error(&e.to_string()), &e.to_string()),
@@ -2069,7 +2090,7 @@ If $$$ISERR(tSC) {{ Write "ERROR:INTEROP_ERROR:"_$System.Status.GetErrorText(tSC
                             serde_json::json!({"success":true,"table":params.table,"key":params.key,"value":params.value}),
                         )
                     } else {
-                        err_json("INTEROP_ERROR", out)
+                        err_json("INTEROP_ERROR", interop_error_text(out))
                     }
                 }
                 Err(e) => err_json(classify_iris_error(&e.to_string()), &e.to_string()),
@@ -2101,7 +2122,7 @@ If $$$ISERR(tSC) {{ Write "ERROR:INTEROP_ERROR:"_$System.Status.GetErrorText(tSC
                     } else if let Some(msg) = out.strip_prefix("ERROR:TABLE_NOT_FOUND:") {
                         err_json("TABLE_NOT_FOUND", msg)
                     } else {
-                        err_json("INTEROP_ERROR", out)
+                        err_json("INTEROP_ERROR", interop_error_text(out))
                     }
                 }
                 Err(e) => err_json(classify_iris_error(&e.to_string()), &e.to_string()),
@@ -2221,7 +2242,7 @@ Write tOut"#,
                     } else if let Some(msg) = out.strip_prefix("ERROR:INVALID_XML:") {
                         err_json("INVALID_XML", msg)
                     } else {
-                        err_json("INTEROP_ERROR", out)
+                        err_json("INTEROP_ERROR", interop_error_text(out))
                     }
                 }
                 Err(e) => err_json(classify_iris_error(&e.to_string()), &e.to_string()),
@@ -2309,7 +2330,14 @@ If $$$ISERR(tSC) { Write "ERROR:INTEROP_ERROR:"_$System.Status.GetErrorText(tSC)
         p.clone()
     } else {
         // Get currently running production
-        let status_code = r#"Set sc=##class(Ens.Director).GetProductionStatus(.n,.s) If $$$ISERR(sc)||n="" { Write "ERROR:NO_PRODUCTION:No production running" } Else { Write n }"#;
+        // #118: NOT `If $$$ISERR(sc)||n=""` — ObjectScript has no operator precedence, so that
+        // parses as `((ISERR)||n)=""` and never fires. The guard silently fell through, `out`
+        // came back empty, and set_autostart called SetAutoStart("") while reporting
+        // `autostart_enabled: true` for a production it never set. Two statements, no ambiguity.
+        let status_code = r#"Set sc=##class(Ens.Director).GetProductionStatus(.n,.s)
+If $$$ISERR(sc) { Write "ERROR:NO_PRODUCTION:"_$System.Status.GetErrorText(sc) Quit }
+If n="" { Write "ERROR:NO_PRODUCTION:No production is running and no production= was given" Quit }
+Write n"#;
         match iris.execute_via_generator(status_code, ns, &client).await {
             Ok(out) => {
                 let out = out.trim().to_string();
@@ -2321,6 +2349,16 @@ If $$$ISERR(tSC) { Write "ERROR:INTEROP_ERROR:"_$System.Status.GetErrorText(tSC)
             Err(e) => return err_json(classify_iris_error(&e.to_string()), &e.to_string()),
         }
     };
+
+    // #118: SetAutoStart("") clears the setting while this tool reports it enabled. Whatever
+    // shape a future probe failure takes, an empty name must never reach IRIS as a write.
+    if prod_name.trim().is_empty() {
+        return err_json(
+            "NO_PRODUCTION",
+            "No production is running and no production= was given, so there is no name to \
+             autostart. Pass production=<Package.ProductionName>.",
+        );
+    }
 
     let code = format!(
         r#"Set tSC=##class(Ens.Director).SetAutoStart({})

--- a/crates/iris-agentic-dev-core/src/tools/mod.rs
+++ b/crates/iris-agentic-dev-core/src/tools/mod.rs
@@ -6241,7 +6241,7 @@ Methods:
     }
 
     #[tool(
-        description = "Inspect a SQL table: returns whether it is a class-projected table or DDL-created, the backing data/index globals, and (optionally) an approximate row count. Works for both class-projected tables (with real storage globals from %Dictionary.CompiledStorage) and DDL tables (globals inferred by IRIS naming convention). Use include_row_count=true to add a COUNT(*) estimate. Call this (or docs_introspect) to discover the real schema/table/column names BEFORE iris_query, rather than guessing catalog tables."
+        description = "Inspect a SQL table: returns whether it is a class-projected table or DDL-created, the backing data/index globals, and (optionally) an approximate row count. Works for both class-projected tables (with real storage globals from %Dictionary.CompiledStorage) and DDL tables (globals inferred by IRIS naming convention). Use include_row_count=true to add a COUNT(*) estimate. Accepts either the SQL name (Ens_Config.Item) or the CLASS name (Ens.Config.Item) — the class→table projection is resolved for you, and a miss lists the tables that do exist in that package. Call this (or docs_introspect) to discover the real schema/table/column names BEFORE iris_query, rather than guessing catalog tables."
     )]
     async fn iris_table_info(
         &self,

--- a/crates/iris-agentic-dev-core/tests/interop_unit_tests.rs
+++ b/crates/iris-agentic-dev-core/tests/interop_unit_tests.rs
@@ -714,3 +714,119 @@ fn tool_payload(r: &Result<rmcp::model::CallToolResult, rmcp::ErrorData>) -> ser
         _ => panic!("expected text content"),
     }
 }
+
+/// #118 / #119 — the production every `iris_production_item` action opens.
+mod production_target_resolution {
+    use super::*;
+
+    /// ObjectScript has no operator precedence. `If $$$ISERR(sc)||n=""` parses as
+    /// `((ISERR)||n)=""`, and since `||` yields 0 or 1 while neither `0=""` nor `1=""` holds,
+    /// the branch is unreachable. Three sites shipped it; this is the guard that keeps a
+    /// fourth from being written.
+    #[test]
+    fn the_prologue_tests_for_no_production_in_a_statement_that_can_fire() {
+        let code = resolve_production_prologue("");
+        assert!(
+            !code.contains("||"),
+            "compound condition reintroduced in generated ObjectScript:\n{code}"
+        );
+        assert_eq!(
+            code.matches(r#"If tProdName="""#).count(),
+            2,
+            "expected the fallback and the still-empty test as two statements:\n{code}"
+        );
+        assert!(code.contains("ERROR:NO_PRODUCTION:"), "{code}");
+    }
+
+    #[test]
+    fn an_explicit_production_is_embedded_and_the_running_one_is_only_a_fallback() {
+        let code = resolve_production_prologue("My.Production");
+        assert!(code.contains(r#"Set tProdName="My.Production""#), "{code}");
+        // GetProductionStatus stays, but behind the `tProdName=""` test — so a named,
+        // STOPPED production is opened from disk instead of being unreachable.
+        assert!(code.contains("GetProductionStatus"), "{code}");
+        assert!(code.contains(r#"%OpenId(tProdName"#), "{code}");
+        assert!(
+            !code.contains("%OpenId(n,"),
+            "must not open the running production by the `n` the status call filled: {code}"
+        );
+    }
+
+    /// #119: `get_settings`/`set_settings`/`enable`/`disable` each inlined their own copy that
+    /// never read `production=`. `add`/`remove` did. One helper now, so they cannot disagree.
+    #[test]
+    fn add_and_remove_are_built_from_the_same_prologue() {
+        let settings = std::collections::HashMap::new();
+        let add = build_add_item_code(
+            "My.Production",
+            "BS.In",
+            "My.BS.In",
+            true,
+            None,
+            None,
+            &settings,
+        );
+        let remove = build_remove_item_code("My.Production", "BS.In");
+        let prologue = resolve_production_prologue("My.Production");
+        for (what, code) in [("add", &add), ("remove", &remove)] {
+            assert!(
+                code.starts_with(&prologue),
+                "{what} does not open the production the shared way:\n{code}"
+            );
+        }
+    }
+}
+
+/// #118, crate-wide: the same precedence trap must not reappear anywhere in generated
+/// ObjectScript. Scans the real source rather than one function's output.
+#[test]
+fn no_generated_objectscript_compares_after_an_unparenthesised_or() {
+    fn scan(dir: &std::path::Path, hits: &mut Vec<String>) {
+        for entry in std::fs::read_dir(dir).expect("readable src dir") {
+            let path = entry.expect("dir entry").path();
+            if path.is_dir() {
+                scan(&path, hits);
+            } else if path.extension().is_some_and(|e| e == "rs") {
+                let text = std::fs::read_to_string(&path).expect("readable source");
+                for (n, line) in text.lines().enumerate() {
+                    // Prose that QUOTES the trap (this file, and the helper's own doc comment)
+                    // is not the trap. Generated ObjectScript comments start `//` as well.
+                    let t = line.trim_start();
+                    if t.starts_with("//") || t.starts_with('*') {
+                        continue;
+                    }
+                    // Only ObjectScript statements — Rust's own `||` obeys precedence.
+                    let is_os = line.contains("$$$ISERR(")
+                        || line.trim_start().starts_with("If ")
+                        || line.trim_start().starts_with("While ");
+                    if !is_os {
+                        continue;
+                    }
+                    for (idx, _) in line.match_indices("||") {
+                        let rest = line[idx + 2..].trim_start();
+                        // Parenthesising the right operand is the fix, so `|| (` is fine.
+                        if rest.starts_with('(') {
+                            continue;
+                        }
+                        let operand: String = rest
+                            .chars()
+                            .take_while(|c| !"()= <>'".contains(*c))
+                            .collect();
+                        let after = rest[operand.len()..].trim_start();
+                        if after.starts_with('=') || after.starts_with("'=") {
+                            hits.push(format!("{}:{}: {}", path.display(), n + 1, line.trim()));
+                        }
+                    }
+                }
+            }
+        }
+    }
+    let src = std::path::Path::new(env!("CARGO_MANIFEST_DIR")).join("src");
+    let mut hits = Vec::new();
+    scan(&src, &mut hits);
+    assert!(
+        hits.is_empty(),
+        "ObjectScript has no operator precedence — parenthesise the right operand (#118):\n{}",
+        hits.join("\n")
+    );
+}


### PR DESCRIPTION
Three defects found by reading the OpenCode eval corpus (566 parsed transcripts,
628 classified IRIS MCP errors) and then reproducing each one live on 0.8.4.

#118 — `If $$$ISERR(tSC)||n=""` is dead code. ObjectScript has no operator
precedence; it evaluates strictly left to right, so that parses as
`((ISERR)||n)=""`, and since `||` yields 0 or 1 while neither `0=""` nor `1=""`
holds, the branch can never fire. Proven on 2026.1: the guard returns 0 where
the parenthesised form returns 1. Three sites shipped it — get_settings,
set_settings and set_autostart — while enable/disable already split it into two
statements, so this was drift rather than a missing insight.

Its worst effect was not the misleading error. `set_autostart` fell through the
dead guard with an empty name, called `SetAutoStart("")`, and answered
`{"autostart_enabled": true, "production": ""}` — while `get_autostart` one call
later still said false. Two calls of the same tool contradicting each other.

#119 — `iris_production_item` advertised `production` as "defaults to the running
one" but four of its six actions never read it: get_settings, set_settings,
enable and disable resolved the target from `Ens.Director.GetProductionStatus()`
and opened whatever was running. So a stopped production was unreachable (the
ordinary build loop: write it, compile it, read its settings before starting),
and set_settings silently wrote to a different production than the caller named.
All six now share one `resolve_production_prologue`, so the next action added
cannot skip it, and the message names the production it failed to open.

#120 — `iris_table_info` accepted only the exact SQL name. Handed the class name
— which is what a caller has, and what every other tool here takes — it returned
a bare TABLE_NOT_FOUND with no candidates, so agents brute-forced the separator
three and four calls at a time. The success payload was already reporting `class`
back to them. IRIS projects `A.B.C.Name` onto schema `A_B_C`, table `Name`; that
mapping is mechanical and is now applied, with every candidate tried inside one
round trip so resolution costs nothing. A miss names what does exist in that
package.

The suggestions are ranked, not just collected: the first cut answered
`Ens.Rule.Definition` with `%DeepSee_Dashboard.Definition` and told the caller to
pass it. A candidate must now share the request's leading segment, and a
`%`-schema table is offered only to a caller who asked for one.

Tests: the pure candidate/ranking functions are unit-tested, and a crate-wide
scan asserts no generated ObjectScript compares after an unparenthesised `||`.
That guard was verified non-vacuous — reintroducing the trap fails it.

Verified live against IRIS 2026.1 on localhost:43080 (namespace APP): the stopped
production now opens, both dead guards now fire, `set_autostart` refuses the
empty name and leaves autostart untouched, and `EnsLib.HL7.Message` resolves to
`EnsLib_HL7.Message` while the exact SQL name is unchanged.

Closes #118
Closes #119
Closes #120

🤖 Generated with [Claude Code](https://claude.com/claude-code)