### PR TITLE
fix(#123,#124,#125): report the abort, name the line that caused it, and split INTEROP_ERROR

### DIFF
--- a/crates/iris-agentic-dev-core/src/tools/interop.rs
+++ b/crates/iris-agentic-dev-core/src/tools/interop.rs
@@ -592,6 +592,123 @@ pub fn parse_status_response(raw: &str) -> Result<(String, i64, String), String>
     Ok((name, code, state))
 }
 
+/// One classified interop failure: the code a caller can branch on, the message with the
+/// server's own prefix noise removed, and whatever the message named (#125).
+pub struct InteropFailure {
+    pub code: &'static str,
+    pub message: String,
+    pub extra: serde_json::Map<String, serde_json::Value>,
+}
+
+/// Split `INTEROP_ERROR` into the states underneath it (#125).
+///
+/// Every failure from `iris_production`/`iris_production_item` used to return the single code
+/// `INTEROP_ERROR`, so a caller had to pattern-match English prose to decide what to do — and
+/// the five conditions hiding under it want opposite responses, one of them being "nothing, this
+/// is the goal state". The production name the caller supplied was dropped as well, so
+/// "that production does not exist" and "you named nothing" read identically.
+///
+/// The prefixes are also normalised here. `Write "ERROR:"_$System.Status.GetErrorText(sc)`
+/// produces `ERROR:ERROR <Ens>…` because GetErrorText adds its own `ERROR ` — two different
+/// shapes (`ERROR:ERROR <Ens>…` and `ERROR:INTEROP_ERROR:…`) reached callers from one tool.
+pub fn classify_interop_failure(raw: &str, production: Option<&str>) -> InteropFailure {
+    let msg = raw
+        .trim()
+        .strip_prefix("ERROR:INTEROP_ERROR:")
+        .or_else(|| raw.trim().strip_prefix("ERROR:ERROR "))
+        .or_else(|| raw.trim().strip_prefix("ERROR:"))
+        .unwrap_or(raw.trim())
+        .trim()
+        .to_string();
+
+    let mut extra = serde_json::Map::new();
+    if let Some(p) = production.map(str::trim).filter(|p| !p.is_empty()) {
+        extra.insert("production".into(), p.into());
+    }
+
+    let code = if msg.contains("ErrProductionAlreadyRunning") {
+        if let Some(name) = between(&msg, "Production '", "'") {
+            extra.insert("running_production".into(), name.into());
+        }
+        "PRODUCTION_ALREADY_RUNNING"
+    } else if msg.contains("ErrInvalidProduction") || msg.contains("Cannot open production") {
+        "PRODUCTION_NOT_FOUND"
+    } else if msg.contains("Config Item") && msg.contains("unknown BusinessType") {
+        if let Some(item) = between(&msg, "Config Item ", " cannot run") {
+            extra.insert("config_item".into(), item.into());
+        }
+        "CONFIG_ITEM_INVALID"
+    } else if msg.contains("<CLASS DOES NOT EXIST>") {
+        // "…<CLASS DOES NOT EXIST>getProductionItems+51^Ens.Director.1 *Ens.Rule.Routing -- …"
+        // The caller's next move is to compile that class, so it must be a field, not a
+        // substring of an ObjectScript stack frame.
+        if let Some(cls) = msg
+            .split('*')
+            .nth(1)
+            .and_then(|rest| rest.split_whitespace().next())
+            .filter(|c| c.contains('.'))
+        {
+            extra.insert("missing_class".into(), cls.into());
+        }
+        "MISSING_CLASS"
+    } else {
+        "INTEROP_ERROR"
+    };
+
+    if let Some(h) = interop_failure_hint(code, &extra) {
+        extra.insert("hint".into(), h.into());
+    }
+    InteropFailure {
+        code,
+        message: msg,
+        extra,
+    }
+}
+
+fn between<'a>(haystack: &'a str, open: &str, close: &str) -> Option<&'a str> {
+    let start = haystack.find(open)? + open.len();
+    let rest = &haystack[start..];
+    let end = rest.find(close)?;
+    Some(rest[..end].trim()).filter(|s| !s.is_empty())
+}
+
+fn interop_failure_hint(
+    code: &str,
+    extra: &serde_json::Map<String, serde_json::Value>,
+) -> Option<String> {
+    let named = extra.get("production").and_then(|v| v.as_str());
+    match code {
+        "PRODUCTION_NOT_FOUND" => Some(match named {
+            Some(p) => format!(
+                "'{p}' is not a production this namespace can open — it is not compiled here, or \
+                 the name is wrong. Check with iris_query \"SELECT ID FROM Ens_Config.Production\", \
+                 then iris_doc(put, compile) the class if it is missing."
+            ),
+            None => "No production was named and none is running. Pass \
+                     production=<Package.ProductionName>."
+                .to_string(),
+        }),
+        "CONFIG_ITEM_INVALID" => extra.get("config_item").and_then(|v| v.as_str()).map(|i| {
+            format!(
+                "Config item '{i}' names a class that is not a Business Service/Process/Operation \
+                 (or is not compiled), so the production cannot start. Fix that one item — the \
+                 production itself is fine."
+            )
+        }),
+        "MISSING_CLASS" => extra.get("missing_class").and_then(|v| v.as_str()).map(|c| {
+            format!("Compile '{c}' — a config item references it and it does not exist here.")
+        }),
+        _ => None,
+    }
+}
+
+/// Answer a failed interop call with the split code, the cleaned message and the fields the
+/// message named.
+fn interop_fail(raw: &str, production: Option<&str>) -> Result<CallToolResult, McpError> {
+    let f = classify_interop_failure(raw, production);
+    crate::tools::envelope::fail_with(f.code, &f.message, serde_json::Value::Object(f.extra))
+}
+
 fn docker_required_interop() -> Result<CallToolResult, McpError> {
     err_json(
         "DOCKER_REQUIRED",
@@ -682,7 +799,30 @@ pub async fn interop_production_start_impl(
             if raw.starts_with("OK") {
                 ok_json(serde_json::json!({"success": true, "state": "Running"}))
             } else {
-                err_json("INTEROP_ERROR", raw)
+                let f = classify_interop_failure(raw, Some(prod));
+                // #125: the caller asked for this production to be running and it is running.
+                // Reporting the goal state as a failure made `start` non-idempotent — a retry
+                // loop could never converge. Only when the SAME production is up: a different
+                // one running is a genuine conflict the caller has to resolve.
+                let already_this_one = f.code == "PRODUCTION_ALREADY_RUNNING"
+                    && f.extra
+                        .get("running_production")
+                        .and_then(|v| v.as_str())
+                        .is_some_and(|r| r.eq_ignore_ascii_case(prod));
+                if already_this_one {
+                    return ok_json(serde_json::json!({
+                        "success": true,
+                        "state": "Running",
+                        "production": prod,
+                        "already_running": true,
+                        "note": format!("'{prod}' was already running; nothing to do."),
+                    }));
+                }
+                crate::tools::envelope::fail_with(
+                    f.code,
+                    &f.message,
+                    serde_json::Value::Object(f.extra),
+                )
             }
         }
         Err(e) if e.to_string() == "DOCKER_REQUIRED" => docker_required_interop(),
@@ -710,7 +850,7 @@ pub async fn interop_production_stop_impl(
             if raw.starts_with("OK") {
                 ok_json(serde_json::json!({"success": true, "state": "Stopped"}))
             } else {
-                err_json("INTEROP_ERROR", raw)
+                interop_fail(raw, None)
             }
         }
         Err(e) if e.to_string() == "DOCKER_REQUIRED" => docker_required_interop(),
@@ -781,7 +921,7 @@ pub async fn interop_production_recover_impl(
             if raw.starts_with("OK") {
                 ok_json(serde_json::json!({"success": true, "state": "Running"}))
             } else {
-                err_json("INTEROP_ERROR", raw)
+                interop_fail(raw, None)
             }
         }
         Err(e) if e.to_string() == "DOCKER_REQUIRED" => docker_required_interop(),
@@ -1441,15 +1581,6 @@ pub struct ProductionItemParams {
     pub category: Option<String>,
 }
 
-/// Strip the `ERROR:INTEROP_ERROR:` sentinel the generated ObjectScript writes so the envelope
-/// does not carry its own error code twice inside the message text (#118/#119: now that these
-/// messages name the production they failed on, the duplication is the only noise left).
-fn interop_error_text(out: &str) -> &str {
-    out.strip_prefix("ERROR:INTEROP_ERROR:")
-        .unwrap_or(out)
-        .trim()
-}
-
 /// The ObjectScript prologue that resolves `tProd`, the production every
 /// `iris_production_item` action operates on (pure → unit-testable).
 ///
@@ -1591,7 +1722,7 @@ Write "OK""#
                     } else if let Some(msg) = out.strip_prefix("ERROR:UPDATE_FAILED:") {
                         err_json("UPDATE_FAILED", msg)
                     } else {
-                        err_json("INTEROP_ERROR", interop_error_text(out))
+                        interop_fail(out, params.production.as_deref())
                     }
                 }
                 Err(e) => err_json(
@@ -1618,7 +1749,7 @@ Set tKey="" For {{ Set tSetting=tItem.Settings.GetNext(.tKey) Quit:tKey=""
                         return err_json("NO_PRODUCTION", msg);
                     }
                     if out.starts_with("ERROR:") {
-                        return err_json("INTEROP_ERROR", interop_error_text(out));
+                        return interop_fail(out, params.production.as_deref());
                     }
                     let settings: std::collections::HashMap<String, String> = out
                         .lines()
@@ -1700,7 +1831,7 @@ If $$$ISERR(tSC4) {{ Write "ERROR:INTEROP_ERROR:"_$System.Status.GetErrorText(tS
                     } else if let Some(msg) = out.strip_prefix("ERROR:UPDATE_FAILED:") {
                         err_json("UPDATE_FAILED", msg)
                     } else {
-                        err_json("INTEROP_ERROR", interop_error_text(out))
+                        interop_fail(out, params.production.as_deref())
                     }
                 }
                 Err(e) => err_json(
@@ -1898,7 +2029,7 @@ If $$$ISERR(tSC) {{ Write "ERROR:CREDENTIAL_EXISTS:"_$System.Status.GetErrorText
                     } else if let Some(msg) = out.strip_prefix("ERROR:CREDENTIAL_EXISTS:") {
                         err_json("CREDENTIAL_EXISTS", msg)
                     } else {
-                        err_json("INTEROP_ERROR", interop_error_text(out))
+                        interop_fail(out, None)
                     }
                 }
                 Err(e) => err_json(classify_iris_error(&e.to_string()), &e.to_string()),
@@ -1932,7 +2063,7 @@ If $$$ISERR(tSC) {{ Write "ERROR:INTEROP_ERROR:"_$System.Status.GetErrorText(tSC
                             serde_json::json!({"success":true,"action":"update","id":params.id}),
                         )
                     } else {
-                        err_json("INTEROP_ERROR", interop_error_text(out))
+                        interop_fail(out, None)
                     }
                 }
                 Err(e) => err_json(classify_iris_error(&e.to_string()), &e.to_string()),
@@ -1954,7 +2085,7 @@ If $$$ISERR(tSC) {{ Write "ERROR:INTEROP_ERROR:"_$System.Status.GetErrorText(tSC
                     } else if let Some(msg) = out.strip_prefix("ERROR:CREDENTIAL_NOT_FOUND:") {
                         err_json("CREDENTIAL_NOT_FOUND", msg)
                     } else {
-                        err_json("INTEROP_ERROR", interop_error_text(out))
+                        interop_fail(out, None)
                     }
                 }
                 Err(e) => err_json(classify_iris_error(&e.to_string()), &e.to_string()),
@@ -2090,7 +2221,7 @@ If $$$ISERR(tSC) {{ Write "ERROR:INTEROP_ERROR:"_$System.Status.GetErrorText(tSC
                             serde_json::json!({"success":true,"table":params.table,"key":params.key,"value":params.value}),
                         )
                     } else {
-                        err_json("INTEROP_ERROR", interop_error_text(out))
+                        interop_fail(out, None)
                     }
                 }
                 Err(e) => err_json(classify_iris_error(&e.to_string()), &e.to_string()),
@@ -2122,7 +2253,7 @@ If $$$ISERR(tSC) {{ Write "ERROR:INTEROP_ERROR:"_$System.Status.GetErrorText(tSC
                     } else if let Some(msg) = out.strip_prefix("ERROR:TABLE_NOT_FOUND:") {
                         err_json("TABLE_NOT_FOUND", msg)
                     } else {
-                        err_json("INTEROP_ERROR", interop_error_text(out))
+                        interop_fail(out, None)
                     }
                 }
                 Err(e) => err_json(classify_iris_error(&e.to_string()), &e.to_string()),
@@ -2242,7 +2373,7 @@ Write tOut"#,
                     } else if let Some(msg) = out.strip_prefix("ERROR:INVALID_XML:") {
                         err_json("INVALID_XML", msg)
                     } else {
-                        err_json("INTEROP_ERROR", interop_error_text(out))
+                        interop_fail(out, None)
                     }
                 }
                 Err(e) => err_json(classify_iris_error(&e.to_string()), &e.to_string()),
@@ -4064,5 +4195,105 @@ mod interop_preflight_tests {
                 .expect("no Ens.Director means no interop");
             assert_eq!(v["error_code"], "NAMESPACE_NOT_INTEROP", "{v}");
         });
+    }
+}
+
+/// #125 — `INTEROP_ERROR` collapsed five states a caller must respond to differently.
+/// Every input below is verbatim from the eval corpus.
+#[cfg(test)]
+mod interop_failure_tests {
+    use super::classify_interop_failure;
+
+    fn field(raw: &str, prod: Option<&str>, key: &str) -> Option<String> {
+        classify_interop_failure(raw, prod)
+            .extra
+            .get(key)
+            .and_then(|v| v.as_str())
+            .map(str::to_string)
+    }
+
+    /// 63 of 89 occurrences. The caller named the production and the answer did not.
+    #[test]
+    fn an_invalid_production_is_named_and_gets_its_own_code() {
+        let raw = "ERROR:ERROR <Ens>ErrInvalidProduction: Invalid Production";
+        let f = classify_interop_failure(raw, Some("ResultOut.Production"));
+        assert_eq!(f.code, "PRODUCTION_NOT_FOUND");
+        assert_eq!(
+            f.extra.get("production").and_then(|v| v.as_str()),
+            Some("ResultOut.Production")
+        );
+        assert!(
+            f.extra
+                .get("hint")
+                .and_then(|v| v.as_str())
+                .is_some_and(|h| h.contains("ResultOut.Production")),
+            "the hint must name the production: {:?}",
+            f.extra.get("hint")
+        );
+    }
+
+    /// The other prefix shape the same tool emitted, for the same caller action.
+    #[test]
+    fn cannot_open_production_lands_on_the_same_code() {
+        let f = classify_interop_failure("ERROR:INTEROP_ERROR:Cannot open production", None);
+        assert_eq!(f.code, "PRODUCTION_NOT_FOUND");
+    }
+
+    /// The sharpest case: the caller asked for it to be running, and it is.
+    #[test]
+    fn already_running_is_its_own_code_and_names_the_running_production() {
+        let raw = "ERROR:ERROR <Ens>ErrProductionAlreadyRunning: Production 'NightLab.Production' is already running";
+        let f = classify_interop_failure(raw, Some("NightLab.Production"));
+        assert_eq!(f.code, "PRODUCTION_ALREADY_RUNNING");
+        assert_eq!(
+            f.extra.get("running_production").and_then(|v| v.as_str()),
+            Some("NightLab.Production")
+        );
+    }
+
+    #[test]
+    fn a_bad_config_item_is_not_a_production_level_failure() {
+        let raw = "ERROR:ERROR <Ens>ErrGeneral: Config Item DT.ADT2Normalized cannot run because it has unknown BusinessType";
+        assert_eq!(
+            classify_interop_failure(raw, None).code,
+            "CONFIG_ITEM_INVALID"
+        );
+        assert_eq!(
+            field(raw, None, "config_item").as_deref(),
+            Some("DT.ADT2Normalized")
+        );
+    }
+
+    /// The caller's next move is to compile that class, so it must be a field — not a
+    /// substring of an ObjectScript stack frame with internal log formatting around it.
+    #[test]
+    fn a_missing_class_is_lifted_out_of_the_stack_frame() {
+        let raw = "ERROR:ERROR <Ens>ErrException: <CLASS DOES NOT EXIST>getProductionItems+51^Ens.Director.1 *Ens.Rule.Routing -- logged as '-' number - @''";
+        assert_eq!(classify_interop_failure(raw, None).code, "MISSING_CLASS");
+        assert_eq!(
+            field(raw, None, "missing_class").as_deref(),
+            Some("Ens.Rule.Routing")
+        );
+    }
+
+    /// Two shapes reached callers from one tool; neither survives into the envelope.
+    #[test]
+    fn the_doubled_error_prefixes_are_stripped() {
+        for raw in [
+            "ERROR:ERROR <Ens>ErrInvalidProduction: Invalid Production",
+            "ERROR:INTEROP_ERROR:Cannot open production My.Prod",
+            "ERROR:something unclassified",
+        ] {
+            let m = classify_interop_failure(raw, None).message;
+            assert!(!m.starts_with("ERROR:"), "prefix survived: {m}");
+            assert!(!m.starts_with("ERROR "), "prefix survived: {m}");
+        }
+    }
+
+    #[test]
+    fn anything_unrecognised_still_falls_back_to_interop_error() {
+        let f = classify_interop_failure("ERROR:something nobody has seen", None);
+        assert_eq!(f.code, "INTEROP_ERROR");
+        assert_eq!(f.message, "something nobody has seen");
     }
 }

--- a/crates/iris-agentic-dev-core/src/tools/mod.rs
+++ b/crates/iris-agentic-dev-core/src/tools/mod.rs
@@ -1250,6 +1250,11 @@ pub struct IntrospectParams {
     /// (IRIS_NAMESPACE) — only pass a value to deliberately target a different namespace.
     #[serde(default)]
     pub namespace: Option<String>,
+    /// Include members inherited from superclasses (default false — only what this class
+    /// declares). Inherited %Persistent plumbing dominates the answer: Ens.Config.Production
+    /// has 451 methods of which 70 are its own.
+    #[serde(default)]
+    pub include_inherited: bool,
 }
 #[derive(Debug, Deserialize, JsonSchema)]
 pub struct DebugMapParams {
@@ -2847,6 +2852,282 @@ pub fn translate_symbols_query(limit: usize, query: &str) -> (String, Vec<serde_
     (
         format!("{} WHERE Name LIKE ? ORDER BY Name", base),
         vec![serde_json::Value::String(format!("%{}%", query))],
+    )
+}
+
+/// Turn the wrapper's opaque frame into something the caller can act on (#124).
+///
+/// Adds the caller's OWN failing line (an IRIS terminal would have echoed it with a caret) and,
+/// when the trap names a member on a class, that class's declared members. Both come from
+/// information the server already holds at the moment it builds the error.
+async fn enrich_abort(
+    iris: &crate::iris::connection::IrisConnection,
+    client: &reqwest::Client,
+    namespace: &str,
+    abort: &str,
+    submitted: &str,
+    resp: &mut serde_json::Value,
+) {
+    let Some(frame) = parse_abort_frame(abort) else {
+        return;
+    };
+    resp["signal"] = serde_json::Value::String(frame.signal.to_string());
+
+    if let Some(n) = frame.line {
+        if let Some(text) = submitted.lines().nth(n - 1) {
+            resp["source_line_number"] = serde_json::Value::from(n);
+            resp["source_line"] = serde_json::Value::String(text.trim_end().to_string());
+        }
+    }
+
+    let mut hint = match (resp.get("source_line").and_then(|v| v.as_str()), frame.line) {
+        (Some(line), Some(n)) => format!("Line {n} of the code you sent is what failed: {line}"),
+        _ => String::new(),
+    };
+
+    if abort_wants_member_list(frame.signal) {
+        if let (Some(member), Some(class)) = (frame.member, frame.class) {
+            let members = declared_members(iris, client, namespace, class, Some(member)).await;
+            if !members.is_empty() {
+                resp["did_you_mean"] = members
+                    .iter()
+                    .take(8)
+                    .map(|m| serde_json::Value::String(m.clone()))
+                    .collect();
+                if !hint.is_empty() {
+                    hint.push(' ');
+                }
+                hint.push_str(&format!(
+                    "'{class}' has no '{member}'. It declares: {}. \
+                     (docs_introspect(class_name='{class}') lists all of them.)",
+                    members
+                        .iter()
+                        .take(8)
+                        .cloned()
+                        .collect::<Vec<_>>()
+                        .join(", ")
+                ));
+            }
+        }
+    }
+
+    if !hint.is_empty() && resp.get("hint").is_none() {
+        resp["hint"] = serde_json::Value::String(hint);
+    }
+}
+
+/// The members a class DECLARES (not inherited, not `%`-prefixed), ranked against the name the
+/// caller got wrong (#124). Runs only on the error path, so a working call never pays for it.
+async fn declared_members(
+    iris: &crate::iris::connection::IrisConnection,
+    client: &reqwest::Client,
+    namespace: &str,
+    class: &str,
+    wanted: Option<&str>,
+) -> Vec<String> {
+    let sql = "SELECT Name FROM %Dictionary.CompiledMethod \
+               WHERE parent = ? AND Origin = parent AND SUBSTRING(Name,1,1) <> '%' \
+               UNION \
+               SELECT Name FROM %Dictionary.CompiledProperty \
+               WHERE parent = ? AND Origin = parent AND SUBSTRING(Name,1,1) <> '%'";
+    let rows = match iris
+        .query(
+            sql,
+            vec![
+                serde_json::Value::String(class.to_string()),
+                serde_json::Value::String(class.to_string()),
+            ],
+            namespace,
+            client,
+        )
+        .await
+    {
+        Ok(v) => v,
+        Err(_) => return Vec::new(),
+    };
+    // `iris.query` answers `{"result":{"content":[…]}}` — the same shape `row_count` reads.
+    let mut names: Vec<String> = rows["result"]["content"]
+        .as_array()
+        .map(|a| {
+            a.iter()
+                .filter_map(|r| r.get("Name").and_then(|n| n.as_str()))
+                .map(str::to_string)
+                .collect()
+        })
+        .unwrap_or_default();
+
+    // Nearest first: the caller is looking for one name.
+    match wanted {
+        Some(w) => rank_members(&mut names, w),
+        None => names.sort(),
+    }
+    names.truncate(25);
+    names
+}
+
+/// Split a CamelCase identifier into lowercase words: `ValidateProduction` -> `[validate, production]`.
+fn camel_words(name: &str) -> Vec<String> {
+    let mut out = Vec::new();
+    let mut cur = String::new();
+    for ch in name.chars() {
+        if ch.is_ascii_uppercase() && !cur.is_empty() {
+            out.push(std::mem::take(&mut cur));
+        }
+        if ch.is_ascii_alphanumeric() {
+            cur.push(ch.to_ascii_lowercase());
+        }
+    }
+    if !cur.is_empty() {
+        out.push(cur);
+    }
+    out
+}
+
+/// Rank a class's members against the name the caller got wrong (#124).
+///
+/// A leading-prefix score alone is useless here: nothing in `Ens.Director` starts with a `V`, so
+/// `ValidateProduction` scored zero against every member and the caller was offered `Console`.
+/// What the caller wants shares a WORD — `StartProduction`, `StopProduction`,
+/// `GetProductionStatus`. Words of three characters or fewer (`get`, `is`, `on`) are skipped:
+/// they match everything and therefore rank nothing.
+fn rank_members(names: &mut [String], wanted: &str) {
+    let words: Vec<String> = camel_words(wanted)
+        .into_iter()
+        .filter(|w| w.len() > 3)
+        .collect();
+    let want_lower = wanted.to_ascii_lowercase();
+    let want_words = camel_words(wanted).len();
+    names.sort_by_cached_key(|n| {
+        let lower = n.to_ascii_lowercase();
+        let shared_words = words.iter().filter(|w| lower.contains(w.as_str())).count();
+        let prefix = lower
+            .chars()
+            .zip(want_lower.chars())
+            .take_while(|(a, b)| a == b)
+            .count();
+        // Among members sharing the same word, the one SHAPED like what the caller wrote is
+        // the better guess: `ValidateProduction` wants `StartProduction`, not
+        // `actualizeProductionDifferences`. Word count first, then length.
+        let shape = camel_words(n).len().abs_diff(want_words);
+        let length = lower.len().abs_diff(want_lower.len());
+        (
+            std::cmp::Reverse(shared_words),
+            std::cmp::Reverse(prefix),
+            shape,
+            length,
+            lower,
+        )
+    });
+}
+
+/// What the wrapper's abort line actually names (#124).
+///
+/// `ERROR: <METHOD DOES NOT EXIST> 148 RunUser+3^IrisDevTmp.Run32b6783ae37d.1 ValidateProduction,Ens.Director`
+///
+/// `RunUser+3` is a location in a routine the caller never submitted, never sees and cannot
+/// fetch, and the hash changes every call — so two identical errors did not even look
+/// identical. But the server wrote that routine: `RunUser+N` is submitted line N (verified on
+/// 2026.1 against a script whose third line trapped), and the trailing `Member,Class` pair is
+/// already parsed out for us by IRIS.
+#[derive(Debug, PartialEq)]
+pub struct AbortFrame<'a> {
+    pub signal: &'a str,
+    pub line: Option<usize>,
+    pub member: Option<&'a str>,
+    pub class: Option<&'a str>,
+}
+
+pub fn parse_abort_frame(abort: &str) -> Option<AbortFrame<'_>> {
+    let open = abort.find('<')?;
+    let close = abort[open..].find('>')? + open;
+    let signal = abort[open + 1..close].trim();
+    let rest = &abort[close + 1..];
+
+    // `RunUser+N^Routine` — N is the submitted line, 1-based.
+    let line = rest.find("RunUser+").and_then(|i| {
+        rest[i + "RunUser+".len()..]
+            .split(|c: char| !c.is_ascii_digit())
+            .next()
+            .and_then(|d| d.parse::<usize>().ok())
+    });
+
+    // Trailing detail after the routine reference, e.g. "ValidateProduction,Ens.Director".
+    let tail = rest
+        .split('^')
+        .nth(1)
+        .and_then(|after| after.split_whitespace().nth(1))
+        .map(str::trim)
+        .filter(|t| !t.is_empty());
+    let (member, class) = match tail.and_then(|t| t.split_once(',')) {
+        Some((m, c)) => (Some(m.trim()), Some(c.trim())),
+        None => (tail, None),
+    };
+
+    Some(AbortFrame {
+        signal,
+        line,
+        member,
+        class,
+    })
+}
+
+/// The signals for which naming the class's declared members answers the question (#124).
+///
+/// Three quarters of the opaque frames in the eval corpus are a name the agent got wrong —
+/// a method, class or property that does not exist. 54% of affected runs never called an
+/// introspection tool afterwards and 70% of missing symbols were never retried: agents do not
+/// recover from these, they abandon the line of enquiry. So the error has to carry the answer.
+fn abort_wants_member_list(signal: &str) -> bool {
+    matches!(
+        signal,
+        "METHOD DOES NOT EXIST" | "PROPERTY DOES NOT EXIST" | "CLASS PROPERTY"
+    )
+}
+
+/// The wrapper's own abort rendering, wherever it lands in the captured output (#123).
+///
+/// `iris_execute` used to decide success with `trimmed.starts_with("ERROR: ")`, which made the
+/// flag a function of whether the script had written anything BEFORE the trap fired. The same
+/// `<SYNTAX>` abort came back `success:false` when it hit line 1 and `success:true` when a
+/// `Write` landed first — 352 of 720 abort-carrying envelopes in the eval corpus were reported
+/// as successes, every one of them with no `error_code` for a caller to branch on. On a client
+/// that raises on `success:false` (opencode does) that is the difference between the agent
+/// seeing a failure and seeing nothing.
+///
+/// The trap is written by the wrapper's Catch block and aborts execution, so it is the LAST
+/// non-empty line. Anchoring there rather than matching anywhere keeps a script that
+/// legitimately prints the word ERROR mid-run from being reported as an abort. The
+/// leading-prefix test is kept as well, so nothing detected before stops being detected.
+pub fn runtime_abort_line(output: &str) -> Option<&str> {
+    fn is_abort(line: &str) -> bool {
+        let t = line.trim();
+        matches!(
+            t.strip_prefix("ERROR: ").or_else(|| t.strip_prefix("ERROR($ZERROR): ")),
+            Some(rest) if rest.starts_with('<')
+        )
+    }
+    let last = output.lines().rev().find(|l| !l.trim().is_empty())?;
+    if is_abort(last) {
+        return Some(last.trim());
+    }
+    // The wrapper's one non-`<signal>` failure, emitted when the device redirect could not be
+    // established. Matched exactly rather than by the old blanket `starts_with("ERROR: ")`,
+    // which also caught a script whose own first line happened to print the word.
+    output
+        .lines()
+        .map(str::trim)
+        .find(|l| *l == "ERROR: output capture unavailable")
+}
+
+/// `<ENDOFFILE>` is a `READ` loop reaching the end of a file — an abort, but usually the
+/// intended terminator rather than a defect. It is still reported as a failure, because the
+/// script did stop early and the ask in #123 was consistency; the hint says so, so a caller
+/// can tell this apart from a real fault without the flag having to lie.
+fn abort_hint(abort: &str) -> Option<&'static str> {
+    abort.contains("<ENDOFFILE>").then_some(
+        "<ENDOFFILE> is usually a READ loop reaching the end of the file, not a defect — the \
+         output above is everything that was read. If that is what you intended, treat this as \
+         done; guard the loop with `Quit:$ZEOF` to end without the trap.",
     )
 }
 
@@ -4590,8 +4871,9 @@ do ##class(%UnitTest.Manager).RunTest({pattern},"{flags}","{token}")"#,
             Ok(Ok(output)) => {
                 let trimmed = output.trim();
                 // Catch ObjectScript runtime errors written by the Catch block or $ZERROR check.
-                let is_runtime_error =
-                    trimmed.starts_with("ERROR: ") || trimmed.starts_with("ERROR($ZERROR): ");
+                // #123: anywhere in the output, not only at the start — see runtime_abort_line.
+                let abort = runtime_abort_line(trimmed);
+                let is_runtime_error = abort.is_some();
                 self.record_call("iris_execute", !is_runtime_error);
                 let mut resp = serde_json::json!({
                     "success": !is_runtime_error,
@@ -4599,8 +4881,11 @@ do ##class(%UnitTest.Manager).RunTest({pattern},"{flags}","{token}")"#,
                     "namespace": namespace,
                     "method": "http",
                 });
-                if is_runtime_error {
+                if let Some(abort) = abort {
                     resp["error_code"] = serde_json::Value::String("IRIS_RUNTIME_ERROR".into());
+                    if let Some(h) = abort_hint(abort) {
+                        resp["hint"] = serde_json::Value::String(h.into());
+                    }
                 } else if trimmed.is_empty() {
                     // Execution succeeded but produced no captured output. With the RunUser
                     // fix the code really ran (this is no longer the objectgenerator silent
@@ -4636,9 +4921,12 @@ do ##class(%UnitTest.Manager).RunTest({pattern},"{flags}","{token}")"#,
                     }
                 }
                 // Issue #2: the runtime-error message must live in `error` (not only
-                // `output`) and the result must be flagged isError on the wire.
-                if is_runtime_error {
-                    return envelope::fail_with("IRIS_RUNTIME_ERROR", trimmed, resp);
+                // `output`) and the result must be flagged isError on the wire. #123: `error`
+                // carries the abort LINE — `output` still holds everything the script wrote
+                // before it, which the caller asked to keep.
+                if let Some(abort) = abort {
+                    enrich_abort(&iris, client, &namespace, abort, code_to_run, &mut resp).await;
+                    return envelope::fail_with("IRIS_RUNTIME_ERROR", abort, resp);
                 }
                 return ok_json(resp);
             }
@@ -4704,8 +4992,9 @@ do ##class(%UnitTest.Manager).RunTest({pattern},"{flags}","{token}")"#,
             }
             Ok(Ok(output)) => {
                 let trimmed = output.trim();
-                let is_runtime_error =
-                    trimmed.starts_with("ERROR: ") || trimmed.starts_with("ERROR($ZERROR): ");
+                // #123: same rule as the HTTP arm — the flag must not depend on prior output.
+                let abort = runtime_abort_line(trimmed);
+                let is_runtime_error = abort.is_some();
                 self.record_call("iris_execute", !is_runtime_error);
                 let mut resp = serde_json::json!({
                     "success": !is_runtime_error,
@@ -4713,8 +5002,11 @@ do ##class(%UnitTest.Manager).RunTest({pattern},"{flags}","{token}")"#,
                     "namespace": namespace,
                     "method": "docker",
                 });
-                if is_runtime_error {
+                if let Some(abort) = abort {
                     resp["error_code"] = serde_json::Value::String("IRIS_RUNTIME_ERROR".into());
+                    if let Some(h) = abort_hint(abort) {
+                        resp["hint"] = serde_json::Value::String(h.into());
+                    }
                 }
                 if let Some(ref tr) = translation {
                     if tr.found {
@@ -4736,8 +5028,8 @@ do ##class(%UnitTest.Manager).RunTest({pattern},"{flags}","{token}")"#,
                         resp["hint"] = serde_json::Value::String(h.into());
                     }
                 }
-                if is_runtime_error {
-                    return envelope::fail_with("IRIS_RUNTIME_ERROR", trimmed, resp);
+                if let Some(abort) = abort {
+                    return envelope::fail_with("IRIS_RUNTIME_ERROR", abort, resp);
                 }
                 ok_json(resp)
             }
@@ -5461,7 +5753,7 @@ do ##class(%UnitTest.Manager).RunTest({pattern},"{flags}","{token}")"#,
     }
 
     #[tool(
-        description = "Introspect an ObjectScript class — returns methods, properties, and type information."
+        description = "Introspect an ObjectScript class — returns methods, properties, and type information. Returns only what the class DECLARES by default; pass include_inherited=true to also get everything it inherits (that is usually an order of magnitude more — Ens.Config.Production declares 70 methods and inherits 381)."
     )]
     async fn docs_introspect(
         &self,
@@ -5477,8 +5769,18 @@ do ##class(%UnitTest.Manager).RunTest({pattern},"{flags}","{token}")"#,
         // methods answers `methods:[]`, so `null` vs `[]` was the ONLY thing separating
         // "unreachable" from "no methods" and no caller makes that distinction. A failed call
         // must never be answered with a negative FACT.
+        // #124: the documented way out of "which members does this class have?" returned every
+        // inherited member — a 16 KB median response on the current pin, 78% of them carrying
+        // %AddToSaveSet/%BindExport plumbing, and often a note that most of the answer was
+        // truncated away. `Origin = parent` is the declared-only filter; it is not interpolated
+        // caller input, only this flag.
+        let origin_filter = if p.include_inherited {
+            ""
+        } else {
+            " AND Origin = parent"
+        };
         let methods = match iris.query(
-            "SELECT Name,FormalSpec,ReturnType FROM %Dictionary.CompiledMethod WHERE parent=? ORDER BY Name",
+            &format!("SELECT Name,FormalSpec,ReturnType FROM %Dictionary.CompiledMethod WHERE parent=?{origin_filter} ORDER BY Name"),
             vec![serde_json::Value::String(p.class_name.clone())],
             &namespace,
             client,
@@ -5490,7 +5792,7 @@ do ##class(%UnitTest.Manager).RunTest({pattern},"{flags}","{token}")"#,
         };
         let props = match iris
             .query(
-                "SELECT Name,Type FROM %Dictionary.CompiledProperty WHERE parent=? ORDER BY Name",
+                &format!("SELECT Name,Type FROM %Dictionary.CompiledProperty WHERE parent=?{origin_filter} ORDER BY Name"),
                 vec![serde_json::Value::String(p.class_name.clone())],
                 &namespace,
                 client,
@@ -5543,9 +5845,17 @@ do ##class(%UnitTest.Manager).RunTest({pattern},"{flags}","{token}")"#,
                 ClassPresence::Compiled | ClassPresence::Undetermined => {}
             }
         }
-        ok_json(
-            serde_json::json!({"success": true, "class_name": p.class_name, "methods": methods["result"]["content"], "properties": props["result"]["content"]}),
-        )
+        let mut payload = serde_json::json!({"success": true, "class_name": p.class_name, "methods": methods["result"]["content"], "properties": props["result"]["content"], "include_inherited": p.include_inherited});
+        if !p.include_inherited {
+            // Say what was left out, or "no methods" reads as a fact about the class rather
+            // than about the filter.
+            payload["note"] = serde_json::Value::String(
+                "Declared members only — inherited members are omitted. Pass \
+                 include_inherited=true for the full surface."
+                    .into(),
+            );
+        }
+        ok_json(payload)
     }
 
     #[tool(
@@ -12960,5 +13270,151 @@ mod agent_stats_wiring_tests {
                 "say WHICH registry was unreadable: {v}"
             );
         });
+    }
+}
+
+/// #123 / #124 — what `iris_execute` makes of the wrapper's abort line.
+#[cfg(test)]
+mod abort_tests {
+    use super::{parse_abort_frame, runtime_abort_line};
+
+    const AFTER_OUTPUT: &str =
+        "one\ntwo\nERROR: <METHOD DOES NOT EXIST> 148 RunUser+3^IrisDevTmp.Run32b6783ae37d.1 ValidateProduction,Ens.Director";
+    const IMMEDIATE: &str =
+        "ERROR: <METHOD DOES NOT EXIST> 148 RunUser+1^IrisDevTmp.Runc793621a6a7d.1 ValidateProduction,Ens.Director";
+
+    /// The defect: `success` was `!trimmed.starts_with("ERROR: ")`, so the identical trap was
+    /// a failure when it hit line 1 and a success when a Write landed first.
+    #[test]
+    fn the_same_abort_is_detected_with_and_without_prior_output() {
+        assert!(runtime_abort_line(IMMEDIATE).is_some());
+        assert!(
+            runtime_abort_line(AFTER_OUTPUT).is_some(),
+            "an abort after output is still an abort"
+        );
+    }
+
+    #[test]
+    fn the_reported_error_is_the_abort_line_not_the_whole_output() {
+        let abort = runtime_abort_line(AFTER_OUTPUT).unwrap();
+        assert!(
+            abort.starts_with("ERROR: <METHOD DOES NOT EXIST>"),
+            "{abort}"
+        );
+        assert!(
+            !abort.contains("one"),
+            "partial output leaked into error: {abort}"
+        );
+    }
+
+    #[test]
+    fn the_zerror_shape_is_detected_too() {
+        let out =
+            "partial\nERROR($ZERROR): <UNDEFINED>RunUser+1^IrisDevTmp.Runde1eee3e4ec3.1 *pName";
+        assert!(runtime_abort_line(out).is_some());
+    }
+
+    /// The wrapper's own non-`<signal>` failure must still be caught.
+    #[test]
+    fn the_capture_unavailable_sentinel_is_an_abort() {
+        assert!(runtime_abort_line("ERROR: output capture unavailable").is_some());
+    }
+
+    /// A script that prints the word ERROR mid-run and then completes is not an abort.
+    #[test]
+    fn ordinary_output_mentioning_error_is_not_an_abort() {
+        for out in [
+            "ERROR: something the script itself printed\nand then it carried on",
+            "checking...\nno problems found",
+            "",
+        ] {
+            assert!(
+                runtime_abort_line(out).is_none(),
+                "false positive on: {out}"
+            );
+        }
+    }
+
+    /// `RunUser+N` is submitted line N — verified on 2026.1 against a four-line script whose
+    /// third line trapped.
+    #[test]
+    fn the_frame_names_the_submitted_line_and_the_member() {
+        let f = parse_abort_frame(runtime_abort_line(AFTER_OUTPUT).unwrap()).unwrap();
+        assert_eq!(f.signal, "METHOD DOES NOT EXIST");
+        assert_eq!(f.line, Some(3));
+        assert_eq!(f.member, Some("ValidateProduction"));
+        assert_eq!(f.class, Some("Ens.Director"));
+
+        let submitted = "write \"one\",!\nwrite \"two\",!\nset x = ##class(Ens.Director).ValidateProduction()\nwrite \"four\",!";
+        assert_eq!(
+            submitted.lines().nth(f.line.unwrap() - 1),
+            Some("set x = ##class(Ens.Director).ValidateProduction()")
+        );
+    }
+
+    /// The suggestion list is only worth attaching if it is ranked. The first cut scored on
+    /// leading prefix alone, so `ValidateProduction` — nothing in `Ens.Director` starts with V —
+    /// scored zero everywhere and the caller was offered `Console` and
+    /// `actualizeProductionDifferences`. These are the real declared members of Ens.Director.
+    #[test]
+    fn members_are_ranked_by_shared_word_then_shape() {
+        let mut names: Vec<String> = [
+            "actualizeProductionDifferences",
+            "CleanProduction",
+            "Console",
+            "CreateBusinessService",
+            "DeleteProduction",
+            "GetProductionStatus",
+            "RestartProduction",
+            "StartProduction",
+            "StopProduction",
+            "SystemStart",
+        ]
+        .iter()
+        .map(|s| s.to_string())
+        .collect();
+        super::rank_members(&mut names, "ValidateProduction");
+
+        let top: Vec<&str> = names.iter().take(6).map(String::as_str).collect();
+        for want in ["StartProduction", "StopProduction", "RestartProduction"] {
+            assert!(top.contains(&want), "{want} missing from top 6: {top:?}");
+        }
+        for noise in ["Console", "CreateBusinessService", "SystemStart"] {
+            assert!(
+                !top.contains(&noise),
+                "{noise} should not outrank a *Production: {top:?}"
+            );
+        }
+        // Two-word members beat the three-word one that merely shares the word.
+        assert!(
+            names.iter().position(|n| n == "StartProduction")
+                < names
+                    .iter()
+                    .position(|n| n == "actualizeProductionDifferences"),
+            "{names:?}"
+        );
+    }
+
+    #[test]
+    fn camel_words_splits_on_case() {
+        assert_eq!(
+            super::camel_words("ValidateProduction"),
+            ["validate", "production"]
+        );
+        assert_eq!(
+            super::camel_words("getProductionItems"),
+            ["get", "production", "items"]
+        );
+        assert_eq!(super::camel_words("Name"), ["name"]);
+    }
+
+    /// A `<SYNTAX>` abort carries no member pair; the line number is still the useful half.
+    #[test]
+    fn a_syntax_abort_still_yields_its_line() {
+        let f =
+            parse_abort_frame("ERROR: <SYNTAX> 3 RunUser+1^IrisDevTmp.Runc793621a6a7d.1").unwrap();
+        assert_eq!(f.signal, "SYNTAX");
+        assert_eq!(f.line, Some(1));
+        assert_eq!(f.class, None);
     }
 }


### PR DESCRIPTION
Three error-surface defects, all measured against the eval corpus before and
verified live on IRIS 2026.1 after.

#123 — `iris_execute`'s success flag was decided by whether the script had
written anything BEFORE the trap fired, not by whether it died. The test was
`trimmed.starts_with("ERROR: ")`, so the identical `<SYNTAX>` abort came back
`success:false` when it hit line 1 and `success:true` when a Write landed first:
352 of 720 abort-carrying envelopes in the corpus reported success, every one of
them with no `error_code` for a caller to branch on. On opencode, which raises on
`success:false`, that is the difference between the agent seeing a failure and
seeing nothing at all.

`runtime_abort_line` now finds the wrapper's own rendering wherever it lands.
Anchored to the LAST non-empty line, because the trap aborts execution and
nothing follows it — a script that prints the word ERROR mid-run and then
completes is not an abort. The old blanket prefix test is replaced by an exact
match on the one non-`<signal>` failure the wrapper emits, `ERROR: output
capture unavailable`, so nothing that was detected before stops being detected
while the false-positive surface shrinks. The partial `output` is kept, as
asked; `error` now carries the abort LINE rather than the whole transcript.

#124 — those aborts named `RunUser+3^IrisDevTmp.Run<hash>.1`, a location in a
routine the caller never submitted and cannot fetch, with a hash that changes
every call so two identical errors did not even look identical. Agents did not
recover: 54% of affected runs never called an introspection tool afterwards, and
70% of missing symbols were never retried.

The server wrote that routine, so it knows the mapping. `RunUser+N` is submitted
line N — verified on 2026.1 against a four-line script whose third line trapped —
and the error now carries `source_line`, `source_line_number` and `signal`. On
`<METHOD DOES NOT EXIST>` / `<PROPERTY DOES NOT EXIST>` it also attaches the
class's DECLARED members, ranked against the name that was wrong.

Ranking matters more than attaching. A leading-prefix score offered `Console` for
`ValidateProduction`, because nothing in `Ens.Director` starts with a V. Scoring
on shared CamelCase words, then on shape, now answers `RecoverProduction,
RestartProduction, DeleteProduction, UpdateProduction, CleanProduction,
StartProduction, StopProduction`.

`docs_introspect` gains `include_inherited`, default false, because it was the
documented way out of that question and returned every inherited member.
Measured on this instance:

    Ens.Config.Production   451 -> 70 methods    44,321 -> 9,020 bytes
    EnsLib.HL7.Message      649 -> 108 methods   61,252 -> 14,184 bytes

The response says what was filtered, so "no methods" cannot be read as a fact
about the class when it is a fact about the flag.

#125 — every production failure returned `INTEROP_ERROR`, so a caller had to
pattern-match English prose out of `error`, and the five conditions underneath
want opposite responses. `classify_interop_failure` splits them into
PRODUCTION_NOT_FOUND, PRODUCTION_ALREADY_RUNNING, CONFIG_ITEM_INVALID and
MISSING_CLASS, keeps INTEROP_ERROR as the fallback, lifts the config item and the
missing class out of the prose into fields, and echoes the production name the
caller supplied — which was being dropped, so "that production does not exist"
and "you named nothing" read identically.

`start` is idempotent: already-running is the goal state, and reporting it as a
failure meant a retry loop could never converge. Only when the SAME production is
up — a different one running is a real conflict, and the envelope now names both.

The two prefix shapes one tool emitted, `ERROR:ERROR <Ens>…` (GetErrorText adds
its own) and `ERROR:INTEROP_ERROR:…`, are normalised away.

Closes #123
Closes #124
Closes #125

🤖 Generated with [Claude Code](https://claude.com/claude-code)