### PR TITLE
chore(release): 0.9.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -945,7 +945,7 @@ dependencies = [
 
 [[package]]
 name = "iris-agentic-dev"
-version = "0.8.5"
+version = "0.9.0"
 dependencies = [
  "anyhow",
  "chrono",
@@ -963,7 +963,7 @@ dependencies = [
 
 [[package]]
 name = "iris-agentic-dev-core"
-version = "0.8.5"
+version = "0.9.0"
 dependencies = [
  "anyhow",
  "bollard",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "0.8.5"
+version = "0.9.0"
 edition = "2021"
 authors = ["Thomas Dyar <thomas.dyar@intersystems.com>"]
 license = "MIT"


### PR DESCRIPTION
Minor, not patch. No new tools — the interop profile is still 23 and the full
registry still 58 — but the tool CONTRACT moved in four places a consumer can
key on:

- `iris_execute` now reports `success: false` for a script that aborted after
  writing output. Anything treating `success: true` as "it ran" sees results it
  did not see before (#123).
- `iris_production`/`iris_production_item` no longer answer every failure with
  `INTEROP_ERROR`; four conditions now have their own codes, and `start` returns
  success when the production is already running (#125).
- `docs_introspect` returns declared members only unless `include_inherited=true`
  (#124).
- `iris_production_item` acts on the production the caller named rather than
  whatever is running (#119).

0.8.5 was bumped but never tagged, so its number is reused rather than burned.

Ten commits since v0.8.4-interop, all fixes: #98-#102, #104-#110, #112, #114,
#118-#120, #123-#126, plus the stale `iris_execute` description.

## Verified on the release binary, against live IRIS 2026.1 (localhost:43080, APP)

```
--version / serverInfo                      iris-interop-dev 0.9.0
iris_execute, abort after output            success:false + IRIS_RUNTIME_ERROR   (#123)
  "one/two/ValidateProduction()"            source_line + "Line 3 ... is what failed"  (#124)
  did_you_mean                              RecoverProduction, RestartProduction, StartProduction…
docs_introspect Ens.Config.Production       451 -> 70 methods, 44,321 -> 9,020 bytes   (#124)
docs_introspect EnsLib.HL7.Message          649 -> 108 methods, 61,252 -> 14,184 bytes (#124)
iris_production start (already running)     success:true, already_running:true   (#125)
iris_production start (a DIFFERENT one)     PRODUCTION_ALREADY_RUNNING + both names
iris_production start No.Such.Production    PRODUCTION_NOT_FOUND + production echoed
iris_production_item on a STOPPED prod      opens it (ITEM_NOT_FOUND, not "Cannot open")  (#119)
iris_table_info EnsLib.HL7.Message          resolves to EnsLib_HL7.Message       (#120)
iris_query STRING_AGG(...)                  SQLCODE -359 + hint naming LIST()    (#126)
```

Gate: **624 passed / 0 failed / 1 ignored** on rust 1.98, the toolchain CI uses. fmt and clippy clean.
`e2e-tests` (master-only, skipped by the `pull_request` event) was dispatched explicitly on every branch that fed this release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)