### PR TITLE
chore: stop pointing the plugin at an archived repo

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,11 +1,11 @@
 {
   "name": "iris-interop-dev",
-  "description": "Streamlined, interop-focused fork of iris-agentic-dev — 20 IRIS Interoperability tools (fixed iris_execute/iris_query/iris_production), distinct MCP server name so it coexists with the original. Single binary, no Python required.",
+  "description": "Streamlined, interop-focused fork of iris-agentic-dev — 23 IRIS Interoperability tools (fixed iris_execute/iris_query/iris_production), distinct MCP server name so it coexists with the original. Single binary, no Python required.",
   "version": "0.2.0",
   "author": {
     "name": "InterSystems Corporation"
   },
-  "homepage": "https://github.com/PYDuquesnoy/iris-agentic-dev",
+  "homepage": "https://github.com/intersystems-ib/iris-interop-dev",
   "license": "MIT",
   "keywords": [
     "intersystems",


### PR DESCRIPTION
`.claude-plugin/plugin.json` listed `PYDuquesnoy/iris-agentic-dev` as the plugin homepage. That repo is **archived and read-only** — issues there cannot be filed, closed or commented on — so anyone following the link from a plugin listing lands somewhere no work can happen. Repointed at this fork.

The tool count in the same `description` was also stale: the interop toolset has been **23** since v0.8.0, not 20.

Swept the tree for other references while I was there. Every remaining `PYDuquesnoy` hit is either the **live** `PYDuquesnoy/iris-agentic-dev-1` (the fork upstream PRs are opened from — deliberately kept) or the repo-local git identity. `Cargo.toml`'s `repository` points at `intersystems-community/iris-agentic-dev`, which is upstream attribution, not the archived personal fork — left alone.

Two lines, no code paths touched; `plugin.json` re-parsed as valid JSON after the edit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)