### PR TITLE
chore(release): 0.9.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -945,7 +945,7 @@ dependencies = [
 
 [[package]]
 name = "iris-agentic-dev"
-version = "0.9.0"
+version = "0.9.1"
 dependencies = [
  "anyhow",
  "chrono",
@@ -963,7 +963,7 @@ dependencies = [
 
 [[package]]
 name = "iris-agentic-dev-core"
-version = "0.9.0"
+version = "0.9.1"
 dependencies = [
  "anyhow",
  "bollard",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "0.9.0"
+version = "0.9.1"
 edition = "2021"
 authors = ["Thomas Dyar <thomas.dyar@intersystems.com>"]
 license = "MIT"


### PR DESCRIPTION
Bumps the workspace to **0.9.1** so `v0.9.1-interop` can be tagged — `release.yml` refuses to publish when the tag and `Cargo.toml` disagree.

### Why patch and not minor

The recorded test is whether the tool **contract moved** where a consumer keys on it — that is what made 0.9.0 a minor. Here it only **grew**, and nothing an existing call returns for an existing input changed shape:

| change | contract effect |
|---|---|
| #137 / #138 compile-time code visibility | `compile_time_methods` + note appear **only** for a class declaring `CodeMode = objectgenerator`; an ordinary write returns exactly the payload it did before. `COMPILE_TIME_CODE_BLOCKED` is reachable only under `IRIS_BLOCK_CODEGEN=1`, which defaults off |
| #136 / #140 %UnitTest discovery | corrects three pieces of diagnostic text and the `Test*` count behind them — a fix, no new surface |
| #135 dependency sweep | none |
| #139 plugin metadata | none |

Still **23 interop / 58 total** tools.

### What ships

Four merges since `v0.9.0-interop`, all CI-green on master including `e2e-tests`:

- `95cfff8` #135 — five cargo bumps, two majors (`toml` 1.x, `dirs` 6), e2e-verified on a dispatched run
- `593a688` #139 — plugin homepage off the archived `PYDuquesnoy/iris-agentic-dev`
- `9f67712` #138 — name the methods that will run at compile time (#137)
- `3fcfe8c` #140 — %UnitTest discovers by name, not by method kind (#136)

### Gate

fmt clean, `clippy --all-targets -D warnings` clean, **1170 passed / 0 failed / 46 ignored**. `target/debug/iris-interop-dev --version` reports `0.9.1`, so the release job's binary-vs-Cargo guard will match.

🤖 Generated with [Claude Code](https://claude.com/claude-code)