### PR TITLE
chore(release): 0.10.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -945,7 +945,7 @@ dependencies = [
 
 [[package]]
 name = "iris-agentic-dev"
-version = "0.9.1"
+version = "0.10.0"
 dependencies = [
  "anyhow",
  "chrono",
@@ -963,7 +963,7 @@ dependencies = [
 
 [[package]]
 name = "iris-agentic-dev-core"
-version = "0.9.1"
+version = "0.10.0"
 dependencies = [
  "anyhow",
  "bollard",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "0.9.1"
+version = "0.10.0"
 edition = "2021"
 authors = ["Thomas Dyar <thomas.dyar@intersystems.com>"]
 license = "MIT"


### PR DESCRIPTION
Bumps the workspace to **0.10.0** so `v0.10.0-interop` can be tagged — `release.yml` refuses to publish when the tag and `Cargo.toml` disagree.

### Why minor and not patch

The recorded test is whether the tool **contract moved** where a consumer keys on it. 0.9.1 only *grew*, so it was a patch. Four of these five change what an **existing call returns for an existing input**:

| fix | contract effect |
|---|---|
| #142 `iris_debug` | returns `ROUTINE_NOT_FOUND` / `INVALID_PARAM` / `UNSUPPORTED_IRIS_VERSION` where it returned `success: true`, and **`source_location` is removed** — replaced by `signal`/`class`/`method`/`offset`/`mapped_to_source_line`. A removed field is the strongest form of the test |
| #143 `iris_interop_query` | now **refuses** a `body_select` shape it used to accept-and-ignore, so a call that returned `success: true` can now return `INVALID_PARAM` |
| #146 `iris_business_rule_info` | **succeeds** where it returned `RULE_NOT_PROJECTED`, with a new `source: class_xdata` |
| #145 `iris_execute` | sets `SQLCODE`/`%ROWCOUNT`, so code that aborted after a committed write now completes |
| #144 `iris_lookup_transfer` | the only purely additive one (`mode`, `entries_applied`) |

Still **23 interop / 58 total** tools — the count is not the test.

### What ships

Three merges since `v0.9.1-interop`, all CI-green on master including `e2e-tests`:

- `5ad9194` #147 — `body_select` shapes (#143) + the `&sql` contract (#145)
- `8144ad4` #148 — `iris_debug` fails closed (#142)
- `41a9729` #149 — lookup import mode (#144) + rule XData fallback (#146)

### Gate

fmt clean, `clippy --all-targets -D warnings` clean, **1192 passed / 0 failed / 46 ignored**. `target/debug/iris-interop-dev --version` reports `0.10.0`, so the release job's binary-vs-Cargo guard will match.

### Note for the eval harness

Four of these change output a grader could key on. The pin should not move to 0.10.x until those are checked — flagged to the testsuite separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)