### PR TITLE
fix(#151,#152,#153): make iris_message_body reachable and let iris_production_diff answer without SCM

### DIFF
--- a/crates/iris-agentic-dev-core/src/tools/interop.rs
+++ b/crates/iris-agentic-dev-core/src/tools/interop.rs
@@ -2556,9 +2556,24 @@ pub struct MessageBodyParams {
     pub max_bytes: u32,
     #[serde(default)]
     pub acknowledge_phi: bool,
+    // #151: the dispatcher READ this option but the schema never declared it, so a
+    // schema-validating client could not send it and the tool was pinned at `block` —
+    // i.e. unreachable for its whole purpose. The enum belongs in the SCHEMA, not only
+    // in the error text; same reasoning as #112 for `action`. Keep the doc comment below
+    // user-facing: schemars renders it as the field's title/description, which is what a
+    // model reads before choosing a value.
+    /// PHI gate. block (default) refuses to read the body at all; redact blanks known
+    /// HL7 v2 PHI fields (PID-3/5/7/8/11/18, MSH-3); allow returns the body unredacted
+    /// and additionally requires acknowledge_phi=true.
+    #[schemars(extend("enum" = ["block", "redact", "allow"]))]
+    #[serde(default = "default_data_policy")]
+    pub data_policy: String,
 }
 fn default_max_bytes() -> u32 {
     65536
+}
+fn default_data_policy() -> String {
+    "block".to_string()
 }
 
 #[derive(Debug, Deserialize, JsonSchema)]
@@ -2755,6 +2770,39 @@ If body.%Extends("Ens.StreamContainer") {{
   }} Catch ex {{
     Write "ERROR:BODY_READ_ERROR:"_ex.DisplayString()
   }}
+}} ElseIf body.%Extends("%Persistent") {{
+  Set cdef=##class(%Dictionary.CompiledClass).%OpenId(bodyClass)
+  If '$IsObject(cdef) {{ Write "ERROR:UNSUPPORTED_BODY_CLASS:"_bodyClass Quit }}
+  Set obj={{}}
+  For i=1:1:cdef.Properties.Count() {{
+    Set pd=cdef.Properties.GetAt(i)
+    If '$IsObject(pd) {{ Continue }}
+    Set nm=pd.Name
+    If $Extract(nm)="%" {{ Continue }}
+    If pd.Private {{ Continue }}
+    If pd.Calculated {{ Continue }}
+    If pd.MultiDimensional {{ Continue }}
+    If pd.Relationship {{ Continue }}
+    Set val=""
+    Try {{
+      Set val=$Property(body,nm)
+    }} Catch pex {{
+      Set val=""
+    }}
+    If $IsObject(val) {{
+      If val.%Extends("%Stream.Object") {{
+        Set val=val.Read({max_bytes})
+      }} Else {{
+        Set val="<"_val.%ClassName(1)_">"
+      }}
+    }}
+    Do obj.%Set(nm,val)
+  }}
+  Set content=obj.%ToJSON()
+  Set full=$Length(content)
+  If full>{max_bytes} {{ Set content=$Extract(content,1,{max_bytes}) }}
+  Write "OK:"_full_":"
+  Write content
 }} Else {{
   Write "ERROR:UNSUPPORTED_BODY_CLASS:"_bodyClass
 }}"#
@@ -2766,6 +2814,18 @@ pub async fn handle_iris_message_body(
     params: &MessageBodyParams,
     data_policy: &str,
 ) -> Result<CallToolResult, McpError> {
+    // #151: an unrecognised value used to fall straight through — not "block", not
+    // "allow", and not "redact" at the end, so a typo like `dataPolicy=Allow` returned
+    // the body UNREDACTED with no acknowledgement. Validate before any gate.
+    if !matches!(data_policy, "block" | "redact" | "allow") {
+        return err_json(
+            "INVALID_PARAM",
+            &format!(
+                "data_policy '{data_policy}' is not one of block, redact, allow — refusing \
+                 rather than falling through to an unredacted read"
+            ),
+        );
+    }
     if data_policy == "block" {
         return err_json(
             "PHI_POLICY_BLOCKED",
@@ -3243,18 +3303,17 @@ If $System.Status.IsError(sc)||('isInSC) {{ Write "NO_SCM" }} Else {{ Write "IN_
         pass_expr = os_str_expr(&iris.password),
         doc_expr = os_str_expr(&doc_name),
     );
-    match iris.execute_via_generator(&scm_code, ns, &client).await {
-        Ok(out) if out.trim() == "NO_SCM" => {
-            return err_json(
-                "NO_SCM",
-                &format!(
-                    "No source control is configured for '{doc_name}' in namespace '{ns}' — there is no committed source to diff against"
-                ),
-            )
-        }
-        Ok(_) => {}
+    // #153: this used to hard-refuse with NO_SCM. The baseline below is an Atelier
+    // `GET /doc/<name>`, which reads the class definition out of the namespace and needs
+    // no source control at all — verified in a namespace that answered NO_SCM while
+    // iris_doc(mode=get) returned the full ProductionDefinition XData. So the refusal
+    // named a cause that was not the reason and blocked a diff the code can compute, in
+    // every eval namespace and most dev namespaces. Report the baseline, do not enforce it.
+    let baseline = match iris.execute_via_generator(&scm_code, ns, &client).await {
+        Ok(out) if out.trim() == "IN_SCM" => "source_control",
+        Ok(_) => "class_definition",
         Err(e) => return err_json(classify_iris_error(&e.to_string()), &e.to_string()),
-    }
+    };
 
     let exists_code = format!(
         r#"Write ##class(%Dictionary.ClassDefinition).%ExistsId({prod_expr})"#,
@@ -3315,7 +3374,30 @@ If $System.Status.IsError(sc)||('isInSC) {{ Write "NO_SCM" }} Else {{ Write "IN_
             let source = crate::tools::doc::doc_content_to_string(&body);
             parse_production_items_from_source(&source)
         }
-        _ => Vec::new(),
+        // #153: this arm used to be `_ => Vec::new()`. An empty baseline is
+        // indistinguishable from "the committed production has no items", so a failed
+        // fetch reported EVERY running item as `added` under success:true — the
+        // silent-wrong shape of #123 and #143. Fail instead.
+        Ok(resp) => {
+            let status = resp.status();
+            return err_json(
+                "BASELINE_UNAVAILABLE",
+                &format!(
+                    "Could not read the class definition for '{doc_name}' in namespace \
+                     '{ns}' (Atelier GET returned HTTP {status}) — refusing rather than \
+                     diffing against an empty baseline, which would report every running \
+                     item as `added`"
+                ),
+            );
+        }
+        Err(e) => {
+            return err_json(
+                "BASELINE_UNAVAILABLE",
+                &format!(
+                    "Could not read the class definition for '{doc_name}' in namespace '{ns}': {e}"
+                ),
+            );
+        }
     };
 
     let mut changes = Vec::new();
@@ -3347,6 +3429,8 @@ If $System.Status.IsError(sc)||('isInSC) {{ Write "NO_SCM" }} Else {{ Write "IN_
         "namespace": ns,
         "in_sync": changes.is_empty(),
         "changes": changes,
+        // #153: name what the diff was taken against, so "in_sync" is interpretable.
+        "baseline": baseline,
     }))
 }
 
@@ -3870,6 +3954,75 @@ mod tests {
         assert!(edi.contains("Set full=$Length(content)"), "{edi}");
         assert!(edi.contains("If full>4096"), "{edi}");
         assert!(edi.contains("$Extract(content,1,4096)"), "{edi}");
+    }
+
+    // ─── #152: a custom Ens.Request / %Persistent body ───
+
+    /// The four original branches cover containers, streams and EDI documents; a custom
+    /// `Ens.Request` with typed properties — the shape the `messages` skill teaches — fell
+    /// straight through to UNSUPPORTED_BODY_CLASS.
+    #[test]
+    fn a_custom_persistent_body_has_its_own_branch() {
+        let code = build_message_body_code(16, 65536);
+        assert!(code.contains(r#"%Extends("%Persistent")"#), "{code}");
+        assert!(code.contains("%Dictionary.CompiledClass"), "{code}");
+        assert!(code.contains("obj.%ToJSON()"), "{code}");
+    }
+
+    /// Ordering is load-bearing: `Ens.StreamContainer` and `Ens.StringContainer` ARE
+    /// %Persistent, so a %Persistent branch placed before them would swallow both and
+    /// render a container as a property bag instead of reading its payload.
+    #[test]
+    fn the_persistent_branch_is_last_so_containers_are_not_swallowed() {
+        let code = build_message_body_code(16, 65536);
+        let persistent = code.find(r#"%Extends("%Persistent")"#).unwrap();
+        for cls in [
+            "Ens.StreamContainer",
+            "%Stream.Object",
+            "Ens.StringContainer",
+            "EnsLib.EDI.Document",
+        ] {
+            let at = code.find(&format!(r#"%Extends("{cls}")"#)).unwrap();
+            assert!(
+                at < persistent,
+                "{cls} must be tested before %Persistent, else it is swallowed: {code}"
+            );
+        }
+    }
+
+    /// A property bag is only useful if it holds readable values: private, calculated,
+    /// multidimensional and relationship properties cannot be rendered and `%`-prefixed
+    /// ones are system bookkeeping.
+    #[test]
+    fn the_persistent_branch_skips_properties_it_cannot_render() {
+        let code = build_message_body_code(16, 65536);
+        let branch = code.split(r#"%Extends("%Persistent")"#).nth(1).unwrap();
+        for guard in [
+            "pd.Private",
+            "pd.Calculated",
+            "pd.MultiDimensional",
+            "pd.Relationship",
+            r#"$Extract(nm)="%""#,
+        ] {
+            assert!(branch.contains(guard), "missing guard {guard}: {branch}");
+        }
+    }
+
+    /// Same #55 trap as the EDI branch: report the FULL length before cutting, or a
+    /// truncated body understates its own size.
+    #[test]
+    fn the_persistent_branch_reports_full_size_before_truncating() {
+        let code = build_message_body_code(16, 4096);
+        let branch = code.split(r#"%Extends("%Persistent")"#).nth(1).unwrap();
+        assert!(branch.contains("Set full=$Length(content)"), "{branch}");
+        assert!(branch.contains("If full>4096"), "{branch}");
+        assert!(branch.contains("$Extract(content,1,4096)"), "{branch}");
+    }
+
+    /// The generated branch must still be syntactically whole — the #6 <SYNTAX> guard.
+    #[test]
+    fn the_persistent_branch_generates_valid_objectscript() {
+        assert_valid_objectscript_lines(&build_message_body_code(16, 65536));
     }
 
     // ─── #63: one reader for the production-name argument ───

--- a/crates/iris-agentic-dev-core/src/tools/mod.rs
+++ b/crates/iris-agentic-dev-core/src/tools/mod.rs
@@ -7279,8 +7279,12 @@ Methods:
             }
         }
         // Default block: a body can carry patient data, so reading one is opt-in.
+        // #151: read the DECLARED (snake_case) name first — the schema is generated from
+        // MessageBodyParams, so that is the only spelling a conformant client can send.
+        // The camelCase spelling stays as an alias so existing callers keep working.
         let data_policy = p
-            .get("dataPolicy")
+            .get("data_policy")
+            .or_else(|| p.get("dataPolicy"))
             .and_then(|v| v.as_str())
             .unwrap_or("block")
             .to_string();
@@ -7296,10 +7300,16 @@ Methods:
                     .unwrap_or_default(),
                 namespace,
                 max_bytes: p.get("max_bytes").and_then(|v| v.as_u64()).unwrap_or(65536) as u32,
+                // #151: declared as `acknowledge_phi`, previously read only as
+                // `acknowledgePhi` — so the one name a conformant client could discover
+                // was the one that did nothing, and the refusal blamed the caller for
+                // omitting what it had supplied.
                 acknowledge_phi: p
-                    .get("acknowledgePhi")
+                    .get("acknowledge_phi")
+                    .or_else(|| p.get("acknowledgePhi"))
                     .and_then(|v| v.as_bool())
                     .unwrap_or(false),
+                data_policy: data_policy.clone(),
             },
             &data_policy,
         )

--- a/crates/iris-agentic-dev-core/tests/interop_unit_tests.rs
+++ b/crates/iris-agentic-dev-core/tests/interop_unit_tests.rs
@@ -587,6 +587,7 @@ mod interop_depth_guards {
                 namespace: "USER".into(),
                 max_bytes: 65536,
                 acknowledge_phi: false,
+                data_policy: "block".into(),
             },
             "block",
         ));
@@ -603,6 +604,7 @@ mod interop_depth_guards {
                 namespace: "USER".into(),
                 max_bytes: 65536,
                 acknowledge_phi: false,
+                data_policy: "allow".into(),
             },
             "allow",
         ));
@@ -619,11 +621,35 @@ mod interop_depth_guards {
                 namespace: "USER".into(),
                 max_bytes: 65536,
                 acknowledge_phi: true,
+                data_policy: "allow".into(),
             },
             "allow",
         ));
         let v = tool_payload(&r);
         assert_eq!(v["error_code"], "INVALID_MESSAGE_ID", "{v}");
+    }
+
+    /// #151: the three checks were `== "block"`, `== "allow"` and a final `== "redact"`,
+    /// so a value matching none of them — `Allow`, `none`, a typo — passed every gate and
+    /// reached the final branch, which returned the body UNREDACTED and unacknowledged.
+    /// Validation has to happen before the gates, not between them.
+    #[test]
+    fn an_unrecognised_policy_is_refused_rather_than_read_unredacted() {
+        for bogus in ["Allow", "ALLOW", "none", "redact ", ""] {
+            let r = rt().block_on(handle_iris_message_body(
+                None,
+                &MessageBodyParams {
+                    message_id: "1".into(),
+                    namespace: "USER".into(),
+                    max_bytes: 65536,
+                    acknowledge_phi: true,
+                    data_policy: bogus.into(),
+                },
+                bogus,
+            ));
+            let v = tool_payload(&r);
+            assert_eq!(v["error_code"], "INVALID_PARAM", "policy {bogus:?}: {v}");
+        }
     }
 
     #[test]


### PR DESCRIPTION
Three defects reported by the eval suite from gen-6 scenario authoring. All three were reproduced live on 0.10.0 against IRIS 2026.1 Build 235U **before** being fixed, and the fixes re-verified live on the same instance.

### #151 — `iris_message_body` was unreachable from a schema-conformant client

The dispatcher read `dataPolicy` and `acknowledgePhi` in **camelCase** off a loose `Described<>` map, while the schema is generated from `MessageBodyParams`, which declares `acknowledge_phi` and had **no `data_policy` field at all**. The option gating the whole tool could not be sent by a schema-validating client, and the ack could only be sent under a name the schema never advertised.

Same call, only the ack spelling differs — before:

```
dataPolicy=allow + acknowledge_phi=true   (the SCHEMA name)  -> PHI_ACK_REQUIRED
dataPolicy=allow + acknowledgePhi=true    (the READ name)    -> passes the gate
```

After — both spellings work, and `data_policy` is now declared with its enum in the schema (same reasoning as #112 for `action`):

```
properties: ['acknowledge_phi', 'data_policy', 'max_bytes', 'message_id', 'namespace']
data_policy: {"enum": ["block","redact","allow"], "default": "block", ...}
```

**Also fixes a PHI bypass found while reading that path.** The gates were `== "block"`, `== "allow"` and a final `== "redact"`, so a value matching none of them passed every gate and reached the final branch, which returned the body **unredacted and unacknowledged**:

```
data_policy="Allow"  ->  before: the body, in the clear
                         after:  INVALID_PARAM
```

### #152 — `iris_message_body` could not read a custom `Ens.Request` / `%Persistent` body

The four `%Extends` branches covered containers, streams and EDI documents; a custom `Ens.Request` with typed properties — the shape the `messages` skill teaches — fell through to `UNSUPPORTED_BODY_CLASS`. Adds a property-walking branch:

```
before: UNSUPPORTED_BODY_CLASS: Body class 'Probe.MSG.CustomBody' is not a supported body type
after:  {"ExamCode":"CT-ABD","PatientId":"P-4471","Score":87}   content_type=JSON
```

Placed **last** on purpose, and there is a test pinning the order: `Ens.StreamContainer` and `Ens.StringContainer` are themselves `%Persistent`, so an earlier branch would swallow them and render a container as a property bag instead of reading its payload.

### #153 — `iris_production_diff` refused with `NO_SCM` although its baseline is Atelier, not source control

The gate was gratuitous. The baseline is an Atelier `GET /doc/<name>`, which reads the class definition out of the namespace and needs no SCM — confirmed by `iris_doc(mode=get)` returning the full `ProductionDefinition` XData in the very namespace that answered `NO_SCM`.

```
before: NO_SCM: No source control is configured for 'Vitals.Production.cls' ...
after:  {"baseline":"class_definition","in_sync":true,"changes":[], ...}
```

Positive check that the baseline is genuinely parsed and compared, not merely skipped: `Boiler.Production` has 5 `<Item>` elements in source and 5 runtime items and reports `in_sync: true` — an empty baseline would have reported all 5 as `added`.

**Second defect in the same path.** A failed baseline fetch fell to `_ => Vec::new()` — an empty baseline indistinguishable from "the committed production has no items" — so a fetch failure reported every running item as `added` under `success:true`, the silent-wrong shape of #123 and #143. Now `BASELINE_UNAVAILABLE`.

### Scope check

These were the only camelCase *parameter* reads in the crate. `grep -rnoE '\.get\("[A-Za-z_]*[A-Z][A-Za-z_]*"\)'` returns 12 hits; the other 10 are SQL column names, JSON-schema keywords and HTTP headers, all correct. Not systemic.

### Verification

Gate 1198 passed / 0 failed (up 6: five codegen tests plus the policy-bypass test), fmt and clippy clean. `e2e-tests` is master-only, so it is dispatched on this branch rather than relying on the `pull_request` run.

Closes #151
Closes #152
Closes #153

🤖 Generated with [Claude Code](https://claude.com/claude-code)