### PR TITLE
chore(release): 0.11.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -945,7 +945,7 @@ dependencies = [
 
 [[package]]
 name = "iris-agentic-dev"
-version = "0.10.0"
+version = "0.11.0"
 dependencies = [
  "anyhow",
  "chrono",
@@ -963,7 +963,7 @@ dependencies = [
 
 [[package]]
 name = "iris-agentic-dev-core"
-version = "0.10.0"
+version = "0.11.0"
 dependencies = [
  "anyhow",
  "bollard",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "0.10.0"
+version = "0.11.0"
 edition = "2021"
 authors = ["Thomas Dyar <thomas.dyar@intersystems.com>"]
 license = "MIT"


### PR DESCRIPTION
MINOR, not patch: two tool contracts moved where a consumer keys on them.

| tool | 0.10.0 | 0.11.0 |
|---|---|---|
| `iris_message_body` | 4 schema properties; `dataPolicy` read but never declared, so a schema-validating client could not send it and the tool was pinned at `block` | 5 properties; `data_policy` declared with its enum, `acknowledge_phi` read under its declared name (camelCase kept as alias) |
| `iris_production_diff` | `NO_SCM` refusal in any namespace without source control | `success:true` with `baseline: source_control\|class_definition`; `BASELINE_UNAVAILABLE` where a failed fetch used to yield an empty baseline |

Also shipping, not contract moves: `iris_message_body` reads a custom `Ens.Request` / `%Persistent` body as JSON (#152), and an unrecognised `data_policy` is refused rather than falling through every gate to return the body unredacted (#151).

Tool count unchanged at 23 of 58 registrations — the count is not the test for minor; the contract is.

Gate 1198 passed / 0 failed, fmt and clippy clean, release binary self-reports `iris-interop-dev 0.11.0`. `e2e-tests` dispatched on this branch since the `pull_request` run skips it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)