### PR TITLE
fix(#159): detect an abort concatenated onto the script's own output line

### DIFF
--- a/crates/iris-agentic-dev-core/src/tools/mod.rs
+++ b/crates/iris-agentic-dev-core/src/tools/mod.rs
@@ -3155,16 +3155,34 @@ fn abort_wants_member_list(signal: &str) -> bool {
 /// legitimately prints the word ERROR mid-run from being reported as an abort. The
 /// leading-prefix test is kept as well, so nothing detected before stops being detected.
 pub fn runtime_abort_line(output: &str) -> Option<&str> {
-    fn is_abort(line: &str) -> bool {
-        let t = line.trim();
-        matches!(
-            t.strip_prefix("ERROR: ").or_else(|| t.strip_prefix("ERROR($ZERROR): ")),
-            Some(rest) if rest.starts_with('<')
-        )
+    /// #159: the abort is not always at the START of the last line. A script whose final
+    /// `Write` did not end in `,!` leaves the trap concatenated onto its own output —
+    /// `ROW=ERROR: <SYNTAX> …` — and a `strip_prefix` test misses it, so a hard abort came
+    /// back `success:true` or not depending on one character. Measured over the eval corpus
+    /// at 0.8.4: 209 aborts at line start, 189 mid-line.
+    ///
+    /// Still anchored to the last non-empty line, which is what keeps a script that
+    /// legitimately prints the word ERROR mid-run from being called an abort — a bare
+    /// substring test over the whole output would lose that. Taking the LAST marker on that
+    /// line to end-of-line also drops the script's own output out of the `error` field,
+    /// which returning the whole line would have carried into it.
+    fn abort_tail(line: &str) -> Option<&str> {
+        let mut best: Option<usize> = None;
+        for marker in ["ERROR: ", "ERROR($ZERROR): "] {
+            let mut from = 0;
+            while let Some(i) = line[from..].find(marker) {
+                let at = from + i;
+                if line[at + marker.len()..].starts_with('<') {
+                    best = Some(best.map_or(at, |b: usize| b.max(at)));
+                }
+                from = at + 1;
+            }
+        }
+        best.map(|i| line[i..].trim_end())
     }
     let last = output.lines().rev().find(|l| !l.trim().is_empty())?;
-    if is_abort(last) {
-        return Some(last.trim());
+    if let Some(tail) = abort_tail(last.trim()) {
+        return Some(tail);
     }
     // The wrapper's one non-`<signal>` failure, emitted when the device redirect could not be
     // established. Matched exactly rather than by the old blanket `starts_with("ERROR: ")`,
@@ -13633,6 +13651,56 @@ mod abort_tests {
         let out =
             "partial\nERROR($ZERROR): <UNDEFINED>RunUser+1^IrisDevTmp.Runde1eee3e4ec3.1 *pName";
         assert!(runtime_abort_line(out).is_some());
+    }
+
+    // ─── #159: the abort concatenated onto the script's own output ───
+
+    /// One character decided this. `Write "ROW=",!` reported the abort and `Write "ROW="`
+    /// did not, because the trap landed on the same line as the output and the old
+    /// `strip_prefix` test saw `ROW=`. Reproduced live on 0.11.0 before the fix.
+    #[test]
+    fn an_abort_concatenated_onto_the_output_line_is_still_an_abort() {
+        let out = "ROW=ERROR: <CLASS DOES NOT EXIST> 150 RunUser+1^IrisDevTmp.Runa8.1 No.Such";
+        assert!(runtime_abort_line(out).is_some(), "{out}");
+    }
+
+    /// The reported error must be the abort, not the script's output with the abort glued on.
+    #[test]
+    fn the_reported_abort_drops_the_scripts_own_output() {
+        let out = "PatientId=[ERROR: <OBJECT DISPATCH> 230 RunUser+9^IrisDevTmp.Runb2.1";
+        let abort = runtime_abort_line(out).unwrap();
+        assert!(abort.starts_with("ERROR: <OBJECT DISPATCH>"), "{abort}");
+        assert!(!abort.contains("PatientId="), "{abort}");
+    }
+
+    /// The `<` is what separates an IRIS signal from a script printing the word. A final
+    /// line mentioning `ERROR: ` with no signal after it must NOT become an abort.
+    #[test]
+    fn a_final_line_mentioning_error_without_a_signal_is_not_an_abort() {
+        for out in [
+            "done. ERROR: none",
+            "summary: 0 rows, ERROR: not applicable",
+            "ERROR: something broke",
+        ] {
+            assert!(runtime_abort_line(out).is_none(), "{out}");
+        }
+    }
+
+    /// When the line carries more than one marker the LAST one is the trap — anything
+    /// earlier is the script quoting a previous error.
+    #[test]
+    fn the_last_marker_on_the_line_wins() {
+        let out = "prev=ERROR: <UNDEFINED> x ERROR: <SYNTAX> 3 RunUser+1^IrisDevTmp.Runc3.1";
+        let abort = runtime_abort_line(out).unwrap();
+        assert!(abort.starts_with("ERROR: <SYNTAX>"), "{abort}");
+    }
+
+    /// The `$ZERROR` spelling must work mid-line too.
+    #[test]
+    fn the_zerror_spelling_is_found_mid_line() {
+        let out = "src=0 copy=ERROR($ZERROR): <METHOD DOES NOT EXIST> 148 RunUser+1^X.1 Copy";
+        let abort = runtime_abort_line(out).unwrap();
+        assert!(abort.starts_with("ERROR($ZERROR): <METHOD"), "{abort}");
     }
 
     /// The wrapper's own non-`<signal>` failure must still be caught.


### PR DESCRIPTION
#123 fixed the line-start case and missed the mid-line one — the same premise the issue was filed on ("the script wrote output before aborting"). Found by the eval suite in its 0.11.0 re-mine, with a clean discriminator:

```
pin       unflagged aborts   abort at LINE START   abort MID-LINE
0.8.4            398                 209                189
0.11.0             5                   0                  5
```

Every line-start case is caught; all five residuals are the trap concatenated onto the script's own output.

**One character decided it.** Reproduced live on the installed 0.11.0, IRIS 2026.1 Build 235U:

```
Write "ROW=",! Do ##class(No.Such.Class).Nope()
  -> success:false  IRIS_RUNTIME_ERROR

Write "ROW="   Do ##class(No.Such.Class).Nope()
  -> success:TRUE   no error_code
     output "ROW=ERROR: <CLASS DOES NOT EXIST> 150 RunUser+1^IrisDevTmp.Run….1 No.Such.Class"
```

### The anchor is kept

The last-non-empty-line anchor stays. It is what stops a script that legitimately prints the word ERROR mid-run from being reported as an abort, and the eval suite's independent detector agrees with it on **all 595 stored detections** — the anchor was never the problem. A bare substring test over the whole output would have thrown that away.

Instead, on that line only, take the **last** `ERROR: <` / `ERROR($ZERROR): <` through end of line. The `<` separates an IRIS signal from prose, and returning the tail also drops the script's own output out of the `error` field, which the whole-line return had been carrying into it.

### After

```
Write "ROW=",! … trap        -> IRIS_RUNTIME_ERROR, error = "ERROR: <CLASS DOES NOT EXIST> …"
Write "ROW="   … trap        -> IRIS_RUNTIME_ERROR, error = "ERROR: <CLASS DOES NOT EXIST> …"   (no "ROW=")
Write "ROW=1"                -> success:true
Write "ERROR: none",! …      -> success:true
```

Five new tests cover the mid-line case, the tail extraction, the `$ZERROR` spelling mid-line, last-marker-wins, and the false-positive guard. Gate 1206 passed / 0 failed, fmt and clippy clean. `e2e-tests` dispatched on this branch.

Closes #159

🤖 Generated with [Claude Code](https://claude.com/claude-code)