### PR TITLE
chore(release): 0.12.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -945,7 +945,7 @@ dependencies = [
 
 [[package]]
 name = "iris-agentic-dev"
-version = "0.11.0"
+version = "0.12.0"
 dependencies = [
  "anyhow",
  "chrono",
@@ -963,7 +963,7 @@ dependencies = [
 
 [[package]]
 name = "iris-agentic-dev-core"
-version = "0.11.0"
+version = "0.12.0"
 dependencies = [
  "anyhow",
  "bollard",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "0.11.0"
+version = "0.12.0"
 edition = "2021"
 authors = ["Thomas Dyar <thomas.dyar@intersystems.com>"]
 license = "MIT"


### PR DESCRIPTION
MINOR, not patch: three tool contracts moved where a consumer keys on them. All three fixes came from eval-suite **measurement** against the 0.11.0 cell rather than from speculation.

| tool | 0.11.0 | 0.12.0 |
|---|---|---|
| `iris_execute` | mid-line abort → `success:true`, no `error_code` | `success:false` / `IRIS_RUNTIME_ERROR`; `error` holds only the abort tail, not the script's output (#159) |
| `docs_introspect` | `%File` → `CLASS_NOT_FOUND` (for a class that exists) | success, `class_name: %Library.File`, 74 methods, plus `requested_class_name` and `resolved` (#157) |
| `docs_introspect` | empty declared-only result disclosed by prose only | adds `inherited_omitted: <n>`, note names the number (#156) |

`#123` had fixed the line-start half of its own premise and missed the mid-line half — 209 vs 189 in the corpus at 0.8.4. `docs_introspect('%Foo')` was reporting a class that exists as absent, which is the confident-wrong-answer category `#107` was meant to close.

Tool count unchanged at 23 of 58 registrations — the count is not the test for minor; the contract is.

Gate 1206 passed / 0 failed, fmt and clippy clean, release binary self-reports `iris-interop-dev 0.12.0`. `e2e-tests` dispatched on this branch since the `pull_request` run skips it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)