### PR TITLE
test(#159): pin the abort detector against verbatim captures from the eval corpus

### DIFF
--- a/crates/iris-agentic-dev-core/src/tools/mod.rs
+++ b/crates/iris-agentic-dev-core/src/tools/mod.rs
@@ -13703,6 +13703,39 @@ mod abort_tests {
         assert!(abort.starts_with("ERROR($ZERROR): <METHOD"), "{abort}");
     }
 
+    // ─── #159: verbatim captures from the eval corpus (opencode/deepseek cell) ───
+
+    /// Real stored output, whitespace exact. The abort is glued to the last row of a
+    /// namespace listing (`USER:1:0:`) with no newline, and the signal is `<COMMAND>` —
+    /// a class none of the hand-written fixtures covered.
+    #[test]
+    fn a_captured_command_abort_after_a_namespace_listing_is_detected() {
+        let out = "Nsp:Status:Remote:\n%SYS:1:0:\nAPP:1:0:\nHSCUSTOM:1:0:\nHSLIB:1:0:\n\
+                   HSSYS:1:0:\nHSSYSLOCALTEMP:1:0:\nUSER:1:0:ERROR: <COMMAND> 101 \
+                   RunUser+1^IrisDevTmp.Run2a3eda04018b.1 Function must return a value at \
+                   RunQuery+9^%Library.AbstractResultSet.1";
+        let abort = runtime_abort_line(out).expect("captured abort must be detected");
+        assert!(abort.starts_with("ERROR: <COMMAND>"), "{abort}");
+        assert!(
+            !abort.contains("USER:1:0:"),
+            "must not carry the listing: {abort}"
+        );
+    }
+
+    /// Real stored output. `<INVALID OREF>`, glued to `global=`, with an earlier line that
+    /// must not be mistaken for the abort.
+    #[test]
+    fn a_captured_invalid_oref_abort_is_detected() {
+        let out =
+            "ns=HSCUSTOM\nglobal=ERROR: <INVALID OREF> 192 RunUser+3^IrisDevTmp.Run39336ac9f214.1";
+        let abort = runtime_abort_line(out).expect("captured abort must be detected");
+        assert!(abort.starts_with("ERROR: <INVALID OREF>"), "{abort}");
+        assert!(
+            !abort.contains("global="),
+            "must not carry the prefix: {abort}"
+        );
+    }
+
     /// The wrapper's own non-`<signal>` failure must still be caught.
     #[test]
     fn the_capture_unavailable_sentinel_is_an_abort() {


### PR DESCRIPTION
Two real stored `iris_execute` outputs from the opencode/deepseek cell, byte for byte, contributed by the eval suite while chasing what it believed were 25 undetected aborts.

They were detected all along. Its signal extractor carried a literal 7-item allowlist without `<COMMAND>` or `<INVALID OREF>`, so those aborts were misfiled as "no signal extracted" — the miss was in the naming, not the detection. Verified here rather than taken on trust: both strings pass through `runtime_abort_line` as aborts.

```
'Nsp:Status:Remote:\n%SYS:1:0:\n…\nUSER:1:0:ERROR: <COMMAND> 101 RunUser+1^…1 Function must return a value…'
'ns=HSCUSTOM\nglobal=ERROR: <INVALID OREF> 192 RunUser+3^…1'
```

Both are the #159 mid-line shape — the abort glued to already-written output with no newline — and both returned `success:true` before #159.

Kept as fixtures because they are real agent output rather than constructed strings, and because they cover two signal classes no hand-written case reached. Each also asserts the returned tail does **not** carry the script's own output (`USER:1:0:`, `global=`), which is the half of #159 a detection-only test would miss.

Tests only, no behaviour change, so no version bump — this rides in the release after `v0.12.0-interop`.

Gate 1208 passed / 0 failed, fmt and clippy clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)