### PR TITLE
test: record that the <OBJECT DISPATCH> fixture has no live reproduction

### DIFF
--- a/crates/iris-agentic-dev-core/src/tools/mod.rs
+++ b/crates/iris-agentic-dev-core/src/tools/mod.rs
@@ -13665,6 +13665,14 @@ mod abort_tests {
     }
 
     /// The reported error must be the abort, not the script's output with the abort glued on.
+    ///
+    /// PROVENANCE: this string is a REAL captured payload from the eval corpus, not a
+    /// constructed one, and `<OBJECT DISPATCH>` has no live reproduction here — the obvious
+    /// attempt (dispatching a missing method on a %DynamicObject) yields
+    /// `<METHOD DOES NOT EXIST>` on 2026.1 instead. So this test is the only record that the
+    /// `<OBJECT DISPATCH>` form occurs in the wild. Do not "simplify" it to a signal that is
+    /// easier to reproduce: the point is that the detector is signal-agnostic, and this is
+    /// the observed evidence for a class that a repro cannot currently produce.
     #[test]
     fn the_reported_abort_drops_the_scripts_own_output() {
         let out = "PatientId=[ERROR: <OBJECT DISPATCH> 230 RunUser+9^IrisDevTmp.Runb2.1";


### PR DESCRIPTION
Raised by the eval suite, and it is a fair point: a test whose only evidence is one observed payload should say so.

`<OBJECT DISPATCH>` has no live reproduction in this repo — the obvious attempt (dispatching a missing method on a `%DynamicObject`) yields `<METHOD DOES NOT EXIST>` on 2026.1. The string in `the_reported_abort_drops_the_scripts_own_output` is a real captured payload from the corpus, so that test is the only record that the form occurs in the wild.

Without the note, a later reader re-deriving the fixture from a repro would replace it with an easier-to-produce signal and silently lose the evidence — which is exactly the case the signal-agnostic detector exists to cover.

Comment only, no behaviour or test-logic change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)