### PR TITLE
fix(#166): stop shaping a test failure like a zeroed scoreboard

### DIFF
--- a/crates/iris-agentic-dev-core/src/tools/mod.rs
+++ b/crates/iris-agentic-dev-core/src/tools/mod.rs
@@ -2162,11 +2162,9 @@ pub fn build_test_run_from_sql(suites: &[SuiteRow], methods: &[MethodRow]) -> se
             "tests_passed": false,
             "error_code": ERR_NO_TESTS_FOUND,
             "error": "Pattern matched no test classes",
-            "total": 0,
-            "passed": 0,
-            "failed": 0,
-            "errors": 0,
-            "skipped": 0,
+            // #166: no zeroed counters on a failure. `success:false` + `completed:false` +
+            // `outcome:"no_tests"` already say what happened; `failed: 0` beside them reads
+            // as a passing run to anything checking the count rather than the code.
         });
     }
 
@@ -4816,9 +4814,10 @@ do ##class(%UnitTest.Manager).RunTest({pattern},"{flags}","{token}")"#,
                             "test_methods": shape.own_test_methods,
                             "pattern": p.pattern,
                             "namespace": namespace,
-                            "total": 0,
-                            "passed": 0,
-                            "failed": 0,
+                            // #166: no `total`/`passed`/`failed` here. A failure envelope must
+                            // not carry counters describing a run that did not happen — `failed: 0`
+                            // is exactly the field a naive green-check reaches for, and it reads
+                            // as a passing run. `success:false` + `error_code` is the contract.
                             "path": path_label,
                         }),
                     );
@@ -4876,9 +4875,8 @@ do ##class(%UnitTest.Manager).RunTest({pattern},"{flags}","{token}")"#,
                     "more_candidates_than_listed": more_than_listed,
                     "pattern": p.pattern,
                     "namespace": namespace,
-                    "total": 0,
-                    "passed": 0,
-                    "failed": 0,
+                    // #166: see the NO_RUNNABLE_TESTS envelope above — a failure must not be
+                    // shaped like a zeroed scoreboard.
                     "path": path_label,
                     "source": "stdout_parse",
                 }),
@@ -13846,5 +13844,28 @@ mod abort_tests {
         assert_eq!(f.signal, "SYNTAX");
         assert_eq!(f.line, Some(1));
         assert_eq!(f.class, None);
+    }
+
+    // ─── #166: a failure envelope must not be shaped like a zeroed scoreboard ───
+
+    /// `failed: 0` beside `success: false` is exactly what a naive green-check reaches for.
+    /// The skills plugin's `tdd_first_green.py` was safe only by the accident of keying on
+    /// `success`/`outcome` instead. Same family as #123, #143, #153 and #164: a failure must
+    /// never be answered with a negative FACT.
+    #[test]
+    fn no_failure_envelope_carries_a_zeroed_counter() {
+        let src = include_str!("mod.rs");
+        // Scope to the handlers — `include_str!` also reads this test's own literals.
+        let handlers = src
+            .split("mod tests")
+            .next()
+            .expect("handlers precede the test module");
+        for frag in ["\"total\": 0,", "\"passed\": 0,", "\"failed\": 0,"] {
+            assert!(
+                !handlers.contains(frag),
+                "a zeroed counter ({frag}) is being emitted; a failure envelope must carry \
+                 the cause, not a scoreboard describing a run that did not happen"
+            );
+        }
     }
 }

--- a/crates/iris-agentic-dev-core/tests/unit/test_iris_test_http.rs
+++ b/crates/iris-agentic-dev-core/tests/unit/test_iris_test_http.rs
@@ -120,8 +120,16 @@ fn test_build_test_run_one_failure() {
 #[test]
 fn test_build_test_run_empty_no_tests_found() {
     let result = build_test_run_from_sql(&[], &[]);
-    assert_eq!(result["total"], 0);
     assert_eq!(result["error_code"], "NO_TESTS_FOUND");
+    assert_eq!(result["success"], false);
+    // #166: the counters must be ABSENT, not zero. `failed: 0` on a failure envelope reads
+    // as a passing run to anything that checks the count instead of the code.
+    for k in ["total", "passed", "failed", "errors", "skipped"] {
+        assert!(
+            result.get(k).is_none(),
+            "failure envelope must not carry `{k}`: {result}"
+        );
+    }
 }
 
 // ── T032: US3 — error vs failed distinction ──────────────────────────────────


### PR DESCRIPTION
`iris_test`'s failure envelopes carried `"total": 0, "passed": 0, "failed": 0` beside `success: false`. `failed == 0` is exactly the field a naive green-check reaches for, and on those payloads it is true while nothing ran at all.

**Not hypothetical.** The skills plugin's `tdd_first_green.py` decides greenness from `outcome == "passed" or bool(success)` — safe, but only by the accident of keying on `success` rather than on the count. Had it keyed on `failed`, every `NO_TESTS_FOUND` would have read as a passing run. In one measured corpus that shape was served 859 times.

### Three sites, all cleaned

| site | note |
|---|---|
| `ERR_NO_RUNNABLE_TESTS` envelope | already names a `cause`; counters removed |
| `ERR_NO_TESTS_FOUND` envelope | counters removed |
| `build_test_run_from_sql` empty case | dead on the live path but `pub`, so part of the crate's API — fixed so the rule has no carve-out |

Nothing replaces them. `success: false` plus `error_code` is the contract, and adding a new field would just be another thing for a consumer to depend on.

### Scope

An audit of every `fail_with`/`err_json` in the crate found **no other instance**. Six further hits were false positives — `SQL_ERROR`'s `extra` only ever receives `hint`/`warnings` (and the regex matched a nearby comment that already reasons about this exact distinction), and `TABLE_NOT_FOUND` passes no extra payload at all. So this is one bug, not a systemic habit; the earlier "pattern worth a sweep" framing was mine and is withdrawn.

Same family as #123, #143, #153 and #164: **a failure must never be answered with a negative fact a caller cannot distinguish from a real measurement.**

### Verification

A guard test asserts no handler emits a zeroed counter, and T008 now asserts the keys are **absent** rather than zero. Gate 1211 passed / 0 failed, fmt and clippy clean. `e2e-tests` dispatched on this branch.

Closes #166

🤖 Generated with [Claude Code](https://claude.com/claude-code)