### PR TITLE
chore(release): 0.13.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -945,7 +945,7 @@ dependencies = [
 
 [[package]]
 name = "iris-agentic-dev"
-version = "0.12.0"
+version = "0.13.0"
 dependencies = [
  "anyhow",
  "chrono",
@@ -963,7 +963,7 @@ dependencies = [
 
 [[package]]
 name = "iris-agentic-dev-core"
-version = "0.12.0"
+version = "0.13.0"
 dependencies = [
  "anyhow",
  "bollard",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "0.12.0"
+version = "0.13.0"
 edition = "2021"
 authors = ["Thomas Dyar <thomas.dyar@intersystems.com>"]
 license = "MIT"


### PR DESCRIPTION
MINOR: two tool contracts moved. Both fixes came from eval-suite **measurement** rather than speculation.

| tool | 0.12.0 | 0.13.0 |
|---|---|---|
| `find_subclass_implementations` | `success:true, implementation_count:0` where ground truth was **96** | correct results; new `MALFORMED_RESULT` on an unparseable payload; cache key now includes `limit` (#164) |
| `resolve_dynamic_dispatch` | identical defect on the identical `FormalSpec` field | same fix (#164) |
| `iris_test` failures | carried `total:0, passed:0, failed:0` beside `success:false` | counters removed — `failed == 0` read as a passing run (#166) |

One row whose `FormalSpec` carried a quote (`pInput:%RegisteredObject=""`) closed the hand-built JSON string early, and `unwrap_or(json!([]))` turned the parse failure into an empty array reported as success. `OnMessage` has zero quoted specs in the test namespace, which is exactly why that tool looked healthy.

Also shipping, not contract moves: two regression fixtures built from verbatim eval-corpus captures, and a provenance note recording that the `<OBJECT DISPATCH>` fixture has no live reproduction on 2026.1.

Tool count unchanged at 23 of 58 registrations — the count is not the test for minor; the contract is.

Gate 1211 passed / 0 failed, fmt and clippy clean, release binary self-reports `iris-interop-dev 0.13.0`. `e2e-tests` dispatched on this branch since the `pull_request` run skips it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)