### PR TITLE
chore(release): 0.14.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -945,7 +945,7 @@ dependencies = [
 
 [[package]]
 name = "iris-agentic-dev"
-version = "0.13.0"
+version = "0.14.0"
 dependencies = [
  "anyhow",
  "chrono",
@@ -963,7 +963,7 @@ dependencies = [
 
 [[package]]
 name = "iris-agentic-dev-core"
-version = "0.13.0"
+version = "0.14.0"
 dependencies = [
  "anyhow",
  "bollard",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "0.13.0"
+version = "0.14.0"
 edition = "2021"
 authors = ["Thomas Dyar <thomas.dyar@intersystems.com>"]
 license = "MIT"


### PR DESCRIPTION
Release bump for #169 / #170. Contains **only** the write-gate change — no tool description moves in this release.

MINOR rather than PATCH, per the rule that the version moves on MINOR iff the tool contract moved where a consumer keys on it:

- `check_config` gains `write_gate_latched`.
- The `WRITE_GATED` envelope **loses** `allow_with`, and the denial no longer names `IRIS_ALLOW_PROD` in the model-facing string.
- Behaviour: a hot-reload can narrow the write gate but can never reopen one that has closed; reopening needs a restart.

`error_code` values are unchanged — `WRITE_GATED` still identifies the refusal.

The testsuite session verified against their suite that nothing they hold reads `allow_with`, `IRIS_ALLOW_PROD` or the `WRITE_GATED` shape, and no arm depends on a gate reopening mid-process. Positive-controlled on the same grep shape (`NO_TESTS_FOUND` 38 files, `error_code` 32), so those zeros are real absences.

🤖 Generated with [Claude Code](https://claude.com/claude-code)