### PR TITLE
feat(dict): find_subclass_implementations names the gap it fills, not the task

### DIFF
--- a/crates/iris-agentic-dev-core/src/tools/mod.rs
+++ b/crates/iris-agentic-dev-core/src/tools/mod.rs
@@ -6821,7 +6821,7 @@ Methods:
     }
 
     #[tool(
-        description = "Find all concrete subclass implementations of a method in the full inheritance hierarchy. Given base class names and a method name, expands to all descendants at any depth and returns classes where the method is defined (Origin = parent, not inherited). Use to resolve polymorphic dispatch: adapter.Execute() → find all EnsLib.*.Adapter subclasses that implement Execute. Results cached 60s per session."
+        description = "Find all concrete subclass implementations of a method in the full inheritance hierarchy. Given base class names and a method name, expands to all descendants at any depth and returns classes where the method is defined (Origin = parent, not inherited). Answers the structural question the other introspection tools cannot: WHICH CLASSES DEFINE a method rather than inherit it, across descendants you have not enumerated. docs_introspect takes one class you must already know the name of; iris_symbols will not walk a hierarchy; neither distinguishes a definition from an inherited copy. Example: adapter.Execute() → every EnsLib.*.Adapter subclass that implements Execute. Results cached 60s per session."
     )]
     async fn find_subclass_implementations(
         &self,


### PR DESCRIPTION
## Why

Measured: this tool was used in **0 of 12** runs of COMPMAP-REVIEW-01 after #165 fixed it (41.4M tokens, all runs passing). The control in the same arm, `extract_message_map_routing`, was used in **7 of 12**. Both are named in **zero** skill files, so guidance is not what separates them.

The two descriptions are near-twins — same length class, same shape, both ending "Results cached 60s per session". One clause differs:

| | clause | used |
|---|---|---|
| control | "find CALLS edges that **static analysis cannot see**" — names a **gap** | 7/12 |
| this tool | "resolve polymorphic dispatch: `adapter.Execute()` …" — names a **task** | 0/12 |

A model already holding `docs_introspect` and `iris_symbols` has every reason to believe it can do a named task, and no way to learn a gap exists.

## The gap is real

This tool expands descendants at any depth and filters on `Origin`, returning the classes that **define** a method rather than inherit it. `docs_introspect` takes one class you must already know the name of; `iris_symbols` will not walk a hierarchy; neither distinguishes a definition from an inherited copy.

Stated at the limit of what is checked: neither rival can do this **in one call**, and neither will **enumerate a hierarchy**. That is enough to say the gap is real. It is not a claim that a determined model could not compose its way there with more calls — that is untested.

## Scope

**One clause, one file, one line.** `git diff --stat` is a single line changed. Nothing else moves here, and nothing else will move in the release that carries it, so any usage change is attributable to the string rather than to a confound.

🤖 Generated with [Claude Code](https://claude.com/claude-code)