### PR TITLE
chore(release): 0.15.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -945,7 +945,7 @@ dependencies = [
 
 [[package]]
 name = "iris-agentic-dev"
-version = "0.14.0"
+version = "0.15.0"
 dependencies = [
  "anyhow",
  "chrono",
@@ -963,7 +963,7 @@ dependencies = [
 
 [[package]]
 name = "iris-agentic-dev-core"
-version = "0.14.0"
+version = "0.15.0"
 dependencies = [
  "anyhow",
  "bollard",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "0.14.0"
+version = "0.15.0"
 edition = "2021"
 authors = ["Thomas Dyar <thomas.dyar@intersystems.com>"]
 license = "MIT"


### PR DESCRIPTION
Release bump for #172. Carries **exactly one change**: the `find_subclass_implementations` description clause.

No behaviour change, no envelope change, no `error_code` change, no tool-count change. The control description (`extract_message_map_routing`) and every other description are byte-identical to 0.14.0.

MINOR rather than PATCH because a tool description **is** the model-facing contract, and this one was changed deliberately to alter which tool a model reaches for. A consumer comparing agent behaviour across builds keys on precisely that.

🤖 Generated with [Claude Code](https://claude.com/claude-code)