### PR TITLE
fix(release): publish a static musl Linux asset, and make both static checks real (#174)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -283,7 +283,16 @@ jobs:
       - run: cargo install cargo-zigbuild
       - run: cargo zigbuild --release --target x86_64-unknown-linux-musl -p iris-agentic-dev
       - run: file target/x86_64-unknown-linux-musl/release/iris-interop-dev
-      - run: |
-          ldd target/x86_64-unknown-linux-musl/release/iris-interop-dev 2>&1 | grep -q "not a dynamic executable" && echo "SC-002 PASS: static binary confirmed" || echo "NOTE: may have dynamic deps on musl"
+      # #174: this used to `echo` on BOTH branches and exit 0 either way — a check that
+      # could not fail in the way the thing actually fails. It is an assertion now.
+      - name: "SC-002: musl build is statically linked"
+        run: |
+          out=$(ldd target/x86_64-unknown-linux-musl/release/iris-interop-dev 2>&1 || true)
+          echo "$out"
+          if ! grep -q "not a dynamic executable\|statically linked" <<<"$out"; then
+            echo "::error::musl build acquired a dynamic dependency — it is no longer portable"
+            exit 1
+          fi
+          echo "SC-002 PASS: static binary confirmed"
 
 # (workflow registered under intersystems-ib/iris-interop-dev)

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -30,6 +30,15 @@ jobs:
             target: x86_64-unknown-linux-gnu
             asset: iris-interop-dev-linux-x64
             bin: iris-interop-dev
+          # #174: the gnu asset above links GLIBC_2.39 (ubuntu-latest), so it downloads,
+          # hash-verifies and then dies at exec on AL2023 / RHEL 8-9 / Debian 12. A static
+          # musl build has no libc floor and removes the class. Additive — the gnu asset
+          # keeps its name and bytes, so existing pins are unaffected.
+          - os: ubuntu-latest
+            target: x86_64-unknown-linux-musl
+            asset: iris-interop-dev-linux-x64-musl
+            bin: iris-interop-dev
+            zig: true
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v7
@@ -53,11 +62,34 @@ jobs:
       - uses: Swatinem/rust-cache@v2
         with:
           key: ${{ matrix.target }}
+      # musl is cross-compiled with zig; the other three are native to their runner.
+      - uses: mlugg/setup-zig@v2
+        if: matrix.zig
+      - name: install cargo-zigbuild
+        if: matrix.zig
+        run: cargo install cargo-zigbuild
       - name: build (release)
+        if: ${{ !matrix.zig }}
         run: cargo build --release -p iris-agentic-dev --target ${{ matrix.target }}
+      - name: build (release, zigbuild)
+        if: ${{ matrix.zig }}
+        run: cargo zigbuild --release -p iris-agentic-dev --target ${{ matrix.target }}
       - name: stage binary
         shell: bash
         run: cp "target/${{ matrix.target }}/release/${{ matrix.bin }}" "${{ matrix.asset }}"
+      # #174: this asset exists ONLY because it is static. If it ever acquires a dynamic
+      # libc dependency it is worthless and must not publish — so this FAILS, it does not warn.
+      - name: "guard: musl asset is statically linked"
+        if: matrix.zig
+        shell: bash
+        run: |
+          out=$(ldd "${{ matrix.asset }}" 2>&1 || true)
+          echo "$out"
+          if ! grep -q "not a dynamic executable\|statically linked" <<<"$out"; then
+            echo "::error::${{ matrix.asset }} is NOT static — refusing to publish a musl asset with a libc floor"
+            exit 1
+          fi
+          echo "static confirmed"
       - name: ad-hoc codesign (macOS — avoids Gatekeeper quarantine hang)
         if: runner.os == 'macOS'
         run: codesign --force --deep --sign - "${{ matrix.asset }}"


### PR DESCRIPTION
Fixes #174.

## The bug

The published Linux asset is built on `ubuntu-latest` and links `GLIBC_2.39`. On AL2023 (glibc 2.34), RHEL 8/9 or Debian 12 it downloads, passes its sha256, and then dies at exec:

```
/lib64/libc.so.6: version `GLIBC_2.39' not found
```

**Every verification gate a careful consumer builds reports success.** Download OK, hash OK, provenance intact — the failure appears only when the process starts, so it reads as "the binary is broken" rather than "the binary is for a different libc". Measured on a live AL2023 instance by the testsuite session, who worked around it on their side and flagged it anyway because they had the measurement and this repo has the build.

## The fix

Adds `x86_64-unknown-linux-musl` to the release matrix as `iris-interop-dev-linux-x64-musl`, built with `cargo zigbuild`.

Notably this needed no new toolchain work: `cross-compile-check` in `ci.yml` **has been building this exact target all along**, so the build was already proven — it simply was never published.

**Additive.** `iris-interop-dev-linux-x64` keeps its name and its bytes, so existing pins are untouched — the eval fleet pins `v0.15.0-interop` linux-x64 at `4af6b8c8d17d7de6046ea16067065483784c1083529b78f3f44c9843d7dbdb78` and that does not move.

## Second defect, same class

Found while reading the first. `ci.yml`'s SC-002 check could not fail:

```yaml
ldd ... | grep -q "not a dynamic executable" && echo "SC-002 PASS: ..." || echo "NOTE: may have dynamic deps on musl"
```

Both branches echo; the step exits 0 regardless. A musl build that silently acquired a dynamic dependency would print `NOTE:` into the log and pass — a check that cannot fail in the way the thing actually fails, guarding a bug whose entire character is that every check passes.

It is an assertion now, in **two** places:
- `ci.yml` — SC-002 fails the job if the musl build is not static.
- `release.yml` — a non-static musl asset **refuses to publish**. That asset exists only because it is static; if it acquires a libc floor it is worthless and must not ship.

## Verification

Rather than trust the YAML, I dispatched the release workflow on this branch — it builds all four assets and the publish job is tag-gated, so nothing is released. That validates the musl target builds, proves static, and passes the existing `--version` provenance guard before any tag exists.

🤖 Generated with [Claude Code](https://claude.com/claude-code)