### PR TITLE
chore(release): 0.15.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -945,7 +945,7 @@ dependencies = [
 
 [[package]]
 name = "iris-agentic-dev"
-version = "0.15.0"
+version = "0.15.1"
 dependencies = [
  "anyhow",
  "chrono",
@@ -963,7 +963,7 @@ dependencies = [
 
 [[package]]
 name = "iris-agentic-dev-core"
-version = "0.15.0"
+version = "0.15.1"
 dependencies = [
  "anyhow",
  "bollard",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "0.15.0"
+version = "0.15.1"
 edition = "2021"
 authors = ["Thomas Dyar <thomas.dyar@intersystems.com>"]
 license = "MIT"


### PR DESCRIPTION
Release bump for #174 / #175.

**PATCH, not MINOR:** no Rust code changed and no tool contract moved. This adds a build target and publishes one additional asset, `iris-interop-dev-linux-x64-musl`, and turns two static-linkage checks into real assertions.

Existing assets keep their names and their bytes — `iris-interop-dev-linux-x64` at `4af6b8c8…` for v0.15.0 is unaffected, and pins do not move.

🤖 Generated with [Claude Code](https://claude.com/claude-code)