### PR TITLE
fix(sql): stop renaming the caller's SQLCODE to a variable nothing sets

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -262,7 +262,14 @@ jobs:
           docker exec iris-e2e bash -c 'printf "Class IrisDevRunTest.UnitTestSuite Extends %%UnitTest.TestCase {\nMethod TestAlwaysPasses() { Do \$\$\$AssertEquals(1,1) }\nMethod TestAlwaysFails() { Do \$\$\$AssertEquals(1,2) }\n}" > /tmp/httest/IrisDevRunTest/UnitTestSuite.cls'
           echo "Created /tmp/httest/IrisDevRunTest/UnitTestSuite.cls in iris-e2e container"
       - name: Run E2E tests against live IRIS (Rust)
-        run: cargo test --test test_e2e -- --nocapture
+        # `--include-ignored` is not optional here. The four `#[ignore]` tests in
+        # test_sql_translate_e2e had never run in ANY job: the branch gate skips this
+        # job, and this job named only `--test test_e2e`. They reported as "ignored",
+        # which reads as coverage and is the absence of it — #177 shipped through four
+        # releases underneath them.
+        run: |
+          cargo test --test test_e2e -- --nocapture
+          cargo test --test test_sql_translate_e2e -- --include-ignored --nocapture
         env:
           IRIS_HOST: ${{ env.IRIS_HOST }}
           IRIS_WEB_PORT: "52773"

--- a/crates/iris-agentic-dev-core/src/tools/mod.rs
+++ b/crates/iris-agentic-dev-core/src/tools/mod.rs
@@ -793,7 +793,6 @@ pub fn translate_sql_macros(code: &str) -> TranslationResult {
             rs_counter += 1;
             let rs_var = format!("sqlrs{}", rs_counter);
             let sc_var = format!("sqlsc{}", rs_counter);
-            let sqlcode_var = format!("sqlSQLCODE{}", rs_counter);
 
             // Find matching closing paren using depth counting
             let start = i + 5; // after &sql(
@@ -823,21 +822,21 @@ pub fn translate_sql_macros(code: &str) -> TranslationResult {
                 output.push_str(&format!("&sql({})", sql_content));
             } else if sql_upper.starts_with("SELECT") {
                 // Translate SELECT INTO
-                output.push_str(&translate_select_into(
-                    &sql_content,
-                    &rs_var,
-                    &sc_var,
-                    &sqlcode_var,
-                ));
+                // #179: no INTO means no host variable is ever bound. The statement runs and
+                // the caller's `write ID` is `<UNDEFINED>` — say so rather than emit code that
+                // cannot work.
+                if find_keyword_pos(&sql_content, "INTO").is_none() {
+                    warnings.push(format!(
+                        "&sql(SELECT ...) at macro #{} has no INTO clause, so no host variable is \
+                         bound and any column you read afterwards will be <UNDEFINED>. Add \
+                         `INTO :var1, :var2`, or use ##class(%SQL.Statement) with a %Next() loop \
+                         directly if you need more than one row.",
+                        rs_counter
+                    ));
+                }
+                output.push_str(&translate_select_into(&sql_content, &rs_var, &sc_var));
                 // Check next line for SQLCODE / %msg and rewrite
-                i = rewrite_next_line_sqlcode(
-                    chars.as_slice(),
-                    i,
-                    n,
-                    &mut output,
-                    &sqlcode_var,
-                    &rs_var,
-                );
+                i = rewrite_next_line_sqlcode(chars.as_slice(), i, n, &mut output);
                 continue;
             } else if sql_upper.starts_with("INSERT")
                 || sql_upper.starts_with("UPDATE")
@@ -847,14 +846,7 @@ pub fn translate_sql_macros(code: &str) -> TranslationResult {
                 // Translate DML
                 output.push_str(&translate_dml(&sql_content, &rs_var));
                 // Check next line for SQLCODE / %msg
-                i = rewrite_next_line_sqlcode(
-                    chars.as_slice(),
-                    i,
-                    n,
-                    &mut output,
-                    &sqlcode_var,
-                    &rs_var,
-                );
+                i = rewrite_next_line_sqlcode(chars.as_slice(), i, n, &mut output);
                 continue;
             } else {
                 // Unknown — leave unchanged with warning
@@ -879,7 +871,7 @@ pub fn translate_sql_macros(code: &str) -> TranslationResult {
 }
 
 /// Translate a SELECT ... INTO :var1, :var2 ... statement.
-fn translate_select_into(sql: &str, rs_var: &str, sc_var: &str, sqlcode_var: &str) -> String {
+fn translate_select_into(sql: &str, rs_var: &str, sc_var: &str) -> String {
     // Parse: split on INTO to separate column list and host variables + WHERE clause
 
     // Find INTO keyword (not inside parens)
@@ -891,7 +883,7 @@ fn translate_select_into(sql: &str, rs_var: &str, sc_var: &str, sqlcode_var: &st
         (before, after.trim().to_string())
     } else {
         // SELECT without INTO — translate as result-set loop but no vars to set
-        return translate_select_no_into(sql, rs_var, sc_var, sqlcode_var);
+        return translate_select_no_into(sql, rs_var, sc_var);
     };
 
     // Extract SELECT column names (between SELECT and INTO)
@@ -973,7 +965,6 @@ fn translate_select_into(sql: &str, rs_var: &str, sc_var: &str, sqlcode_var: &st
     for var in &host_vars {
         out.push_str(&format!(" set {} = \"\"", var));
     }
-    out.push_str(&format!(" set {} = {}.%SQLCODE", sqlcode_var, rs_var));
     out.push_str(" }");
     // #145: also on the FOUND branch — a successful SELECT INTO left SQLCODE
     // undefined, so `If SQLCODE=0` threw exactly like the DML case.
@@ -982,7 +973,7 @@ fn translate_select_into(sql: &str, rs_var: &str, sc_var: &str, sqlcode_var: &st
     out
 }
 
-fn translate_select_no_into(sql: &str, rs_var: &str, sc_var: &str, _sqlcode_var: &str) -> String {
+fn translate_select_no_into(sql: &str, rs_var: &str, sc_var: &str) -> String {
     // SELECT without INTO — translate to prepare/execute but no host var assignment
     let where_params = extract_where_params(sql);
     let prepared_sql = replace_host_vars_with_positional(sql, &where_params);
@@ -1023,7 +1014,7 @@ fn sqlcode_epilogue(rs_var: &str) -> String {
     // -400 is IRIS's "fatal error" SQLCODE — the honest answer when %ExecDirect
     // returned no result object at all, and never a value that reads as success.
     format!(
-        " set SQLCODE=$Select($IsObject({rs}):{rs}.%SQLCODE,1:-400),%ROWCOUNT=$Select($IsObject({rs}):{rs}.%ROWCOUNT,1:0)"
+        " set SQLCODE=$Select($IsObject({rs}):{rs}.%SQLCODE,1:-400),%ROWCOUNT=$Select($IsObject({rs}):{rs}.%ROWCOUNT,1:0),%msg=$Select($IsObject({rs}):{rs}.%Message,1:\"\")"
     , rs = rs_var)
 }
 
@@ -1044,17 +1035,17 @@ fn translate_dml(sql: &str, rs_var: &str) -> String {
     )
 }
 
-/// After a translated &sql, check if the immediately following line contains
-/// a standalone SQLCODE or %msg reference and rewrite it.
-/// Returns the new position in chars after consuming any rewritten line.
-fn rewrite_next_line_sqlcode(
-    chars: &[char],
-    mut i: usize,
-    n: usize,
-    output: &mut String,
-    sqlcode_var: &str,
-    rs_var: &str,
-) -> usize {
+/// Copy the remainder of the `&sql` line and the line after it through to the output,
+/// stopping short of a following `&sql(` so the main loop can translate that one too.
+///
+/// #177: this used to REWRITE `SQLCODE` to a generated `sqlSQLCODE{n}` and `%msg` to
+/// `{rs}.%Message` on that next line. `sqlcode_epilogue` sets `SQLCODE`, `%ROWCOUNT` and
+/// `%msg` under their REAL names, so the rewrite renamed the caller's read to a variable
+/// nothing sets any more — `&sql(...)` followed by `If SQLCODE` threw `<UNDEFINED>` every
+/// time, including on the success path of a SELECT INTO. The names now resolve wherever
+/// they appear (same line, next line, ten lines later), which is what embedded SQL promises,
+/// so this function no longer edits anything.
+fn rewrite_next_line_sqlcode(chars: &[char], mut i: usize, n: usize, output: &mut String) -> usize {
     // Skip whitespace (but not newlines) to find the next line
     // First, collect the rest of the current line (should be empty or whitespace after &sql)
     while i < n && chars[i] != '\n' {
@@ -1086,12 +1077,7 @@ fn rewrite_next_line_sqlcode(
         return line_start;
     }
 
-    // Rewrite SQLCODE → sqlcode_var and %msg → rs_var.%Message on this specific line
-    let rewritten = next_line
-        .replace("SQLCODE", sqlcode_var)
-        .replace("%msg", &format!("{}.%Message", rs_var));
-
-    output.push_str(&rewritten);
+    output.push_str(&next_line);
     i
 }
 

--- a/crates/iris-agentic-dev-core/tests/integration/test_sql_translate_e2e.rs
+++ b/crates/iris-agentic-dev-core/tests/integration/test_sql_translate_e2e.rs
@@ -145,6 +145,78 @@ fn test_e2e_select_into_translates_and_runs() {
     );
 }
 
+/// #177: a SELECT INTO that FINDS a row and then reads SQLCODE.
+///
+/// This is the shape that was broken in every shipped release up to 0.15.1 and that no
+/// test held: T025 above executes a SELECT INTO but never reads `SQLCODE`, and the unit
+/// suite asserted the rename that caused the failure. The failure was inverted — the
+/// generated variable was assigned in the `else` branch only, so the statement threw
+/// `<UNDEFINED>` precisely when the query SUCCEEDED.
+///
+/// It lives at the wire deliberately. The unit test and the translator share a frame; only
+/// running the generated ObjectScript through IRIS proves the names actually resolve.
+#[test]
+#[ignore]
+fn test_e2e_sqlcode_is_readable_after_a_successful_select_into() {
+    if iris_host().is_empty() {
+        eprintln!("Skipping: IRIS_HOST not set");
+        return;
+    }
+    let code = "&sql(SELECT Name INTO :name FROM %Dictionary.ClassDefinition WHERE Name = '%ASQ.AST')\nwrite \"sqlcode=\", SQLCODE, \" rows=\", %ROWCOUNT, \" name=\", name, !";
+    let result = execute(code, None);
+    eprintln!("#177: {}", serde_json::to_string_pretty(&result).unwrap());
+    let output = result["output"].as_str().unwrap_or("");
+    assert!(
+        !output.contains("sqlSQLCODE"),
+        "the caller's SQLCODE read was renamed to a variable nothing sets: {output}"
+    );
+    assert_eq!(result["success"], true, "output was: {output}");
+    assert!(
+        output.contains("sqlcode=0"),
+        "SQLCODE must be readable and 0 after a successful SELECT INTO, got: {output}"
+    );
+    assert!(
+        output.contains("name=%ASQ.AST"),
+        "the host variable must still be bound, got: {output}"
+    );
+}
+
+/// #179: a SELECT with no INTO binds nothing, so the caller's column read is
+/// `<UNDEFINED>`. The translation must say so rather than emit code that cannot work.
+#[test]
+#[ignore]
+fn test_e2e_select_without_into_warns_that_nothing_is_bound() {
+    if iris_host().is_empty() {
+        eprintln!("Skipping: IRIS_HOST not set");
+        return;
+    }
+    let result = execute(
+        "&sql(SELECT Name FROM %Dictionary.ClassDefinition WHERE Name = '%ASQ.AST')",
+        None,
+    );
+    eprintln!("#179: {}", serde_json::to_string_pretty(&result).unwrap());
+    assert_eq!(result["sql_translated"], true);
+    let warnings = result["translation_warning"].to_string();
+    assert!(
+        warnings.contains("no INTO clause"),
+        "expected an unbound-host-variable warning, got: {warnings}"
+    );
+
+    // Positive control for the warning itself: the INTO form must NOT carry it, or the
+    // assertion above would pass on a translator that warns unconditionally.
+    let with_into = execute(
+        "&sql(SELECT Name INTO :n FROM %Dictionary.ClassDefinition WHERE Name = '%ASQ.AST')",
+        None,
+    );
+    assert!(
+        !with_into["translation_warning"]
+            .to_string()
+            .contains("no INTO clause"),
+        "a SELECT INTO must not warn: {}",
+        with_into["translation_warning"]
+    );
+}
+
 /// T026: INSERT translation fires — sql_translated: true (don't actually execute insert against real table).
 /// Uses a read-only table to verify translation, then checks sql_translated even if INSERT fails.
 #[test]

--- a/crates/iris-agentic-dev-core/tests/unit/test_sql_translate.rs
+++ b/crates/iris-agentic-dev-core/tests/unit/test_sql_translate.rs
@@ -116,22 +116,93 @@ fn test_delete_dml() {
     assert!(r.translated_code.contains("DELETE FROM MyApp.Foo"));
 }
 
-// ── T012: SQLCODE on next line rewritten ──────────────────────────────────────
+// ── T012: SQLCODE on the next line survives verbatim (#177) ──────────────────
 
+/// This test used to assert the DEFECT: that `if SQLCODE` was rewritten to a generated
+/// `sqlSQLCODE{n}`. Once #145 moved the producer to the real `SQLCODE`, that rewrite
+/// renamed the caller's read to a variable nothing sets, and every `&sql(...)` followed
+/// by `If SQLCODE` threw `<UNDEFINED>`. The assertions passed through #145 untouched
+/// because #145 only ADDED assertions about the producer and never asked whether the
+/// existing ones still described a contract we wanted.
 #[test]
-fn test_sqlcode_next_line_rewritten() {
+fn test_sqlcode_next_line_is_not_renamed() {
     let code =
         "&sql(SELECT Name INTO :name FROM foo WHERE ID = :id)\nif SQLCODE { write \"err\",! }";
     let r = translate_sql_macros(code);
     assert!(r.found);
-    // The SQLCODE on the NEXT line should be rewritten
     assert!(
-        !r.translated_code.contains("\nif SQLCODE"),
-        "bare SQLCODE on next line should be rewritten"
+        r.translated_code.contains("\nif SQLCODE"),
+        "the caller's SQLCODE read must survive verbatim: {}",
+        r.translated_code
     );
     assert!(
-        r.translated_code.contains("sqlSQLCODE"),
-        "should contain generated SQLCODE var"
+        !r.translated_code.contains("sqlSQLCODE"),
+        "no generated SQLCODE variable may appear — nothing sets one: {}",
+        r.translated_code
+    );
+    assert!(
+        r.translated_code.contains("set SQLCODE="),
+        "the epilogue must still set SQLCODE under its real name: {}",
+        r.translated_code
+    );
+}
+
+/// The regression that would have caught #177: a SELECT INTO that FINDS a row and then
+/// reads SQLCODE. The old code set the generated variable in the `else` branch ONLY, so
+/// the failure was inverted — the statement threw precisely when the query SUCCEEDED.
+#[test]
+fn test_select_into_found_branch_leaves_sqlcode_readable() {
+    let r = translate_sql_macros(
+        "&sql(SELECT Name INTO :name FROM foo WHERE ID = 1)\nwrite SQLCODE, !",
+    );
+    let found_branch = r
+        .translated_code
+        .split(" } else {")
+        .next()
+        .expect("if/else emitted");
+    assert!(
+        !found_branch.contains("sqlSQLCODE"),
+        "the found branch must not depend on a generated name: {found_branch}"
+    );
+    assert!(
+        r.translated_code.contains("write SQLCODE, !"),
+        "the read must be left alone: {}",
+        r.translated_code
+    );
+}
+
+/// #177: `%msg` is set by the epilogue under its real name too, so it needs no rewrite.
+#[test]
+fn test_msg_is_set_under_its_real_name() {
+    let r = translate_sql_macros("&sql(SELECT Name INTO :n FROM foo)\nwrite %msg,!");
+    assert!(
+        r.translated_code.contains("%msg="),
+        "epilogue must set %msg: {}",
+        r.translated_code
+    );
+    assert!(
+        r.translated_code.contains("write %msg,!"),
+        "the caller's %msg read must survive verbatim: {}",
+        r.translated_code
+    );
+}
+
+/// #179: a SELECT with no INTO binds nothing, so every column read afterwards is
+/// <UNDEFINED>. Emitting that silently is worse than refusing.
+#[test]
+fn test_select_without_into_warns_that_nothing_is_bound() {
+    let r = translate_sql_macros("&sql(SELECT ID, Name FROM Ens_Config.Production)");
+    assert!(r.found);
+    assert!(
+        r.warnings.iter().any(|w| w.contains("no INTO clause")),
+        "expected an unbound-host-variable warning, got {:?}",
+        r.warnings
+    );
+    let with_into = translate_sql_macros("&sql(SELECT Name INTO :n FROM foo)");
+    assert!(
+        !with_into.warnings.iter().any(|w| w.contains("no INTO")),
+        "a SELECT INTO must not warn: {:?}",
+        with_into.warnings
     );
 }
 
@@ -150,20 +221,26 @@ fn test_sqlcode_elsewhere_not_rewritten() {
     );
 }
 
-// ── T013: %msg on next line rewritten ────────────────────────────────────────
+// ── T013: %msg is set, not rewritten (#177) ──────────────────────────────────
 
+/// The sibling of T012, and it had the same defect for the same reason: the rewrite
+/// pointed the caller's `%msg` at `{rs}.%Message`, which works only on the ONE line
+/// immediately after the macro. The epilogue now sets `%msg` itself, so a read works
+/// wherever it appears.
 #[test]
-fn test_msg_next_line_rewritten() {
+fn test_msg_next_line_is_not_rewritten() {
     let code = "&sql(SELECT Name INTO :name FROM foo WHERE ID = :id)\nwrite %msg,!";
     let r = translate_sql_macros(code);
     assert!(r.found);
     assert!(
-        !r.translated_code.contains("\nwrite %msg"),
-        "%msg on next line should be rewritten"
+        r.translated_code.contains("\nwrite %msg,!"),
+        "the caller's %msg read must survive verbatim: {}",
+        r.translated_code
     );
     assert!(
-        r.translated_code.contains(".%Message") || r.translated_code.contains("_sqlMsg"),
-        "should reference result set message"
+        r.translated_code.contains("%msg=$Select("),
+        "the epilogue must set %msg: {}",
+        r.translated_code
     );
 }
 
@@ -312,7 +389,7 @@ fn test_sc001_representative_patterns() {
         ("&sql(UPDATE foo SET Name = :n WHERE ID = :id)", "execDirect"),
         // DELETE
         ("&sql(DELETE FROM foo WHERE ID = :id)", "execDirect"),
-        // SQLCODE next line
+        // SQLCODE next line (#177: set under its real name, never renamed)
         ("&sql(SELECT Name INTO :n FROM foo WHERE 1=1)\nif SQLCODE { }", "rewrite_sqlcode"),
         // %msg next line
         ("&sql(SELECT Name INTO :n FROM foo WHERE 1=1)\nwrite %msg,!", "rewrite_msg"),
@@ -346,17 +423,18 @@ fn test_sc001_representative_patterns() {
             }
             "rewrite_sqlcode" => {
                 assert!(r.found);
+                // #177: the read is left alone and the epilogue defines the name.
                 assert!(
-                    r.translated_code.contains("sqlSQLCODE")
-                        || !r.translated_code.contains("\nif SQLCODE"),
-                    "SQLCODE should be rewritten for: {code}"
+                    !r.translated_code.contains("sqlSQLCODE")
+                        && r.translated_code.contains("set SQLCODE="),
+                    "SQLCODE must be set, not renamed, for: {code}"
                 );
             }
             "rewrite_msg" => {
                 assert!(r.found);
                 assert!(
-                    !r.translated_code.contains("\nwrite %msg"),
-                    "%msg should be rewritten for: {code}"
+                    r.translated_code.contains("%msg="),
+                    "%msg must be set by the epilogue for: {code}"
                 );
             }
             "no_rows" => {


### PR DESCRIPTION
Reported by the skills session, reproduced at the wire on 0.15.1 before any code was touched.

`&sql(...)` followed by `If SQLCODE` threw `<UNDEFINED> sqlSQLCODE1` in every shipped release. The producer (#145) sets `SQLCODE`; the consumer was rewritten to a generated name nothing sets. On the SELECT INTO path the generated name was assigned in the `else` branch only — so it threw **when the query succeeded**.

### What changed
- `sqlcode_epilogue` sets `%msg` as well, still on one line (#124's `RunUser+N` mapping)
- `rewrite_next_line_sqlcode` no longer rewrites — reads of `SQLCODE`/`%ROWCOUNT`/`%msg` resolve wherever they appear
- dead `sqlSQLCODE{n}` producer and parameter threading removed
- #179: `&sql(SELECT ...)` with no `INTO` now warns that no host variable is bound

### The tests were part of the bug
`test_sql_translate.rs` asserted *"bare SQLCODE on next line should be rewritten"* and *"should contain generated SQLCODE var"* — the defect, verbatim. They survived #145 because #145 only added assertions about the producer.

### And the e2e suite could not fail
`test_sql_translate_e2e`'s tests had never run in any job: the branch gate skips `e2e-tests`, and `e2e-tests` invoked only `--test test_e2e`. Four tests reporting as `ignored` read as coverage. The job now runs the target with `--include-ignored`.

### Evidence
| | shipped 0.15.1 | this branch |
|---|---|---|
| `test_e2e_sqlcode_is_readable_after_a_successful_select_into` | **FAIL** — `sqlcode=ERROR: <UNDEFINED> ... sqlSQLCODE1` | pass |
| `test_e2e_select_without_into_warns_that_nothing_is_bound` | **FAIL** — `got: null` | pass |
| the 4 pre-existing e2e tests | pass | pass |

Wire check on dev IRIS after the fix: `&sql(SELECT Name INTO :nm ...)` + `write SQLCODE` → `sqlcode=0 nm=Ens.Director`.

Unit: 576 lib + 28 translator + 16/26/35 across the other suites, green.

Closes #177

🤖 Generated with [Claude Code](https://claude.com/claude-code)