### PR TITLE
chore(release): 0.16.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -945,7 +945,7 @@ dependencies = [
 
 [[package]]
 name = "iris-agentic-dev"
-version = "0.15.1"
+version = "0.16.0"
 dependencies = [
  "anyhow",
  "chrono",
@@ -963,7 +963,7 @@ dependencies = [
 
 [[package]]
 name = "iris-agentic-dev-core"
-version = "0.15.1"
+version = "0.16.0"
 dependencies = [
  "anyhow",
  "bollard",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "0.15.1"
+version = "0.16.0"
 edition = "2021"
 authors = ["Thomas Dyar <thomas.dyar@intersystems.com>"]
 license = "MIT"


### PR DESCRIPTION
MINOR, not PATCH — three changes since 0.15.1 move contract a consumer keys on.

| # | change | why it is not a PATCH |
|---|---|---|
| #177 | `&sql(...)` + `SQLCODE` runs instead of throwing `<UNDEFINED> sqlSQLCODE1` | `translated_code` changed shape — the read is left verbatim, the epilogue sets `SQLCODE`/`%ROWCOUNT`/`%msg` under their real names |
| #179 | `&sql(SELECT ...)` with no `INTO` emits `translation_warning` | a field that was previously absent |
| #178, #182 | hint text and `did_you_mean` on four error paths | hint text IS the model-facing contract — same reasoning that made 0.15.0 a MINOR for a one-line description reword |

Per **ADR-008** this tag is a NEW CELL in the eval comparability triple. Results from 0.15.x arms are not comparable for anything that reads a hint.

Verified against a build of this branch, at the wire on dev IRIS: all five behaviours green, with the no-INTO warning checked two-sided (fires without `INTO`, silent with it).

🤖 Generated with [Claude Code](https://claude.com/claude-code)