### PR TITLE
docs: say what the VS Code path actually is, in both places that misdescribed it

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,8 +65,20 @@ Or add it by hand to `~/.claude/settings.json`:
 
 Restart Claude and **verify with the `check_config` tool** that it connects and the tools appear.
 
-> **VS Code + GitHub Copilot?** The VS Code extension path is provided by the upstream community tool —
-> see [`intersystems-community/iris-agentic-dev`](https://github.com/intersystems-community/iris-agentic-dev).
+> **VS Code?** Three separate things get read as one here, so to be explicit about which is which:
+>
+> - **Claude Code's own VS Code extension works today, with no extra setup.** It is a front-end for
+>   Claude Code and reads the same user-scope `~/.claude.json` registration shown above.
+> - **Connection settings from VS Code are read natively by this binary.** `iris-interop-dev` parses
+>   `.vscode/settings.json` — `objectscript.conn`, including named servers resolved through
+>   `intersystems.servers` — as the last step of its discovery cascade. The order, and the known
+>   limits of that step, are documented at the top of
+>   [`discovery.rs`](crates/iris-agentic-dev-core/src/iris/discovery.rs) (issue #187).
+> - **What this fork does not carry is the Marketplace extension** that auto-registers the server,
+>   and `skill install --agent copilot`. That path belongs to the upstream community tool — see
+>   [`intersystems-community/iris-agentic-dev`](https://github.com/intersystems-community/iris-agentic-dev)
+>   — and it is bound to the `iris-agentic-dev` binary, so it will not register this one.
+>
 > This fork ships as the `iris-interop-dev` binary; the workshop VM registers it for Claude Code.
 
 ---

--- a/crates/iris-agentic-dev-core/src/iris/discovery.rs
+++ b/crates/iris-agentic-dev-core/src/iris/discovery.rs
@@ -3,11 +3,26 @@
 //! Order of priority (highest to lowest):
 //! 1. Explicit IrisConnection passed directly
 //! 2. Env vars (IRIS_HOST + IRIS_WEB_PORT)
-//! 3. Localhost port scan (100ms timeout, parallel)
-//! 4. Docker containers via bollard
-//! 5. VS Code settings.json objectscript.conn
+//! 3. IRIS_CONTAINER — named Docker container, web port resolved via bollard
+//! 4. Localhost port scan (100ms timeout, parallel), env-var credentials
+//! 5. Docker container scan via bollard
+//! 6. VS Code settings.json — `objectscript.conn`, resolving named servers through
+//!    `intersystems.servers` (see `vscode_config.rs`)
 //!
 //! Each step fails silently and falls through to the next.
+//!
+//! KNOWN LIMITS of step 6, tracked by issue #187. Recorded here because a reader
+//! concluded from a README sentence that no VS Code config path existed at all —
+//! the code is the only place that can answer that:
+//! - It runs LAST. Wherever IRIS answers on localhost or in Docker, steps 4-5 win
+//!   and settings.json is never opened. Step 3 already carries the equivalent
+//!   precedence fix for the named-container case; step 6 has no counterpart.
+//! - `discover_via_vscode_settings` searches exactly one path,
+//!   `current_dir()/.vscode/settings.json` — not user-scope settings, which is where
+//!   Server Manager normally keeps servers.
+//! - There is no OS-keychain reader. A server entry whose password lives in the
+//!   keychain arrives here with no password and defaults to _SYSTEM/SYS instead of
+//!   failing, producing a 401 that names no cause.
 
 use crate::iris::connection::{DiscoverySource, IrisConnection};
 use std::time::Duration;


### PR DESCRIPTION
Two documentation sites described a VS Code configuration path this fork does not have, while the one it *does* have went unmentioned. A peer session read `README.md:68` and filed #187 saying the fork carries no VS Code / Server Manager path at all. It carries one — `crates/iris-agentic-dev-core/src/iris/vscode_config.rs`, 207 lines, parsing `objectscript.conn` **and** `intersystems.servers`, resolving named servers, wired into `discover_iris()` and covered by `tests/vscode_config_tests.rs`.

### README.md

The old sentence was **true and narrow** — it is about the Copilot extension — and was read as covering the config reader as well. It now separates the three things that were being read as one:

- Claude Code's own VS Code extension: works today, no extra setup, reads the same `~/.claude.json`.
- VS Code connection settings: read natively by this binary.
- The Marketplace extension and `skill install --agent copilot`: genuinely upstream-only, and bound to the `iris-agentic-dev` binary, so it will not register this one.

### discovery.rs

The module header documented a 5-step cascade with VS Code at #5 reading only `objectscript.conn`. The code runs **6**, with `IRIS_CONTAINER` at #3 and VS Code at #6 reading `intersystems.servers` too — a doc disagreeing with the code in the same file.

The header now matches, and records the three known limits of step 6 so the next reader gets them from the file that owns the behaviour:

1. it runs **last**, so wherever IRIS answers on localhost or in Docker, steps 4–5 win and `settings.json` is never opened — step 3 already carries the equivalent precedence fix for the named-container case, step 6 has no counterpart;
2. `discover_via_vscode_settings` searches exactly one path, `current_dir()/.vscode/settings.json`, through a one-element array built to hold more;
3. no OS-keychain reader, and an absent password `unwrap_or`s to `_SYSTEM`/`SYS` rather than erroring — the nastiest of the three, because the other two produce *"it ignored my config"* while this one produces *"it used your config and it is wrong"*: a 401 naming no cause.

### Scope

Prose and comments only. No behaviour change, no version bump — the tool contract has not moved. `cargo check -p iris-agentic-dev-core --all-targets` is clean.

**This does not fix #187** and deliberately says `Refs`, not `Closes`: the precedence, search-path and credential-default defects are all still live. It removes the reason someone would rebuild a reader that already exists.

Refs #187

🤖 Generated with [Claude Code](https://claude.com/claude-code)