### PR TITLE
test(vscode): pin the settings shape that actually exists in the wild

### DIFF
--- a/crates/iris-agentic-dev-core/tests/vscode_config_tests.rs
+++ b/crates/iris-agentic-dev-core/tests/vscode_config_tests.rs
@@ -278,3 +278,36 @@ fn path_prefix_survives_resolution() {
         other => panic!("expected Resolved, got {other:?}"),
     }
 }
+
+/// The shape that actually exists in the wild, found by the SKILLS session in three
+/// workshop directories: `active: true` and a `server:` name, with NO
+/// `intersystems.servers` map at all — because Server Manager keeps the server
+/// definition in USER-scope settings, which this binary does not read.
+///
+/// `a_named_server_with_no_matching_entry_is_not_configured` covers the neighbouring
+/// case (map present, key absent). This one takes a different branch —
+/// `intersystems_servers.as_ref()` yields `None` before `.get()` is ever reached — and
+/// the two must not be assumed to agree just because they should.
+///
+/// It must resolve to NotConfigured so discovery falls THROUGH to the scans. Anything
+/// else would make 0.17.0 break every workshop directory: under the new precedence this
+/// entry is reached at step 4, ahead of the port scan that currently serves it.
+#[test]
+fn a_server_name_with_no_servers_map_at_all_is_not_configured() {
+    let settings = r#"{
+        "objectscript.conn": { "active": true, "server": "workshop-iris", "ns": "HOSPITAL" },
+        "objectscript.export": { "folder": "src", "atelier": true }
+    }"#;
+    match resolve(settings, None) {
+        VsCodeResolution::NotConfigured => {}
+        VsCodeResolution::Resolved(conn) => panic!(
+            "guessed a connection to {} for a server this binary cannot resolve — \
+             discovery would stop here instead of falling through to the scans",
+            conn.base_url
+        ),
+        VsCodeResolution::MissingPassword { .. } => panic!(
+            "reported a missing password for a server that was never resolved — \
+             the warning would name a cause that is not the real one"
+        ),
+    }
+}


### PR DESCRIPTION
The SKILLS session swept its tree for #187 exposure and found three `.vscode/settings.json` of one shape, none of which the test suite covered:

```json
{ "objectscript.conn": { "active": true, "server": "workshop-iris", "ns": "HOSPITAL" },
  "objectscript.export": { "folder": "src", "atelier": true } }
```

`active: true`, a server **name**, and **no `intersystems.servers` map at all** — because Server Manager keeps the server definition in USER-scope settings, which this binary does not read. That is the commonest real entry in the wild, and under 0.17.0's precedence it is now reached at **step 4**, ahead of the port scan that currently serves those directories.

### Why the neighbouring test didn't already cover it

`a_named_server_with_no_matching_entry_is_not_configured` covers *map present, key absent*. This shape takes a different sub-expression: `intersystems_servers.as_ref()` yields `None` before `.get()` is ever reached. Two branches that ought to agree are not evidence that they do.

### Evidence

Behaviour was verified **at the wire on the shipped 0.17.0 binary** before this test existed — 0 `#187` warnings, the scans ran, `✓ Compiled: T.cls`, with a no-`.vscode` control returning zero. The branch simply had no test.

**Distinguishing mutation control.** Making a missing map skip the named path and fall through to direct host/port fails **only the new test**:

```
test result: FAILED. 13 passed; 1 failed
  a_server_name_with_no_servers_map_at_all_is_not_configured
  → reported a missing password for a server that was never resolved
```

A mutation on the shared `match` arm would have killed both tests and proved nothing about coverage. This one isolates the branch, which is the whole claim being made.

### Scope

Tests only. No behaviour change, no version bump. Gate run as one command: `cargo fmt --all -- --check && cargo clippy --workspace --all-targets -- -D warnings && cargo test --workspace` → 47 suites green.

Issue 187 stays open for the search-path gap this shape is a symptom of: user-scope VS Code settings are still not read, and there is no keychain reader.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
